### PR TITLE
Admin bug/allow system admin to switch between all clinics

### DIFF
--- a/apps/api/src/auth/auth.controller.spec.ts
+++ b/apps/api/src/auth/auth.controller.spec.ts
@@ -8,6 +8,10 @@ describe('AuthController', () => {
       { id: 'clinic-1', name: 'Test Clinic', region: 'Greater Accra' },
       { id: 'clinic-2', name: 'Second Clinic', region: 'Ashanti' },
     ]),
+    listActiveSwitchableClinics: jest.fn().mockResolvedValue([
+      { id: 'clinic-2', name: 'Second Clinic', region: 'Ashanti' },
+      { id: 'clinic-1', name: 'Test Clinic', region: 'Greater Accra' },
+    ]),
   };
   const prisma = {
     user: {
@@ -36,6 +40,14 @@ describe('AuthController', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    clinicService.findByIds.mockResolvedValue([
+      { id: 'clinic-1', name: 'Test Clinic', region: 'Greater Accra' },
+      { id: 'clinic-2', name: 'Second Clinic', region: 'Ashanti' },
+    ]);
+    clinicService.listActiveSwitchableClinics.mockResolvedValue([
+      { id: 'clinic-2', name: 'Second Clinic', region: 'Ashanti' },
+      { id: 'clinic-1', name: 'Test Clinic', region: 'Greater Accra' },
+    ]);
     prisma.user.findUnique.mockResolvedValue({
       email: 'test@example.com',
       phoneE164: null,
@@ -55,6 +67,7 @@ describe('AuthController', () => {
     });
 
     expect(clinicService.findByIds).toHaveBeenCalledWith(['clinic-1', 'clinic-2']);
+    expect(clinicService.listActiveSwitchableClinics).toHaveBeenCalledWith(undefined);
     expect(response).toMatchObject({
       userId: 'user-1',
       keycloakSub: 'test-sub',
@@ -74,11 +87,126 @@ describe('AuthController', () => {
         roles: ['VOLUNTEER'],
       },
     ]);
+    expect(response.availableClinics).toEqual([
+      {
+        clinicId: 'clinic-2',
+        clinicName: 'Second Clinic',
+      },
+      {
+        clinicId: 'clinic-1',
+        clinicName: 'Test Clinic',
+      },
+    ]);
     expect(response.effectiveRolesForActiveClinic).toEqual([
       UserRole.MANAGER,
       UserRole.SYSTEM_ADMIN,
     ]);
     expect(response.effectivePermissionsForActiveClinic).toContain('*');
+  });
+
+  it('lets global system admins with no clinic roles switch to any active clinic', async () => {
+    clinicService.listActiveSwitchableClinics.mockResolvedValue([
+      { id: 'clinic-2', name: 'Second Clinic', region: 'Ashanti' },
+      { id: 'clinic-1', name: 'Test Clinic', region: 'Greater Accra' },
+    ]);
+
+    const response = await controller.whoami({
+      user: {
+        user: {
+          id: 'admin-user-1',
+          keycloakSub: 'admin-sub',
+          displayName: 'System Admin',
+          email: 'admin@example.com',
+        },
+        roles: [{ clinicId: null, role: UserRole.SYSTEM_ADMIN }],
+      },
+      headers: { 'x-clinic-id': 'clinic-1' },
+    });
+
+    expect(clinicService.findByIds).not.toHaveBeenCalled();
+    expect(clinicService.listActiveSwitchableClinics).toHaveBeenCalledWith(undefined);
+    expect(response.memberships).toEqual([]);
+    expect(response.availableClinics).toEqual([
+      {
+        clinicId: 'clinic-2',
+        clinicName: 'Second Clinic',
+      },
+      {
+        clinicId: 'clinic-1',
+        clinicName: 'Test Clinic',
+      },
+    ]);
+    expect(response.activeClinicId).toBe('clinic-1');
+    expect(response.effectiveRolesForActiveClinic).toEqual([UserRole.SYSTEM_ADMIN]);
+    expect(response.effectivePermissionsForActiveClinic).toEqual(['*']);
+  });
+
+  it('falls back when a system admin requests a clinic that is not active', async () => {
+    clinicService.listActiveSwitchableClinics.mockResolvedValue([
+      { id: 'clinic-2', name: 'Second Clinic', region: 'Ashanti' },
+      { id: 'clinic-1', name: 'Test Clinic', region: 'Greater Accra' },
+    ]);
+
+    const response = await controller.whoami({
+      user: {
+        user: {
+          id: 'admin-user-1',
+          keycloakSub: 'admin-sub',
+          displayName: 'System Admin',
+          email: 'admin@example.com',
+        },
+        roles: [{ clinicId: null, role: UserRole.SYSTEM_ADMIN }],
+      },
+      headers: { 'x-clinic-id': 'inactive-clinic' },
+    });
+
+    expect(response.activeClinicId).toBe('clinic-2');
+  });
+
+  it('only exposes active assigned clinics for non-system-admin users', async () => {
+    clinicService.findByIds.mockResolvedValue([
+      { id: 'clinic-1', name: 'Test Clinic', region: 'Greater Accra' },
+    ]);
+    clinicService.listActiveSwitchableClinics.mockResolvedValue([
+      { id: 'clinic-1', name: 'Test Clinic', region: 'Greater Accra' },
+    ]);
+
+    const response = await controller.whoami({
+      user: {
+        user: {
+          id: 'manager-user-1',
+          keycloakSub: 'manager-sub',
+          displayName: 'Clinic Manager',
+          email: 'manager@example.com',
+        },
+        roles: [
+          { clinicId: 'clinic-1', role: UserRole.MANAGER },
+          { clinicId: 'inactive-clinic', role: UserRole.DIRECTOR },
+        ],
+      },
+      headers: { 'x-clinic-id': 'inactive-clinic' },
+    });
+
+    expect(clinicService.findByIds).toHaveBeenCalledWith(['clinic-1', 'inactive-clinic']);
+    expect(clinicService.listActiveSwitchableClinics).toHaveBeenCalledWith([
+      'clinic-1',
+      'inactive-clinic',
+    ]);
+    expect(response.memberships).toEqual([
+      {
+        clinicId: 'clinic-1',
+        clinicName: 'Test Clinic',
+        roles: ['MANAGER'],
+      },
+    ]);
+    expect(response.availableClinics).toEqual([
+      {
+        clinicId: 'clinic-1',
+        clinicName: 'Test Clinic',
+      },
+    ]);
+    expect(response.activeClinicId).toBe('clinic-1');
+    expect(response.effectiveRolesForActiveClinic).toEqual([UserRole.MANAGER]);
   });
 
   it('uses a stable disabled-user payload', () => {

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -17,11 +17,17 @@ export interface Membership {
   roles: string[];
 }
 
+export interface AvailableClinic {
+  clinicId: string;
+  clinicName: string;
+}
+
 export interface WhoAmIResponse {
   userId: string;
   keycloakSub: string;
   displayName: string;
   memberships: Membership[];
+  availableClinics: AvailableClinic[];
   globalRoles: string[];
   activeClinicId: string | null;
   effectiveRolesForActiveClinic: string[];
@@ -81,28 +87,38 @@ export class AuthController {
       ? [...new Set((byClinicId.get('global') ?? []).map((r) => r.role))]
       : [];
 
+    const isSystemAdmin = roles.some((r) => r.role === 'SYSTEM_ADMIN' && r.clinicId === null);
+    const availableClinicRows = await this.clinicService.listActiveSwitchableClinics(
+      isSystemAdmin ? undefined : clinicIds,
+    );
+    const availableClinics: AvailableClinic[] = availableClinicRows.map((clinic) => ({
+      clinicId: clinic.id,
+      clinicName: clinic.name,
+    }));
+    const availableClinicIds = new Set(availableClinics.map((clinic) => clinic.clinicId));
+
     const memberships: Membership[] = [];
     for (const cid of clinicIds.sort()) {
       const roleEntries = byClinicId.get(cid) ?? [];
       const roleNames = [...new Set(roleEntries.map((r) => r.role))];
       const clinic = clinicMap.get(cid) ?? null;
+      if (!clinic) {
+        continue;
+      }
       memberships.push({
         clinicId: cid,
-        clinicName: clinic?.name ?? '',
+        clinicName: clinic.name,
         roles: roleNames,
       });
     }
 
-    const sortedClinicIds = [...clinicIds].sort();
     const headerClinicId = req.headers?.['x-clinic-id']?.trim();
-    const isSystemAdmin = roles.some((r) => r.role === 'SYSTEM_ADMIN' && r.clinicId === null);
-    const hasMembership = (cid: string) => roles.some((r) => r.clinicId === cid) || isSystemAdmin;
 
     let activeClinicId: string | null;
-    if (headerClinicId && hasMembership(headerClinicId)) {
+    if (headerClinicId && availableClinicIds.has(headerClinicId)) {
       activeClinicId = headerClinicId;
     } else {
-      activeClinicId = sortedClinicIds.length > 0 ? sortedClinicIds[0] : null;
+      activeClinicId = availableClinics[0]?.clinicId ?? null;
     }
 
     const activeRoles =
@@ -121,6 +137,7 @@ export class AuthController {
       keycloakSub: user.keycloakSub,
       displayName: user.displayName,
       memberships,
+      availableClinics,
       globalRoles,
       activeClinicId,
       effectiveRolesForActiveClinic,

--- a/apps/api/src/clinics/clinic.service.ts
+++ b/apps/api/src/clinics/clinic.service.ts
@@ -70,6 +70,20 @@ export class ClinicService {
     });
   }
 
+  async listActiveSwitchableClinics(
+    ids?: string[],
+  ): Promise<{ id: string; name: string; region: string | null }[]> {
+    if (ids && ids.length === 0) return [];
+    return this.prisma.clinic.findMany({
+      where: {
+        isActive: true,
+        ...(ids ? { id: { in: ids } } : {}),
+      },
+      select: { id: true, name: true, region: true },
+      orderBy: { name: 'asc' },
+    });
+  }
+
   async getResearchSettings(clinicId: string) {
     const settings = await this.prisma.clinicResearchSettings.findUnique({
       where: { clinicId },

--- a/apps/web/app/(workspace)/admin/users/page.tsx
+++ b/apps/web/app/(workspace)/admin/users/page.tsx
@@ -6,6 +6,7 @@ import { DataGrid, type GridColDef } from '@mui/x-data-grid';
 import { Layers3, RefreshCw, ShieldAlert, Users } from 'lucide-react';
 import { useAuth } from '@/lib/auth-context';
 import { useBootstrap } from '@/lib/bootstrap-context';
+import { getActiveBootstrapClinic, getBootstrapActiveClinicId } from '@/lib/bootstrap-clinics';
 import { apiFetch } from '@/lib/api';
 import { formatRoleLabel, readApiError } from '@/lib/ops';
 import { dataGridSx } from '@/lib/datagrid-theme';
@@ -291,10 +292,10 @@ export default function AdminUsersPage() {
   const getToken = useAuth();
   const bootstrapCtx = useBootstrap();
   const bootstrap = bootstrapCtx?.bootstrap ?? null;
-  const activeClinicId = bootstrap?.activeClinicId ?? bootstrap?.memberships?.[0]?.clinicId ?? null;
+  const activeClinicId = getBootstrapActiveClinicId(bootstrap);
   const activeMembership =
     bootstrap?.memberships.find((membership) => membership.clinicId === activeClinicId) ?? null;
-  const activeClinicName = activeMembership?.clinicName ?? null;
+  const activeClinicName = getActiveBootstrapClinic(bootstrap, activeClinicId)?.clinicName ?? null;
   const isSystemAdmin = bootstrap?.globalRoles?.includes('SYSTEM_ADMIN') ?? false;
   const directorMemberships = (bootstrap?.memberships ?? []).filter((membership) =>
     membership.roles.includes('DIRECTOR'),

--- a/apps/web/app/(workspace)/audit/page.tsx
+++ b/apps/web/app/(workspace)/audit/page.tsx
@@ -5,6 +5,7 @@ import { ActivitySquare, FileClock, Shield } from 'lucide-react';
 import { useBootstrap } from '@/lib/bootstrap-context';
 import { useAuth } from '@/lib/auth-context';
 import { apiFetch } from '@/lib/api';
+import { getBootstrapActiveClinicId } from '@/lib/bootstrap-clinics';
 import { AppMetricCard } from '@/components/app-shell/AppMetricCard';
 import { ActiveFilterSummary } from '@/components/app-shell/ActiveFilterSummary';
 import { AppPageHeader } from '@/components/app-shell/AppPageHeader';
@@ -33,7 +34,7 @@ interface AuditRow {
 export default function AuditPage() {
   const bootstrap = useBootstrap()?.bootstrap ?? null;
   const getToken = useAuth();
-  const clinicId = bootstrap?.activeClinicId ?? bootstrap?.memberships?.[0]?.clinicId ?? null;
+  const clinicId = getBootstrapActiveClinicId(bootstrap);
 
   const [from, setFrom] = useState('');
   const [to, setTo] = useState('');

--- a/apps/web/app/(workspace)/dashboard/page.tsx
+++ b/apps/web/app/(workspace)/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useBootstrap } from '@/lib/bootstrap-context';
 import { useAuth } from '@/lib/auth-context';
 import { apiFetch } from '@/lib/api';
+import { getActiveBootstrapClinic, getBootstrapActiveClinicId } from '@/lib/bootstrap-clinics';
 import { AppPageHeader } from '@/components/app-shell/AppPageHeader';
 import { InlineErrorState, SectionSkeleton } from '@/components/feedback/AppState';
 import { RouteGuard } from '@/components/RouteGuard';
@@ -98,9 +99,8 @@ export default function DashboardPage() {
   const bootstrapCtx = useBootstrap();
   const bootstrap = bootstrapCtx?.bootstrap ?? null;
   const getToken = useAuth();
-  const clinicId = bootstrap?.activeClinicId ?? bootstrap?.memberships?.[0]?.clinicId;
-  const activeMembership =
-    bootstrap?.memberships.find((membership) => membership.clinicId === clinicId) ?? null;
+  const clinicId = getBootstrapActiveClinicId(bootstrap);
+  const activeClinic = getActiveBootstrapClinic(bootstrap, clinicId);
 
   const [data, setData] = useState<DashboardData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -139,15 +139,15 @@ export default function DashboardPage() {
       <div className="space-y-6">
         <AppPageHeader
           eyebrow="Clinic snapshot"
-          title={activeMembership?.clinicName ?? 'Dashboard'}
+          title={activeClinic?.clinicName ?? 'Dashboard'}
           description="Current clinic totals and next work."
           hint="The dashboard always reflects the clinic selected in the header."
           helpTitle="How the dashboard is organized"
           helpText="Start with the clinic snapshot, then use the role sections below to clear intake work, reviews, finalizations, and oversight tasks."
           badges={
-            activeMembership ? (
+            activeClinic ? (
               <Badge variant="secondary" className="rounded-full px-3 py-1">
-                {activeMembership.clinicName}
+                {activeClinic.clinicName}
               </Badge>
             ) : null
           }

--- a/apps/web/app/(workspace)/dashboard/page.tsx
+++ b/apps/web/app/(workspace)/dashboard/page.tsx
@@ -6,7 +6,7 @@ import { useAuth } from '@/lib/auth-context';
 import { apiFetch } from '@/lib/api';
 import { getActiveBootstrapClinic, getBootstrapActiveClinicId } from '@/lib/bootstrap-clinics';
 import { AppPageHeader } from '@/components/app-shell/AppPageHeader';
-import { InlineErrorState, SectionSkeleton } from '@/components/feedback/AppState';
+import { DashboardLoadingState, InlineErrorState } from '@/components/feedback/AppState';
 import { RouteGuard } from '@/components/RouteGuard';
 import { DashboardSectionHeader } from '@/components/dashboard/DashboardSectionHeader';
 import { SummaryCards } from '@/components/dashboard/SummaryCards';
@@ -16,7 +16,10 @@ import { DirectorDashboard } from '@/components/dashboard/DirectorDashboard';
 import { VolunteerDashboard } from '@/components/dashboard/VolunteerDashboard';
 import { SystemAdminDashboard } from '@/components/dashboard/SystemAdminDashboard';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/components/ui/toast';
 import { EmptyStateCard } from '@/components/ops/OpsShared';
+import { RefreshCw } from 'lucide-react';
 
 interface DashboardData {
   summary: {
@@ -99,6 +102,7 @@ export default function DashboardPage() {
   const bootstrapCtx = useBootstrap();
   const bootstrap = bootstrapCtx?.bootstrap ?? null;
   const getToken = useAuth();
+  const { showToast } = useToast();
   const clinicId = getBootstrapActiveClinicId(bootstrap);
   const activeClinic = getActiveBootstrapClinic(bootstrap, clinicId);
 
@@ -106,29 +110,48 @@ export default function DashboardPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchDashboard = useCallback(async () => {
-    if (!clinicId || !getToken) {
-      setLoading(false);
-      setData(null);
-      return;
-    }
-    setLoading(true);
-    setError(null);
-    try {
-      const res = await apiFetch(`/clinics/${encodeURIComponent(clinicId)}/dashboard`, {
-        getToken,
-      });
-      if (!res.ok) {
-        throw new Error(await res.text());
+  const fetchDashboard = useCallback(
+    async (showRefreshToast = false) => {
+      if (!clinicId || !getToken) {
+        setLoading(false);
+        setData(null);
+        return;
       }
-      const json = (await res.json()) as DashboardData;
-      setData(json);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setLoading(false);
-    }
-  }, [clinicId, getToken]);
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await apiFetch(`/clinics/${encodeURIComponent(clinicId)}/dashboard`, {
+          getToken,
+        });
+        if (!res.ok) {
+          throw new Error(await res.text());
+        }
+        const json = (await res.json()) as DashboardData;
+        setData(json);
+        if (showRefreshToast) {
+          showToast({
+            tone: 'success',
+            title: 'Dashboard refreshed',
+            description: activeClinic
+              ? `${activeClinic.clinicName} metrics are up to date.`
+              : 'Clinic metrics are up to date.',
+          });
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        setError(message);
+        showToast({
+          tone: 'error',
+          title: 'Dashboard could not refresh',
+          description: message,
+          durationMs: 6500,
+        });
+      } finally {
+        setLoading(false);
+      }
+    },
+    [activeClinic, clinicId, getToken, showToast],
+  );
 
   useEffect(() => {
     fetchDashboard();
@@ -151,6 +174,20 @@ export default function DashboardPage() {
               </Badge>
             ) : null
           }
+          actions={
+            clinicId ? (
+              <Button
+                type="button"
+                variant="outline"
+                className="rounded-2xl border-border/70 bg-card/80"
+                onClick={() => void fetchDashboard(true)}
+                disabled={loading}
+              >
+                <RefreshCw className={loading ? 'animate-spin' : ''} />
+                Refresh
+              </Button>
+            ) : null
+          }
         />
 
         {!clinicId ? (
@@ -160,12 +197,7 @@ export default function DashboardPage() {
           />
         ) : null}
 
-        {loading && !data ? (
-          <div className="space-y-4">
-            <SectionSkeleton lines={2} className="rounded-[28px] p-6" />
-            <SectionSkeleton lines={4} className="rounded-[28px] p-6" />
-          </div>
-        ) : null}
+        {loading && !data ? <DashboardLoadingState clinicName={activeClinic?.clinicName} /> : null}
 
         {error ? (
           <InlineErrorState
@@ -189,7 +221,7 @@ export default function DashboardPage() {
               readyToFinalize={data.summary.readyToFinalize}
             />
 
-            <div className="border-t border-border pt-6">
+            <div className="space-y-8 border-t border-border/70 pt-6">
               {data.doctor && <DoctorDashboard {...data.doctor} />}
 
               {data.review && <ReviewDashboard {...data.review} />}

--- a/apps/web/app/(workspace)/encounters/[encounterId]/page.tsx
+++ b/apps/web/app/(workspace)/encounters/[encounterId]/page.tsx
@@ -7,6 +7,7 @@ import { useAuth } from '@/lib/auth-context';
 import { useBootstrap } from '@/lib/bootstrap-context';
 import { useSync } from '@/app/ServiceWorkerAndSyncProvider';
 import { apiFetch } from '@/lib/api';
+import { getBootstrapActiveClinicId } from '@/lib/bootstrap-clinics';
 import { AppMetricCard } from '@/components/app-shell/AppMetricCard';
 import { AppPageHeader } from '@/components/app-shell/AppPageHeader';
 import { EmptyStateCard, InlineNotice } from '@/components/ops/OpsShared';
@@ -47,7 +48,7 @@ export default function EncounterDetailPage() {
   const getToken = useAuth();
   const bootstrap = useBootstrap()?.bootstrap ?? null;
   const { syncNow } = useSync();
-  const clinicId = bootstrap?.activeClinicId ?? bootstrap?.memberships?.[0]?.clinicId ?? null;
+  const clinicId = getBootstrapActiveClinicId(bootstrap);
   const userId = bootstrap?.userId ?? '';
   const perms = bootstrap?.effectivePermissionsForActiveClinic ?? [];
 

--- a/apps/web/app/(workspace)/login/page.tsx
+++ b/apps/web/app/(workspace)/login/page.tsx
@@ -6,7 +6,7 @@ import { useSearchParams } from 'next/navigation';
 import { useBootstrap } from '@/lib/bootstrap-context';
 import { getPostAuthPath, getSafeNextPath } from '@/lib/auth-routing';
 import { useKeycloak } from '@/app/KeycloakProvider';
-import { FullscreenStatus } from '@/components/feedback/AppState';
+import { FullscreenStatus, PageSkeleton } from '@/components/feedback/AppState';
 import { Button } from '@/components/ui/button';
 
 export default function LoginPage() {
@@ -35,10 +35,11 @@ export default function LoginPage() {
 
   if (isAuthenticated) {
     return (
-      <FullscreenStatus
-        eyebrow="Secure sign in"
+      <PageSkeleton
         title="Opening your workspace"
-        description="We restored your session and are routing you to the right workspace."
+        description="Your session is active. We are selecting the right clinic context and opening your workspace."
+        steps={['Session restored', 'Clinic selected', 'Dashboard loading']}
+        className="min-h-screen"
       />
     );
   }

--- a/apps/web/app/(workspace)/my/assigned/page.tsx
+++ b/apps/web/app/(workspace)/my/assigned/page.tsx
@@ -9,6 +9,7 @@ import { DataGrid, type GridColDef } from '@mui/x-data-grid';
 import { useAuth } from '@/lib/auth-context';
 import { useBootstrap } from '@/lib/bootstrap-context';
 import { apiFetch } from '@/lib/api';
+import { getBootstrapActiveClinicId } from '@/lib/bootstrap-clinics';
 import {
   OPS_DEFAULT_TIMEZONE,
   type ActiveShift,
@@ -52,7 +53,7 @@ export default function MyAssignedPage() {
   const getToken = useAuth();
   const { isOnline } = useSync();
 
-  const clinicId = bootstrap?.activeClinicId ?? bootstrap?.memberships?.[0]?.clinicId ?? null;
+  const clinicId = getBootstrapActiveClinicId(bootstrap);
   const activeMembership = bootstrap?.memberships?.find(
     (membership) => membership.clinicId === clinicId,
   );

--- a/apps/web/app/(workspace)/patients/[patientId]/consent/page.tsx
+++ b/apps/web/app/(workspace)/patients/[patientId]/consent/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { useBootstrap } from '@/lib/bootstrap-context';
 import { useAuth } from '@/lib/auth-context';
 import { apiFetch } from '@/lib/api';
+import { getBootstrapActiveClinicId } from '@/lib/bootstrap-clinics';
 import { CONSENT_TEXT_V1_EN } from '@/lib/consent-text';
 import { db } from '@/lib/db';
 import { enqueueOutboxMutation, SYNC_OPERATION } from '@/lib/outbox';
@@ -30,7 +31,7 @@ export default function ConsentPage() {
   const patientId = params.patientId as string;
   const getToken = useAuth();
   const bootstrap = useBootstrap()?.bootstrap ?? null;
-  const clinicId = bootstrap?.activeClinicId ?? bootstrap?.memberships?.[0]?.clinicId ?? null;
+  const clinicId = getBootstrapActiveClinicId(bootstrap);
   const recordedByUserId = bootstrap?.userId ?? '';
 
   const [attested, setAttested] = useState(false);

--- a/apps/web/app/(workspace)/patients/[patientId]/encounters/new/page.tsx
+++ b/apps/web/app/(workspace)/patients/[patientId]/encounters/new/page.tsx
@@ -7,6 +7,7 @@ import { useBootstrap } from '@/lib/bootstrap-context';
 import { useAuth } from '@/lib/auth-context';
 import { useSync } from '@/app/ServiceWorkerAndSyncProvider';
 import { apiFetch } from '@/lib/api';
+import { getBootstrapActiveClinicId } from '@/lib/bootstrap-clinics';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { VitalsForm } from '@/components/VitalsForm';
@@ -22,7 +23,7 @@ export default function NewEncounterPage() {
   const getToken = useAuth();
   const bootstrap = useBootstrap()?.bootstrap ?? null;
   const { syncNow } = useSync();
-  const clinicId = bootstrap?.activeClinicId ?? bootstrap?.memberships?.[0]?.clinicId ?? null;
+  const clinicId = getBootstrapActiveClinicId(bootstrap);
   const userId = bootstrap?.userId ?? '';
 
   const [step, setStep] = useState(0);

--- a/apps/web/app/(workspace)/patients/[patientId]/page.tsx
+++ b/apps/web/app/(workspace)/patients/[patientId]/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { useAuth } from '@/lib/auth-context';
 import { useBootstrap } from '@/lib/bootstrap-context';
 import { apiFetch } from '@/lib/api';
+import { getBootstrapActiveClinicId } from '@/lib/bootstrap-clinics';
 import { getOpsDestination, hasPermission, readApiError } from '@/lib/ops';
 import { RouteGuard } from '@/components/RouteGuard';
 import { db } from '@/lib/db';
@@ -53,11 +54,7 @@ export default function PatientDetailPage() {
   const getToken = useAuth();
   const bootstrapContext = useBootstrap();
   const bootstrap = bootstrapContext?.bootstrap ?? null;
-  const clinicId =
-    bootstrapContext?.activeClinicId ??
-    bootstrap?.activeClinicId ??
-    bootstrap?.memberships?.[0]?.clinicId ??
-    null;
+  const clinicId = bootstrapContext?.activeClinicId ?? getBootstrapActiveClinicId(bootstrap);
   const perms = bootstrap?.effectivePermissionsForActiveClinic ?? [];
   const canRecordConsent = perms.includes('*') || perms.includes('CONSENT.RECORD');
   const canCreateOpsCheckIn = hasPermission(perms, 'OPS.CHECKIN.CREATE');

--- a/apps/web/app/(workspace)/patients/new/page.tsx
+++ b/apps/web/app/(workspace)/patients/new/page.tsx
@@ -2,6 +2,7 @@
 
 import { useBootstrap } from '@/lib/bootstrap-context';
 import { useAuth } from '@/lib/auth-context';
+import { getBootstrapActiveClinicId } from '@/lib/bootstrap-clinics';
 import { RouteGuard } from '@/components/RouteGuard';
 import { RegisterPatientScreen } from '@/components/patients/RegisterPatientScreen';
 
@@ -9,11 +10,7 @@ export default function NewPatientPage() {
   const bootstrapContext = useBootstrap();
   const bootstrap = bootstrapContext?.bootstrap ?? null;
   const getToken = useAuth();
-  const clinicId =
-    bootstrapContext?.activeClinicId ??
-    bootstrap?.activeClinicId ??
-    bootstrap?.memberships?.[0]?.clinicId ??
-    null;
+  const clinicId = bootstrapContext?.activeClinicId ?? getBootstrapActiveClinicId(bootstrap);
 
   if (!clinicId) {
     return (

--- a/apps/web/app/(workspace)/patients/page.tsx
+++ b/apps/web/app/(workspace)/patients/page.tsx
@@ -7,6 +7,7 @@ import { Search, UserPlus, Users } from 'lucide-react';
 import { useBootstrap } from '@/lib/bootstrap-context';
 import { useAuth } from '@/lib/auth-context';
 import { apiFetch } from '@/lib/api';
+import { getBootstrapActiveClinicId } from '@/lib/bootstrap-clinics';
 import { AppMetricCard } from '@/components/app-shell/AppMetricCard';
 import { ActiveFilterSummary } from '@/components/app-shell/ActiveFilterSummary';
 import { AppPageHeader } from '@/components/app-shell/AppPageHeader';
@@ -43,11 +44,7 @@ export default function PatientsPage() {
   const bootstrapContext = useBootstrap();
   const bootstrap = bootstrapContext?.bootstrap ?? null;
   const getToken = useAuth();
-  const clinicId =
-    bootstrapContext?.activeClinicId ??
-    bootstrap?.activeClinicId ??
-    bootstrap?.memberships?.[0]?.clinicId ??
-    null;
+  const clinicId = bootstrapContext?.activeClinicId ?? getBootstrapActiveClinicId(bootstrap);
   const perms = bootstrap?.effectivePermissionsForActiveClinic ?? [];
   const canCreateOpsCheckIn = hasPermission(perms, 'OPS.CHECKIN.CREATE');
 

--- a/apps/web/app/(workspace)/queues/page.tsx
+++ b/apps/web/app/(workspace)/queues/page.tsx
@@ -6,6 +6,7 @@ import { ClipboardList, Eye, FileEdit, Stethoscope } from 'lucide-react';
 import { useBootstrap } from '@/lib/bootstrap-context';
 import { useAuth } from '@/lib/auth-context';
 import { apiFetch } from '@/lib/api';
+import { getBootstrapActiveClinicId } from '@/lib/bootstrap-clinics';
 import { AppMetricCard } from '@/components/app-shell/AppMetricCard';
 import { AppPageHeader } from '@/components/app-shell/AppPageHeader';
 import { RouteGuard } from '@/components/RouteGuard';
@@ -39,7 +40,7 @@ export default function QueuesPage() {
   const tabParam = searchParams.get('tab') ?? '';
   const bootstrap = useBootstrap()?.bootstrap ?? null;
   const getToken = useAuth();
-  const clinicId = bootstrap?.activeClinicId ?? bootstrap?.memberships?.[0]?.clinicId ?? null;
+  const clinicId = getBootstrapActiveClinicId(bootstrap);
   const perms = bootstrap?.effectivePermissionsForActiveClinic ?? [];
 
   const canFinalize = hasPermission(perms, 'DOCTOR.FINALIZE');

--- a/apps/web/app/(workspace)/reminders/page.tsx
+++ b/apps/web/app/(workspace)/reminders/page.tsx
@@ -5,6 +5,7 @@ import { Bell, Clock3, SendHorizontal } from 'lucide-react';
 import { useBootstrap } from '@/lib/bootstrap-context';
 import { useAuth } from '@/lib/auth-context';
 import { apiFetch } from '@/lib/api';
+import { getBootstrapActiveClinicId } from '@/lib/bootstrap-clinics';
 import { AppMetricCard } from '@/components/app-shell/AppMetricCard';
 import { ActiveFilterSummary } from '@/components/app-shell/ActiveFilterSummary';
 import { AppPageHeader } from '@/components/app-shell/AppPageHeader';
@@ -47,7 +48,7 @@ interface ReminderRow {
 export default function RemindersPage() {
   const bootstrap = useBootstrap()?.bootstrap ?? null;
   const getToken = useAuth();
-  const clinicId = bootstrap?.activeClinicId ?? bootstrap?.memberships?.[0]?.clinicId ?? null;
+  const clinicId = getBootstrapActiveClinicId(bootstrap);
 
   const [status, setStatus] = useState('');
   const [from, setFrom] = useState('');

--- a/apps/web/app/(workspace)/settings/clinic/page.tsx
+++ b/apps/web/app/(workspace)/settings/clinic/page.tsx
@@ -5,6 +5,7 @@ import { Microscope, Settings2, ShieldCheck } from 'lucide-react';
 import { useBootstrap } from '@/lib/bootstrap-context';
 import { useAuth } from '@/lib/auth-context';
 import { apiFetch } from '@/lib/api';
+import { getBootstrapActiveClinicId } from '@/lib/bootstrap-clinics';
 import { AppMetricCard } from '@/components/app-shell/AppMetricCard';
 import { AppPageHeader } from '@/components/app-shell/AppPageHeader';
 import { RouteGuard } from '@/components/RouteGuard';
@@ -24,7 +25,7 @@ interface ResearchSettings {
 export default function ClinicSettingsPage() {
   const bootstrap = useBootstrap()?.bootstrap ?? null;
   const getToken = useAuth();
-  const clinicId = bootstrap?.activeClinicId ?? bootstrap?.memberships?.[0]?.clinicId ?? null;
+  const clinicId = getBootstrapActiveClinicId(bootstrap);
 
   const [settings, setSettings] = useState<ResearchSettings | null>(null);
   const [researchEnabled, setResearchEnabled] = useState(false);

--- a/apps/web/app/(workspace)/today/page.tsx
+++ b/apps/web/app/(workspace)/today/page.tsx
@@ -6,6 +6,7 @@ import { ArrowRight, CalendarDays, RefreshCw, Users } from 'lucide-react';
 import { useAuth } from '@/lib/auth-context';
 import { useBootstrap } from '@/lib/bootstrap-context';
 import { apiFetch } from '@/lib/api';
+import { getBootstrapActiveClinicId } from '@/lib/bootstrap-clinics';
 import {
   CHECKIN_STATUS_ORDER,
   OPS_DEFAULT_TIMEZONE,
@@ -74,7 +75,7 @@ export default function TodayBoardPage() {
   const getToken = useAuth();
   const { isOnline } = useSync();
 
-  const clinicId = bootstrap?.activeClinicId ?? bootstrap?.memberships?.[0]?.clinicId ?? null;
+  const clinicId = getBootstrapActiveClinicId(bootstrap);
   const activeMembership = bootstrap?.memberships?.find(
     (membership) => membership.clinicId === clinicId,
   );

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -159,6 +159,18 @@
   }
 }
 
+@keyframes loading-bar {
+  0% {
+    transform: translateX(-110%);
+  }
+  52% {
+    transform: translateX(80%);
+  }
+  100% {
+    transform: translateX(230%);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css';
 import type { Metadata } from 'next';
+import { ToastProvider } from '@/components/ui/toast';
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://app.nkwapa.app';
 
@@ -63,7 +64,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <head>
         <link href="https://fonts.cdnfonts.com/css/circular-std" rel="stylesheet" />
       </head>
-      <body suppressHydrationWarning>{children}</body>
+      <body suppressHydrationWarning>
+        <ToastProvider>{children}</ToastProvider>
+      </body>
     </html>
   );
 }

--- a/apps/web/app/loading.tsx
+++ b/apps/web/app/loading.tsx
@@ -5,6 +5,7 @@ export default function Loading() {
     <PageSkeleton
       title="Loading Nkwapa"
       description="Pulling together clinic context, patient-safe navigation, and the next actions for this page."
+      steps={['Route requested', 'Clinic context', 'Page data']}
     />
   );
 }

--- a/apps/web/components/Header.tsx
+++ b/apps/web/components/Header.tsx
@@ -31,6 +31,7 @@ import { useKeycloak } from '@/app/KeycloakProvider';
 import { db } from '@/lib/db';
 import { getActiveBootstrapClinic, getSwitchableClinics } from '@/lib/bootstrap-clinics';
 import { setStoredActiveClinicId } from '@/lib/bootstrap-storage';
+import { useToast } from '@/components/ui/toast';
 import {
   ArrowRightLeft,
   LogOut,
@@ -58,6 +59,7 @@ export function Header({
   const { activeClinicId: contextActiveClinicId, setActiveClinicId } = bootstrapCtx ?? {};
   const { isOnline, syncStatus, syncError, syncNow } = useSync();
   const { logout } = useKeycloak() ?? {};
+  const { showToast } = useToast();
   const [pendingCount, setPendingCount] = useState(0);
 
   const clinicId = contextActiveClinicId ?? null;
@@ -91,10 +93,19 @@ export function Header({
   }, [clinicId]);
 
   const handleClinicChange = (value: string) => {
+    const nextClinic = switchableClinics.find((clinic) => clinic.clinicId === value);
     setStoredActiveClinicId(value);
     setActiveClinicId?.(value);
+    showToast({
+      tone: 'loading',
+      title: nextClinic ? `Switching to ${nextClinic.clinicName}` : 'Switching clinic',
+      description: 'Refreshing clinic-scoped queues, dashboard data, and records.',
+      durationMs: 1800,
+    });
     if (value) {
-      window.location.href = '/dashboard';
+      window.setTimeout(() => {
+        window.location.href = '/dashboard';
+      }, 180);
     }
   };
 
@@ -128,7 +139,7 @@ export function Header({
           >
             <SheetHeader className="border-b border-border/70 p-5 text-left">
               <SheetTitle className="text-left">
-                <div className="flex items-center gap-3">
+                <div className="space-y-3">
                   <div className="relative h-11 w-40">
                     <Image
                       src="/images/nkwapa-logo.png"
@@ -137,14 +148,7 @@ export function Header({
                       className="object-contain"
                     />
                   </div>
-                  <div>
-                    <p className="text-xs font-semibold uppercase tracking-[0.28em] text-primary/80">
-                      Nkwapa EMR
-                    </p>
-                    <p className="mt-1 text-sm text-muted-foreground">
-                      Mobile workspace navigation
-                    </p>
-                  </div>
+                  <p className="text-xs font-medium text-muted-foreground">Workspace menu</p>
                 </div>
               </SheetTitle>
             </SheetHeader>

--- a/apps/web/components/Header.tsx
+++ b/apps/web/components/Header.tsx
@@ -29,6 +29,7 @@ import { formatRoleLabel } from '@/lib/ops';
 import { useSync } from '@/app/ServiceWorkerAndSyncProvider';
 import { useKeycloak } from '@/app/KeycloakProvider';
 import { db } from '@/lib/db';
+import { getActiveBootstrapClinic, getSwitchableClinics } from '@/lib/bootstrap-clinics';
 import { setStoredActiveClinicId } from '@/lib/bootstrap-storage';
 import {
   ArrowRightLeft,
@@ -54,13 +55,15 @@ export function Header({
 }) {
   const bootstrapCtx = useBootstrap();
   const bootstrap = bootstrapCtx?.bootstrap ?? null;
-  const { setActiveClinicId } = bootstrapCtx ?? {};
+  const { activeClinicId: contextActiveClinicId, setActiveClinicId } = bootstrapCtx ?? {};
   const { isOnline, syncStatus, syncError, syncNow } = useSync();
   const { logout } = useKeycloak() ?? {};
   const [pendingCount, setPendingCount] = useState(0);
 
-  const clinicId = bootstrap?.activeClinicId ?? bootstrap?.memberships?.[0]?.clinicId ?? null;
+  const clinicId = contextActiveClinicId ?? null;
   const memberships = bootstrap?.memberships ?? [];
+  const switchableClinics = getSwitchableClinics(bootstrap);
+  const activeClinic = getActiveBootstrapClinic(bootstrap, clinicId);
   const activeMembership = memberships.find((membership) => membership.clinicId === clinicId);
   const perms = bootstrap?.effectivePermissionsForActiveClinic ?? [];
   const canSync =
@@ -180,20 +183,20 @@ export function Header({
             />
           </div>
           <p className="truncate text-sm font-medium text-foreground">
-            {activeMembership?.clinicName ?? 'Choose an active clinic'}
+            {activeClinic?.clinicName ?? 'Choose an active clinic'}
           </p>
         </div>
 
         <div className="hidden items-center gap-2 lg:flex">
-          {memberships.length > 1 ? (
+          {switchableClinics.length > 1 ? (
             <Select value={clinicId ?? ''} onValueChange={handleClinicChange}>
               <SelectTrigger className="h-10 w-[220px] rounded-2xl border-border/70 bg-card/70">
                 <SelectValue placeholder="Select clinic" />
               </SelectTrigger>
               <SelectContent>
-                {memberships.map((membership) => (
-                  <SelectItem key={membership.clinicId} value={membership.clinicId}>
-                    {membership.clinicName}
+                {switchableClinics.map((clinic) => (
+                  <SelectItem key={clinic.clinicId} value={clinic.clinicId}>
+                    {clinic.clinicName}
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -201,7 +204,7 @@ export function Header({
           ) : clinicId ? (
             <div className="inline-flex items-center gap-2 rounded-2xl border border-border/70 bg-card/70 px-3 py-2 text-sm text-muted-foreground">
               <ArrowRightLeft className="h-4 w-4 text-primary" />
-              {activeMembership?.clinicName ?? 'Clinic'}
+              {activeClinic?.clinicName ?? 'Clinic'}
             </div>
           ) : null}
 

--- a/apps/web/components/PortalLayout.tsx
+++ b/apps/web/components/PortalLayout.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useBootstrap } from '@/lib/bootstrap-context';
+import { getActiveBootstrapClinic, getBootstrapActiveClinicId } from '@/lib/bootstrap-clinics';
 import { Header } from '@/components/Header';
 import { Badge } from '@/components/ui/badge';
 import { ProgressiveHelp } from '@/components/ui/progressive-help';
@@ -35,10 +36,8 @@ const navItems = [
 export function PortalLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const bootstrap = useBootstrap()?.bootstrap ?? null;
-  const activeClinicId = bootstrap?.activeClinicId ?? bootstrap?.memberships?.[0]?.clinicId ?? null;
-  const activeClinic = bootstrap?.memberships.find(
-    (membership) => membership.clinicId === activeClinicId,
-  );
+  const activeClinicId = getBootstrapActiveClinicId(bootstrap);
+  const activeClinic = getActiveBootstrapClinic(bootstrap, activeClinicId);
   const displayName = bootstrap?.displayName ?? 'Patient';
 
   return (

--- a/apps/web/components/Sidebar.tsx
+++ b/apps/web/components/Sidebar.tsx
@@ -4,13 +4,15 @@ import Image from 'next/image';
 import { Badge } from '@/components/ui/badge';
 import { AppNavList } from '@/components/app-shell/AppNavList';
 import { useBootstrap } from '@/lib/bootstrap-context';
+import { getActiveBootstrapClinic, getBootstrapActiveClinicId } from '@/lib/bootstrap-clinics';
 import { formatRoleLabel } from '@/lib/ops';
 import { cn } from '@/lib/utils';
 
 export function Sidebar({ collapsed }: { collapsed: boolean }) {
   const bootstrap = useBootstrap()?.bootstrap ?? null;
-  const clinicId = bootstrap?.activeClinicId ?? bootstrap?.memberships?.[0]?.clinicId ?? null;
+  const clinicId = getBootstrapActiveClinicId(bootstrap);
   const memberships = bootstrap?.memberships ?? [];
+  const activeClinic = getActiveBootstrapClinic(bootstrap, clinicId);
   const activeMembership = memberships.find((membership) => membership.clinicId === clinicId);
   const roleLabels = [...(activeMembership?.roles ?? []), ...(bootstrap?.globalRoles ?? [])].slice(
     0,
@@ -77,7 +79,7 @@ export function Sidebar({ collapsed }: { collapsed: boolean }) {
           {collapsed ? (
             <div className="flex justify-center">
               <Badge variant="outline" className="rounded-full px-2.5 py-1 text-[10px]">
-                {activeMembership?.clinicName?.slice(0, 1) ?? 'C'}
+                {activeClinic?.clinicName?.slice(0, 1) ?? 'C'}
               </Badge>
             </div>
           ) : (
@@ -87,7 +89,7 @@ export function Sidebar({ collapsed }: { collapsed: boolean }) {
                   Active clinic
                 </p>
                 <p className="mt-2 text-sm font-semibold text-foreground">
-                  {activeMembership?.clinicName ?? 'Select a clinic'}
+                  {activeClinic?.clinicName ?? 'Select a clinic'}
                 </p>
               </div>
               {roleLabels.length > 0 && (

--- a/apps/web/components/Sidebar.tsx
+++ b/apps/web/components/Sidebar.tsx
@@ -30,7 +30,7 @@ export function Sidebar({ collapsed }: { collapsed: boolean }) {
       <div className="flex h-full w-full flex-col gap-5 p-4">
         <div className="overflow-hidden rounded-[30px] border border-primary/15 bg-gradient-to-br from-primary/14 via-card to-secondary/12 shadow-lg shadow-primary/5">
           <div className={cn('p-4', collapsed ? 'px-3 py-4' : 'p-5')}>
-            <div className={cn('flex items-center gap-3', collapsed && 'justify-center')}>
+            <div className={cn('flex flex-col gap-3', collapsed ? 'items-center' : 'items-start')}>
               {collapsed ? (
                 <div className="relative h-12 w-12 shrink-0 overflow-hidden rounded-2xl bg-background shadow-lg shadow-primary/10">
                   <Image
@@ -51,23 +51,9 @@ export function Sidebar({ collapsed }: { collapsed: boolean }) {
                 </div>
               )}
               {!collapsed && (
-                <div className="min-w-0">
-                  <p className="text-xs font-semibold uppercase tracking-[0.28em] text-primary/80">
-                    Nkwapa EMR
-                  </p>
-                  <p className="mt-1 text-sm font-medium text-foreground">Clinic workspace</p>
-                </div>
+                <p className="text-sm font-medium text-muted-foreground">Clinic workspace</p>
               )}
             </div>
-
-            {!collapsed && (
-              <div className="mt-5 rounded-[24px] border border-border/70 bg-background/80 p-4">
-                <p className="text-sm font-medium text-foreground">Daily workflow</p>
-                <p className="mt-2 text-sm leading-6 text-muted-foreground xl:max-w-[18rem]">
-                  Patients, queues, and follow-up work in one place.
-                </p>
-              </div>
-            )}
           </div>
         </div>
 

--- a/apps/web/components/app-shell/AppNavList.tsx
+++ b/apps/web/components/app-shell/AppNavList.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
 import { getAccessibleNavSections, getNavItemHref, isNavItemActive } from '@/lib/app-nav';
+import { getBootstrapActiveClinicId } from '@/lib/bootstrap-clinics';
 import type { WhoAmIResponse } from '@/lib/bootstrap-context';
 
 export function AppNavList({
@@ -18,7 +19,7 @@ export function AppNavList({
   onNavigate?: () => void;
 }) {
   const pathname = usePathname();
-  const clinicId = bootstrap?.activeClinicId ?? bootstrap?.memberships?.[0]?.clinicId ?? null;
+  const clinicId = getBootstrapActiveClinicId(bootstrap);
   const sections = getAccessibleNavSections(bootstrap);
 
   return (

--- a/apps/web/components/feedback/AppState.tsx
+++ b/apps/web/components/feedback/AppState.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { AlertTriangle, RefreshCw, ShieldCheck, Stethoscope } from 'lucide-react';
+import { Activity, AlertTriangle, RefreshCw, ShieldCheck, Stethoscope } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
@@ -9,38 +9,59 @@ import { cn } from '@/lib/utils';
 export function PageSkeleton({
   title = 'Preparing your workspace',
   description = 'Loading clinic context, recent activity, and the safest next actions for this page.',
+  steps = ['Secure session', 'Clinic context', 'Workspace data'],
   className,
 }: {
   title?: string;
   description?: string;
+  steps?: string[];
   className?: string;
 }) {
   return (
     <div className={cn('min-h-[60vh] bg-clinical-grid px-4 py-8 md:px-6', className)}>
       <div className="mx-auto flex max-w-6xl flex-col gap-6">
-        <div className="rounded-[32px] border border-border/70 bg-card/95 p-6 shadow-2xl shadow-black/5 md:p-8">
-          <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
-            <div className="space-y-3">
-              <div className="inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.28em] text-primary/80">
-                <Stethoscope className="h-3.5 w-3.5" />
-                Loading
+        <div className="overflow-hidden rounded-[32px] border border-border/70 bg-card/95 shadow-2xl shadow-black/5">
+          <div className="h-1.5 w-full overflow-hidden bg-muted/50">
+            <div className="h-full w-1/2 animate-[loading-bar_1.7s_ease-in-out_infinite] bg-primary/80" />
+          </div>
+          <div className="p-6 md:p-8">
+            <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+              <div className="space-y-3">
+                <div className="inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.28em] text-primary/80">
+                  <Activity className="h-3.5 w-3.5 animate-pulse" />
+                  Loading
+                </div>
+                <div className="space-y-2">
+                  <h1 className="font-heading text-3xl font-semibold tracking-tight text-foreground md:text-4xl">
+                    {title}
+                  </h1>
+                  <p className="max-w-2xl text-sm leading-6 text-muted-foreground md:text-base">
+                    {description}
+                  </p>
+                </div>
+                <div className="grid max-w-xl gap-2 pt-2 sm:grid-cols-3">
+                  {steps.map((step, index) => (
+                    <div
+                      key={step}
+                      className="flex items-center gap-2 rounded-2xl border border-border/70 bg-background/75 px-3 py-2 text-xs font-medium text-muted-foreground"
+                    >
+                      <span
+                        className="h-2 w-2 rounded-full bg-primary"
+                        style={{ animation: `pulse 1.4s ease-in-out ${index * 160}ms infinite` }}
+                      />
+                      <span className="truncate">{step}</span>
+                    </div>
+                  ))}
+                </div>
               </div>
-              <div className="space-y-2">
-                <h1 className="font-heading text-3xl font-semibold tracking-tight text-foreground md:text-4xl">
-                  {title}
-                </h1>
-                <p className="max-w-2xl text-sm leading-6 text-muted-foreground md:text-base">
-                  {description}
-                </p>
+              <div className="grid gap-3 sm:grid-cols-3 lg:w-[420px]">
+                {Array.from({ length: 3 }).map((_, index) => (
+                  <div
+                    key={index}
+                    className="h-24 animate-pulse rounded-2xl border border-border/70 bg-muted/40"
+                  />
+                ))}
               </div>
-            </div>
-            <div className="grid gap-3 sm:grid-cols-3 lg:w-[420px]">
-              {Array.from({ length: 3 }).map((_, index) => (
-                <div
-                  key={index}
-                  className="h-24 animate-pulse rounded-2xl border border-border/70 bg-muted/40"
-                />
-              ))}
             </div>
           </div>
         </div>
@@ -48,6 +69,37 @@ export function PageSkeleton({
         <SectionSkeleton lines={2} className="rounded-[28px] p-6 md:p-8" />
         <SectionSkeleton lines={5} className="rounded-[28px] p-6 md:p-8" />
       </div>
+    </div>
+  );
+}
+
+export function DashboardLoadingState({ clinicName }: { clinicName?: string | null }) {
+  return (
+    <div className="space-y-5">
+      <div className="rounded-[28px] border border-border/70 bg-card/90 p-5 shadow-sm">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div className="space-y-2">
+            <div className="h-4 w-36 animate-pulse rounded-full bg-primary/20" />
+            <div className="h-7 w-64 max-w-full animate-pulse rounded-full bg-muted/60" />
+            <div className="h-4 w-80 max-w-full animate-pulse rounded-full bg-muted/40" />
+          </div>
+          <div className="inline-flex items-center gap-3 rounded-2xl border border-primary/20 bg-primary/10 px-4 py-3 text-sm font-medium text-primary">
+            <Stethoscope className="h-4 w-4 animate-pulse" />
+            {clinicName ? `Loading ${clinicName}` : 'Loading clinic dashboard'}
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
+        {Array.from({ length: 5 }).map((_, index) => (
+          <div
+            key={index}
+            className="h-32 animate-pulse rounded-2xl border border-border/70 bg-card/80"
+          />
+        ))}
+      </div>
+
+      <SectionSkeleton lines={4} className="rounded-[28px] p-6" />
     </div>
   );
 }

--- a/apps/web/components/ui/toast.tsx
+++ b/apps/web/components/ui/toast.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Info,
+  Loader2,
+  X,
+  XCircle,
+  type LucideIcon,
+} from 'lucide-react';
+import { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+type ToastTone = 'info' | 'success' | 'warning' | 'error' | 'loading';
+
+interface ToastInput {
+  title: string;
+  description?: string;
+  tone?: ToastTone;
+  durationMs?: number;
+}
+
+interface ToastItem extends Required<ToastInput> {
+  id: string;
+}
+
+interface ToastContextValue {
+  showToast: (toast: ToastInput) => string;
+  dismissToast: (id: string) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+const toneStyles: Record<
+  ToastTone,
+  { icon: LucideIcon; className: string; iconClassName: string }
+> = {
+  info: {
+    icon: Info,
+    className: 'border-primary/20 bg-card text-foreground',
+    iconClassName: 'text-primary',
+  },
+  success: {
+    icon: CheckCircle2,
+    className: 'border-emerald-200 bg-emerald-50 text-emerald-950',
+    iconClassName: 'text-emerald-600',
+  },
+  warning: {
+    icon: AlertTriangle,
+    className: 'border-amber-200 bg-amber-50 text-amber-950',
+    iconClassName: 'text-amber-600',
+  },
+  error: {
+    icon: XCircle,
+    className: 'border-destructive/25 bg-destructive/10 text-foreground',
+    iconClassName: 'text-destructive',
+  },
+  loading: {
+    icon: Loader2,
+    className: 'border-primary/20 bg-card text-foreground',
+    iconClassName: 'animate-spin text-primary',
+  },
+};
+
+function createToastId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `toast-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+  const timers = useRef(new Map<string, ReturnType<typeof setTimeout>>());
+
+  const dismissToast = useCallback((id: string) => {
+    const timer = timers.current.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      timers.current.delete(id);
+    }
+    setToasts((current) => current.filter((toast) => toast.id !== id));
+  }, []);
+
+  const showToast = useCallback(
+    ({ title, description = '', tone = 'info', durationMs = 4200 }: ToastInput) => {
+      const id = createToastId();
+      const nextToast: ToastItem = { id, title, description, tone, durationMs };
+      setToasts((current) => [nextToast, ...current].slice(0, 4));
+
+      if (durationMs > 0) {
+        const timer = setTimeout(() => dismissToast(id), durationMs);
+        timers.current.set(id, timer);
+      }
+
+      return id;
+    },
+    [dismissToast],
+  );
+
+  const value = useMemo(() => ({ showToast, dismissToast }), [dismissToast, showToast]);
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <div
+        aria-live="polite"
+        aria-relevant="additions text"
+        className="fixed right-4 top-4 z-[100] flex w-[calc(100vw-2rem)] max-w-sm flex-col gap-3 sm:right-5 sm:top-5"
+      >
+        {toasts.map((toast) => {
+          const tone = toneStyles[toast.tone];
+          const Icon = tone.icon;
+
+          return (
+            <div
+              key={toast.id}
+              className={cn(
+                'rounded-2xl border p-4 shadow-2xl shadow-black/10 backdrop-blur transition-all',
+                tone.className,
+              )}
+            >
+              <div className="flex items-start gap-3">
+                <Icon className={cn('mt-0.5 h-5 w-5 shrink-0', tone.iconClassName)} />
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-semibold leading-5">{toast.title}</p>
+                  {toast.description ? (
+                    <p className="mt-1 text-sm leading-5 text-current/75">{toast.description}</p>
+                  ) : null}
+                </div>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 shrink-0 rounded-full text-current/65 hover:bg-current/10 hover:text-current"
+                  onClick={() => dismissToast(toast.id)}
+                >
+                  <X className="h-4 w-4" />
+                  <span className="sr-only">Dismiss notification</span>
+                </Button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const ctx = useContext(ToastContext);
+  if (!ctx) {
+    return {
+      showToast: () => '',
+      dismissToast: () => undefined,
+    };
+  }
+  return ctx;
+}

--- a/apps/web/lib/app-nav.ts
+++ b/apps/web/lib/app-nav.ts
@@ -12,6 +12,7 @@ import {
   UserCog,
   Users,
 } from 'lucide-react';
+import { getBootstrapActiveClinicId } from '@/lib/bootstrap-clinics';
 import type { WhoAmIResponse } from '@/lib/bootstrap-context';
 
 export interface AppNavItem {
@@ -152,7 +153,7 @@ function hasAnyPermission(permissions: string[], perms: string[]): boolean {
 }
 
 export function getAccessibleNavSections(bootstrap: WhoAmIResponse | null): AppNavSection[] {
-  const clinicId = bootstrap?.activeClinicId ?? bootstrap?.memberships?.[0]?.clinicId ?? null;
+  const clinicId = getBootstrapActiveClinicId(bootstrap);
   const memberships = bootstrap?.memberships ?? [];
   const activeMembership = memberships.find((membership) => membership.clinicId === clinicId);
   const isSystemAdmin = bootstrap?.globalRoles?.includes('SYSTEM_ADMIN') ?? false;

--- a/apps/web/lib/bootstrap-clinics.test.ts
+++ b/apps/web/lib/bootstrap-clinics.test.ts
@@ -1,0 +1,55 @@
+import {
+  getActiveBootstrapClinic,
+  getBootstrapActiveClinicId,
+  getSwitchableClinics,
+  isStoredClinicIdValid,
+} from '@/lib/bootstrap-clinics';
+
+describe('bootstrap clinic helpers', () => {
+  it('uses availableClinics as the switchable clinic contract for system admins', () => {
+    const bootstrap = {
+      activeClinicId: 'clinic-2',
+      availableClinics: [
+        { clinicId: 'clinic-1', clinicName: 'Clinic One' },
+        { clinicId: 'clinic-2', clinicName: 'Clinic Two' },
+      ],
+      memberships: [],
+    };
+
+    expect(getSwitchableClinics(bootstrap)).toEqual([
+      { clinicId: 'clinic-1', clinicName: 'Clinic One' },
+      { clinicId: 'clinic-2', clinicName: 'Clinic Two' },
+    ]);
+    expect(getBootstrapActiveClinicId(bootstrap)).toBe('clinic-2');
+    expect(getActiveBootstrapClinic(bootstrap)?.clinicName).toBe('Clinic Two');
+    expect(isStoredClinicIdValid(bootstrap, 'clinic-1')).toBe(true);
+  });
+
+  it('falls back to explicit memberships for older bootstrap payloads', () => {
+    const bootstrap = {
+      activeClinicId: null,
+      memberships: [
+        { clinicId: 'clinic-3', clinicName: 'Clinic Three', roles: ['MANAGER'] },
+        { clinicId: 'clinic-4', clinicName: 'Clinic Four', roles: ['VOLUNTEER'] },
+      ],
+    };
+
+    expect(getSwitchableClinics(bootstrap)).toEqual([
+      { clinicId: 'clinic-3', clinicName: 'Clinic Three' },
+      { clinicId: 'clinic-4', clinicName: 'Clinic Four' },
+    ]);
+    expect(getBootstrapActiveClinicId(bootstrap)).toBe('clinic-3');
+    expect(isStoredClinicIdValid(bootstrap, 'clinic-4')).toBe(true);
+  });
+
+  it('rejects stored clinic ids not returned by the server as switchable', () => {
+    const bootstrap = {
+      activeClinicId: 'clinic-1',
+      availableClinics: [{ clinicId: 'clinic-1', clinicName: 'Clinic One' }],
+      memberships: [],
+    };
+
+    expect(isStoredClinicIdValid(bootstrap, 'inactive-clinic')).toBe(false);
+    expect(getActiveBootstrapClinic(bootstrap, 'inactive-clinic')).toBeNull();
+  });
+});

--- a/apps/web/lib/bootstrap-clinics.ts
+++ b/apps/web/lib/bootstrap-clinics.ts
@@ -1,0 +1,75 @@
+export interface BootstrapClinic {
+  clinicId: string;
+  clinicName: string;
+}
+
+export interface BootstrapMembership extends BootstrapClinic {
+  roles: string[];
+}
+
+export interface BootstrapClinicSource {
+  activeClinicId?: string | null;
+  availableClinics?: BootstrapClinic[];
+  memberships?: BootstrapMembership[];
+}
+
+function uniqueClinics(clinics: BootstrapClinic[]): BootstrapClinic[] {
+  const seen = new Set<string>();
+  const deduped: BootstrapClinic[] = [];
+
+  for (const clinic of clinics) {
+    if (seen.has(clinic.clinicId)) {
+      continue;
+    }
+    seen.add(clinic.clinicId);
+    deduped.push(clinic);
+  }
+
+  return deduped;
+}
+
+export function getSwitchableClinics(
+  bootstrap: BootstrapClinicSource | null | undefined,
+): BootstrapClinic[] {
+  const availableClinics = bootstrap?.availableClinics ?? [];
+  if (availableClinics.length > 0) {
+    return uniqueClinics(availableClinics);
+  }
+
+  return uniqueClinics(
+    (bootstrap?.memberships ?? []).map((membership) => ({
+      clinicId: membership.clinicId,
+      clinicName: membership.clinicName,
+    })),
+  );
+}
+
+export function getBootstrapActiveClinicId(
+  bootstrap: BootstrapClinicSource | null | undefined,
+): string | null {
+  return bootstrap?.activeClinicId ?? getSwitchableClinics(bootstrap)[0]?.clinicId ?? null;
+}
+
+export function getActiveBootstrapClinic(
+  bootstrap: BootstrapClinicSource | null | undefined,
+  activeClinicId = getBootstrapActiveClinicId(bootstrap),
+): BootstrapClinic | null {
+  if (!activeClinicId) {
+    return null;
+  }
+
+  return (
+    getSwitchableClinics(bootstrap).find((clinic) => clinic.clinicId === activeClinicId) ?? null
+  );
+}
+
+export function isStoredClinicIdValid(
+  bootstrap: BootstrapClinicSource | null | undefined,
+  clinicId: string | null | undefined,
+): boolean {
+  if (!clinicId) {
+    return false;
+  }
+
+  return getSwitchableClinics(bootstrap).some((clinic) => clinic.clinicId === clinicId);
+}

--- a/apps/web/lib/bootstrap-context.tsx
+++ b/apps/web/lib/bootstrap-context.tsx
@@ -17,6 +17,11 @@ import {
   type GetToken,
   readApiError,
 } from './api';
+import {
+  getBootstrapActiveClinicId,
+  isStoredClinicIdValid,
+  type BootstrapClinic,
+} from './bootstrap-clinics';
 import { getStoredActiveClinicId, setStoredActiveClinicId } from './bootstrap-storage';
 
 export { BOOTSTRAP_STORAGE_KEY } from './bootstrap-storage';
@@ -27,11 +32,14 @@ export interface WhoAmIMembership {
   roles: string[];
 }
 
+export type WhoAmIAvailableClinic = BootstrapClinic;
+
 export interface WhoAmIResponse {
   userId: string;
   keycloakSub: string;
   displayName: string;
   memberships: WhoAmIMembership[];
+  availableClinics?: WhoAmIAvailableClinic[];
   globalRoles: string[];
   activeClinicId: string | null;
   effectiveRolesForActiveClinic: string[];
@@ -86,7 +94,7 @@ export function BootstrapProvider({
   const activeClinicId =
     activeClinicIdOverride !== undefined
       ? activeClinicIdOverride
-      : (bootstrap?.activeClinicId ?? getStoredActiveClinicId());
+      : (getBootstrapActiveClinicId(bootstrap) ?? getStoredActiveClinicId());
 
   const setActiveClinicId = useCallback((id: string | null) => {
     setStoredActiveClinicId(id);
@@ -142,10 +150,7 @@ export function BootstrapProvider({
       // The server only returns an activeClinicId the user actually has
       // access to, so we always mirror it back to localStorage (even when
       // null), and clear any stale override state.
-      const membershipIds = new Set(data.memberships.map((m) => m.clinicId));
-      const isSystemAdmin = data.globalRoles.includes('SYSTEM_ADMIN');
-      const storedIsValid =
-        !!storedClinicId && (isSystemAdmin || membershipIds.has(storedClinicId));
+      const storedIsValid = isStoredClinicIdValid(data, storedClinicId);
 
       if (!storedIsValid && storedClinicId) {
         // Stale value from a prior session (e.g. after a DB reseed or an

--- a/apps/web/lib/patient-portal.ts
+++ b/apps/web/lib/patient-portal.ts
@@ -1,5 +1,6 @@
 import type { GetToken } from '@/lib/api';
 import { apiFetch } from '@/lib/api';
+import { getActiveBootstrapClinic, getBootstrapActiveClinicId } from '@/lib/bootstrap-clinics';
 import type { WhoAmIResponse } from '@/lib/bootstrap-context';
 
 export const PATIENT_PORTAL_LINK_MISSING = 'PATIENT_PORTAL_LINK_MISSING';
@@ -179,14 +180,11 @@ export function getPortalErrorMessage(error: unknown) {
 }
 
 export function getPortalClinicId(bootstrap: WhoAmIResponse | null) {
-  return bootstrap?.activeClinicId ?? bootstrap?.memberships?.[0]?.clinicId ?? null;
+  return getBootstrapActiveClinicId(bootstrap);
 }
 
 export function getPortalClinicName(bootstrap: WhoAmIResponse | null, clinicId: string | null) {
-  if (!bootstrap || !clinicId) return null;
-  return (
-    bootstrap.memberships.find((membership) => membership.clinicId === clinicId)?.clinicName ?? null
-  );
+  return getActiveBootstrapClinic(bootstrap, clinicId)?.clinicName ?? null;
 }
 
 export async function fetchPortalMe(clinicId: string, getToken: GetToken) {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -38,6 +38,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "recharts": "^3.7.0",
+    "sharp": "^0.34.5",
     "socket.io-client": "^4.8.3",
     "tailwind-merge": "^3.5.0",
     "tailwindcss-animate": "^1.0.7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -124,6 +124,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "recharts": "^3.7.0",
+        "sharp": "^0.34.5",
         "socket.io-client": "^4.8.3",
         "tailwind-merge": "^3.5.0",
         "tailwindcss-animate": "^1.0.7"
@@ -1031,7 +1032,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
       "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1447,6 +1447,471 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
     },
     "node_modules/@ioredis/commands": {
       "version": "1.5.1",
@@ -18582,6 +19047,50 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",


### PR DESCRIPTION
## Summary
- Added `availableClinics` to `/auth/whoami` so global `SYSTEM_ADMIN` users can switch among all active clinics without per-clinic role workarounds.
- Preserved explicit `memberships` semantics while keeping system-admin effective permissions as `['*']`.
- Updated web bootstrap reconciliation, active clinic resolution, and the header clinic picker to use the new switchable-clinic contract.
- Polished the dashboard and shell UX with cleaner Nkwapa branding, animated loading states, dashboard-shaped skeletons, refresh feedback, and reusable toast notifications.
- Added `sharp` to the web app runtime dependencies so self-hosted `next start` uses Next.js production image optimization without warnings.

## Testing
- `npm run test --workspace=@nkwapa/api -- auth.controller.spec.ts`
- `npm run test --workspace=@nkwapa/web -- bootstrap-clinics.test.ts`
- `npm run test --workspaces --if-present`
- `npm run typecheck --workspaces --if-present`
- `npm run lint --workspaces --if-present`
- `npm run build --workspaces --if-present`
- `npm run security:scan`
