### PR TITLE
Auth bug/fix keycloak forgot password email reset flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,23 @@ KEYCLOAK_URL=http://localhost:8080
 KEYCLOAK_REALM=nkwapa
 KEYCLOAK_CLIENT_ID=nkwapa-web
 KEYCLOAK_CLIENT_SECRET=replace_me_if_confidential_client
+KC_BOOTSTRAP_ADMIN_USERNAME=admin
+KC_BOOTSTRAP_ADMIN_PASSWORD=admin
+
+# Keycloak SMTP for local password resets. docker-compose includes Mailpit:
+# SMTP host is mailpit from inside Docker; inbox UI is http://localhost:8025.
+KC_SMTP_HOST=mailpit
+KC_SMTP_PORT=1025
+KC_SMTP_FROM=no-reply@nkwapa.local
+KC_SMTP_FROM_DISPLAY_NAME=Nkwapa
+KC_SMTP_REPLY_TO=support@nkwapa.local
+KC_SMTP_REPLY_TO_DISPLAY_NAME=Nkwapa Support
+KC_SMTP_ENVELOPE_FROM=no-reply@nkwapa.local
+KC_SMTP_AUTH=false
+KC_SMTP_STARTTLS=false
+KC_SMTP_SSL=false
+KC_SMTP_USER=
+KC_SMTP_PASSWORD=
 
 # Seed (packages/db)
 SEED_ORGANIZATION_NAME=Nkwapa Health

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Prisma generate
         run: npm run db:generate
 
+      - name: Validate Keycloak realm
+        run: npm run keycloak:validate-realm
+
       - name: Build @nkwapa/db
         run: npm run build --workspace=@nkwapa/db
 
@@ -176,6 +179,12 @@ jobs:
       E2E_STAFF_PASSWORD: NkwapaE2E!23
       E2E_STAFF_NAME: E2E Staff
       E2E_STAFF_EMAIL: e2e.staff@nkwapa.local
+      E2E_RESET_SUB: 00000000-0000-4000-8000-000000000043
+      E2E_RESET_USERNAME: e2e.reset
+      E2E_RESET_PASSWORD: NkwapaReset!23
+      E2E_RESET_NAME: E2E Reset
+      E2E_RESET_EMAIL: e2e.reset@nkwapa.local
+      MAILPIT_BASE_URL: http://localhost:8025
       CORS_ALLOWED_ORIGINS: http://localhost:3000
       PLAYWRIGHT_BASE_URL: http://localhost:3000
     steps:
@@ -201,11 +210,11 @@ jobs:
         run: npm run build --workspace=@nkwapa/web
 
       - name: Start local infra
-        run: docker compose -f infra/nkwapa/docker-compose.yml up -d postgres redis keycloak
+        run: docker compose -f infra/nkwapa/docker-compose.yml up -d postgres redis mailpit keycloak
 
       - name: Wait for infra health
         run: |
-          for container in nkwapa-postgres nkwapa-redis nkwapa-keycloak; do
+          for container in nkwapa-postgres nkwapa-redis nkwapa-mailpit nkwapa-keycloak; do
             until [ "$(docker inspect -f '{{.State.Health.Status}}' "$container")" = "healthy" ]; do
               echo "Waiting for $container..."
               sleep 2

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -23,7 +23,7 @@ COPY apps/api/ ./apps/api/
 
 RUN npx prisma generate --schema=packages/db/prisma/schema.prisma
 RUN cd packages/db && npx tsc
-RUN cd apps/api && npx nest build
+RUN cd apps/api && npx tsc -p tsconfig.build.json
 
 # ── Stage 3: Production image ──
 FROM node:20-alpine AS runner

--- a/apps/web/e2e/auth.setup.js
+++ b/apps/web/e2e/auth.setup.js
@@ -17,7 +17,16 @@ setup('authenticate deterministic staff user', async ({ page }) => {
     .click();
   await page.waitForURL(/realms\/nkwapa/, { timeout: 20_000 });
 
-  await page.locator('input[name="username"]').fill(username);
+  const usernameField = page.locator('input[name="username"]');
+  const backToSignIn = page.getByRole('link', { name: /back to sign in/i });
+  if (!(await usernameField.isVisible({ timeout: 5_000 }).catch(() => false))) {
+    if (await backToSignIn.isVisible().catch(() => false)) {
+      await backToSignIn.click();
+    }
+  }
+
+  await expect(usernameField).toBeVisible({ timeout: 20_000 });
+  await usernameField.fill(username);
   await page.locator('input[name="password"]').fill(password);
   await page.locator('#kc-login, button[type="submit"]').click();
 

--- a/apps/web/e2e/forgot-password.spec.js
+++ b/apps/web/e2e/forgot-password.spec.js
@@ -1,0 +1,68 @@
+const { test, expect } = require('@playwright/test');
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+const mailpitBaseUrl = process.env.MAILPIT_BASE_URL || 'http://localhost:8025';
+const resetEmail = process.env.E2E_RESET_EMAIL || 'e2e.reset@nkwapa.local';
+
+async function mailpitFetch(path, options) {
+  const response = await fetch(`${mailpitBaseUrl}${path}`, options);
+  if (!response.ok) {
+    throw new Error(`Mailpit request failed (${response.status} ${response.statusText})`);
+  }
+  return response;
+}
+
+async function clearMailpitInbox() {
+  await mailpitFetch('/api/v1/messages', { method: 'DELETE' });
+}
+
+async function findResetMessage() {
+  const deadline = Date.now() + 30_000;
+
+  while (Date.now() < deadline) {
+    const response = await mailpitFetch('/api/v1/messages');
+    const payload = await response.json();
+    const messages = payload.messages || [];
+    const message = messages.find((candidate) =>
+      candidate.To?.some(
+        (recipient) =>
+          typeof recipient.Address === 'string' &&
+          recipient.Address.toLowerCase() === resetEmail.toLowerCase(),
+      ),
+    );
+
+    if (message) {
+      const detailResponse = await mailpitFetch(`/api/v1/message/${message.ID}`);
+      return detailResponse.json();
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+
+  throw new Error(`Timed out waiting for reset email to ${resetEmail}`);
+}
+
+test('forgot password sends a Keycloak reset email to Mailpit', async ({ page }) => {
+  await clearMailpitInbox();
+
+  await page.goto('/login?next=%2Fdashboard');
+  await page
+    .getByRole('button', { name: /continue to secure sign in|try secure sign in again/i })
+    .click();
+  await page.waitForURL(/realms\/nkwapa/, { timeout: 20_000 });
+
+  await expect(page.getByRole('link', { name: /forgot password/i })).toBeVisible();
+  await page.getByRole('link', { name: /forgot password/i }).click();
+
+  await expect(page.getByRole('heading', { name: /reset your password/i })).toBeVisible();
+  await page.locator('input[name="username"]').fill(resetEmail);
+  await page.locator('#kc-reset-password-form input[type="submit"], button[type="submit"]').click();
+
+  const message = await findResetMessage();
+  const messageText = `${message.Subject || ''}\n${message.Text || ''}\n${message.HTML || ''}`;
+
+  expect(messageText).toMatch(/reset|password|credential/i);
+  expect(messageText).toContain('/realms/nkwapa/login-actions/reset-credentials');
+  expect(messageText).toContain('key=');
+});

--- a/apps/web/e2e/forgot-password.spec.js
+++ b/apps/web/e2e/forgot-password.spec.js
@@ -63,6 +63,7 @@ test('forgot password sends a Keycloak reset email to Mailpit', async ({ page })
   const messageText = `${message.Subject || ''}\n${message.Text || ''}\n${message.HTML || ''}`;
 
   expect(messageText).toMatch(/reset|password|credential/i);
-  expect(messageText).toContain('/realms/nkwapa/login-actions/reset-credentials');
+  expect(messageText).toContain('/realms/nkwapa/login-actions/action-token');
+  expect(messageText).toContain('client_id=nkwapa-web');
   expect(messageText).toContain('key=');
 });

--- a/deploy/env/production.keycloak.env.example
+++ b/deploy/env/production.keycloak.env.example
@@ -15,5 +15,19 @@ KC_HTTP_ENABLED=true
 KC_PROXY_HEADERS=xforwarded
 KC_HOSTNAME=https://auth.nkwapa.app
 
-KEYCLOAK_ADMIN=<bootstrap-admin-username>
-KEYCLOAK_ADMIN_PASSWORD=<bootstrap-admin-password>
+KC_BOOTSTRAP_ADMIN_USERNAME=<bootstrap-admin-username>
+KC_BOOTSTRAP_ADMIN_PASSWORD=<bootstrap-admin-password>
+
+# Required for forgot password and email verification.
+KC_SMTP_HOST=<smtp-host>
+KC_SMTP_PORT=587
+KC_SMTP_FROM=no-reply@nkwapa.app
+KC_SMTP_FROM_DISPLAY_NAME=Nkwapa
+KC_SMTP_REPLY_TO=support@nkwapa.app
+KC_SMTP_REPLY_TO_DISPLAY_NAME=Nkwapa Support
+KC_SMTP_ENVELOPE_FROM=no-reply@nkwapa.app
+KC_SMTP_AUTH=true
+KC_SMTP_STARTTLS=true
+KC_SMTP_SSL=false
+KC_SMTP_USER=<smtp-username>
+KC_SMTP_PASSWORD=<smtp-password>

--- a/deploy/env/staging.keycloak.env.example
+++ b/deploy/env/staging.keycloak.env.example
@@ -15,5 +15,19 @@ KC_HTTP_ENABLED=true
 KC_PROXY_HEADERS=xforwarded
 KC_HOSTNAME=https://nkwapa-auth-staging.onrender.com
 
-KEYCLOAK_ADMIN=<bootstrap-admin-username>
-KEYCLOAK_ADMIN_PASSWORD=<bootstrap-admin-password>
+KC_BOOTSTRAP_ADMIN_USERNAME=<bootstrap-admin-username>
+KC_BOOTSTRAP_ADMIN_PASSWORD=<bootstrap-admin-password>
+
+# Required for forgot password and email verification.
+KC_SMTP_HOST=<smtp-host>
+KC_SMTP_PORT=587
+KC_SMTP_FROM=no-reply@staging.nkwapa.app
+KC_SMTP_FROM_DISPLAY_NAME=Nkwapa Staging
+KC_SMTP_REPLY_TO=support@staging.nkwapa.app
+KC_SMTP_REPLY_TO_DISPLAY_NAME=Nkwapa Support
+KC_SMTP_ENVELOPE_FROM=no-reply@staging.nkwapa.app
+KC_SMTP_AUTH=true
+KC_SMTP_STARTTLS=true
+KC_SMTP_SSL=false
+KC_SMTP_USER=<smtp-username>
+KC_SMTP_PASSWORD=<smtp-password>

--- a/docs/FEATURE_WORKFLOWS_GUIDE.md
+++ b/docs/FEATURE_WORKFLOWS_GUIDE.md
@@ -34,6 +34,23 @@ Important rules:
 - permissions and clinic memberships are stored in Nkwapa
 - a user usually needs to log in once before appearing in local admin tables
 
+### Forgot password
+
+1. The user opens the Keycloak Forgot Password link from the sign-in page.
+2. Keycloak asks for username or email and sends the reset email through the realm SMTP settings.
+3. The reset link opens the themed Keycloak update-password flow.
+4. After the password is changed, Keycloak forces a fresh login and returns the user through the
+   normal app redirect.
+
+Recovery behavior:
+
+- local development uses Mailpit at `http://localhost:8025`
+- staging and production require real `KC_SMTP_*` secrets on the Keycloak service
+- expired or invalid reset links show the branded recovery page with actions to request a new link
+  or return to sign in
+- admins should trigger password reset emails with Keycloak Admin REST `execute-actions-email` and
+  `["UPDATE_PASSWORD"]`
+
 ---
 
 ## 3. Staff Clinical Workflow

--- a/docs/USER_AND_ROLE_SETUP_GUIDE.md
+++ b/docs/USER_AND_ROLE_SETUP_GUIDE.md
@@ -215,7 +215,50 @@ Main surfaces:
 
 ---
 
-## 10. Key Reminders
+## 10. Password Reset And Recovery
+
+Forgot Password is owned by Keycloak. Nkwapa must not store raw passwords or expose an app/API
+password reset endpoint.
+
+Required Keycloak settings:
+
+- `resetPasswordAllowed: true`
+- a working realm SMTP `Host` and `From`
+- reset credentials flow set to `reset credentials`
+- the `reset-credential-email` authenticator present in that flow
+- the `UPDATE_PASSWORD` required action enabled
+
+Local QA:
+
+1. Start local infra with `docker compose -f infra/nkwapa/docker-compose.yml up -d`.
+2. Open the app sign-in path and use Forgot Password.
+3. Open Mailpit at `http://localhost:8025`.
+4. Follow the reset link, set a new password, and verify Keycloak returns the user to the app.
+
+Staging and production:
+
+- set the `KC_SMTP_*` variables from `deploy/env/*.keycloak.env.example`
+- use provider-backed SMTP credentials stored as deployment secrets
+- recreate or explicitly re-import the realm when changing realm import settings; Keycloak startup
+  import skips realms that already exist
+
+Admin-triggered password reset:
+
+Use Keycloak Admin REST `execute-actions-email` with `UPDATE_PASSWORD`:
+
+```bash
+PUT /admin/realms/nkwapa/users/<user-id>/execute-actions-email
+Content-Type: application/json
+
+["UPDATE_PASSWORD"]
+```
+
+Do not use the older `reset-password-email` endpoint. Direct admin password setting through
+`/reset-password` is only appropriate for deterministic test setup, not normal user recovery.
+
+---
+
+## 11. Key Reminders
 
 - Keycloak manages passwords, reset tokens, and session expiry.
 - Nkwapa manages permissions, memberships, and clinic scope.

--- a/infra/keycloak/Dockerfile
+++ b/infra/keycloak/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:25.0 AS builder
+FROM quay.io/keycloak/keycloak:26.6.2 AS builder
 
 ENV KC_DB=postgres
 ENV KC_HEALTH_ENABLED=true
@@ -11,7 +11,7 @@ COPY infra/nkwapa/keycloak/themes/nkwapa /opt/keycloak/themes/nkwapa
 
 RUN /opt/keycloak/bin/kc.sh build
 
-FROM quay.io/keycloak/keycloak:25.0
+FROM quay.io/keycloak/keycloak:26.6.2
 
 ENV KC_DB=postgres
 ENV KC_HEALTH_ENABLED=true

--- a/infra/nkwapa/docker-compose.yml
+++ b/infra/nkwapa/docker-compose.yml
@@ -31,14 +31,29 @@ services:
       retries: 20
 
   keycloak:
-    image: quay.io/keycloak/keycloak:25.0
+    image: quay.io/keycloak/keycloak:26.6.2
     container_name: nkwapa-keycloak
     command: ['start-dev', '--import-realm']
     environment:
-      KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN:-admin}
-      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-admin}
+      KC_BOOTSTRAP_ADMIN_USERNAME: ${KC_BOOTSTRAP_ADMIN_USERNAME:-${KEYCLOAK_ADMIN:-admin}}
+      KC_BOOTSTRAP_ADMIN_PASSWORD: ${KC_BOOTSTRAP_ADMIN_PASSWORD:-${KEYCLOAK_ADMIN_PASSWORD:-admin}}
+      KC_SMTP_HOST: ${KC_SMTP_HOST:-mailpit}
+      KC_SMTP_PORT: ${KC_SMTP_PORT:-1025}
+      KC_SMTP_FROM: ${KC_SMTP_FROM:-no-reply@nkwapa.local}
+      KC_SMTP_FROM_DISPLAY_NAME: ${KC_SMTP_FROM_DISPLAY_NAME:-Nkwapa}
+      KC_SMTP_REPLY_TO: ${KC_SMTP_REPLY_TO:-support@nkwapa.local}
+      KC_SMTP_REPLY_TO_DISPLAY_NAME: ${KC_SMTP_REPLY_TO_DISPLAY_NAME:-Nkwapa Support}
+      KC_SMTP_ENVELOPE_FROM: ${KC_SMTP_ENVELOPE_FROM:-no-reply@nkwapa.local}
+      KC_SMTP_AUTH: ${KC_SMTP_AUTH:-false}
+      KC_SMTP_STARTTLS: ${KC_SMTP_STARTTLS:-false}
+      KC_SMTP_SSL: ${KC_SMTP_SSL:-false}
+      KC_SMTP_USER: ${KC_SMTP_USER:-}
+      KC_SMTP_PASSWORD: ${KC_SMTP_PASSWORD:-}
     ports:
       - '8080:8080'
+    depends_on:
+      mailpit:
+        condition: service_started
     volumes:
       - ./keycloak/realm-export:/opt/keycloak/data/import:ro
       - ./keycloak/themes/nkwapa:/opt/keycloak/themes/nkwapa:ro
@@ -53,6 +68,18 @@ services:
       interval: 5s
       timeout: 3s
       retries: 30
+
+  mailpit:
+    image: axllent/mailpit:v1.20
+    container_name: nkwapa-mailpit
+    ports:
+      - '1025:1025'
+      - '8025:8025'
+    healthcheck:
+      test: ['CMD', 'wget', '--quiet', '--tries=1', '--spider', 'http://127.0.0.1:8025/api/v1/info']
+      interval: 5s
+      timeout: 3s
+      retries: 20
 
 volumes:
   pgdata:

--- a/infra/nkwapa/keycloak/realm-export/realm-nkwapa.json
+++ b/infra/nkwapa/keycloak/realm-export/realm-nkwapa.json
@@ -26,6 +26,112 @@
     "actionTokenGeneratedByUserLifespan.reset-credentials": "900",
     "actionTokenGeneratedByUserLifespan.verify-email": "86400"
   },
+  "smtpServer": {
+    "host": "${KC_SMTP_HOST}",
+    "port": "${KC_SMTP_PORT}",
+    "from": "${KC_SMTP_FROM}",
+    "fromDisplayName": "${KC_SMTP_FROM_DISPLAY_NAME}",
+    "replyTo": "${KC_SMTP_REPLY_TO}",
+    "replyToDisplayName": "${KC_SMTP_REPLY_TO_DISPLAY_NAME}",
+    "envelopeFrom": "${KC_SMTP_ENVELOPE_FROM}",
+    "auth": "${KC_SMTP_AUTH}",
+    "starttls": "${KC_SMTP_STARTTLS}",
+    "ssl": "${KC_SMTP_SSL}",
+    "user": "${KC_SMTP_USER}",
+    "password": "${KC_SMTP_PASSWORD}"
+  },
+  "resetCredentialsFlow": "reset credentials",
+  "authenticatorConfig": [
+    {
+      "alias": "nkwapa-reset-email-force-login",
+      "config": {
+        "force-login": "true"
+      }
+    }
+  ],
+  "authenticationFlows": [
+    {
+      "alias": "reset credentials",
+      "description": "Reset credentials for a user who forgot their password.",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "reset-credentials-choose-user",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-credential-email",
+          "authenticatorConfig": "nkwapa-reset-email-force-login",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 30,
+          "userSetupAllowed": false
+        },
+        {
+          "flowAlias": "Reset - Conditional OTP",
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 40,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "alias": "Reset - Conditional OTP",
+      "description": "Require OTP during credential reset when the user has OTP configured.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false
+        }
+      ]
+    }
+  ],
+  "requiredActions": [
+    {
+      "alias": "UPDATE_PASSWORD",
+      "name": "Update Password",
+      "providerId": "UPDATE_PASSWORD",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 30,
+      "config": {}
+    },
+    {
+      "alias": "VERIFY_EMAIL",
+      "name": "Verify Email",
+      "providerId": "VERIFY_EMAIL",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 50,
+      "config": {}
+    }
+  ],
   "defaultRoles": ["uma_authorization", "offline_access"],
   "roles": {
     "realm": [

--- a/infra/nkwapa/keycloak/themes/nkwapa/login/error.ftl
+++ b/infra/nkwapa/keycloak/themes/nkwapa/login/error.ftl
@@ -1,7 +1,7 @@
 <#import "template.ftl" as layout>
 <@layout.registrationLayout displayMessage=false; section>
     <#if section = "header">
-        something went wrong
+        recovery link needs attention
     <#elseif section = "form">
         <div class="alert-error" style="margin-bottom: 1.5rem;">
             <p style="font-family: 'Circular Std', 'Poppins', sans-serif; font-size: 0.875rem; color: #DC2626; margin: 0;">
@@ -11,11 +11,21 @@
 
         <#if skipLink??>
         <#else>
-            <#if client?? && client.baseUrl?has_content>
-                <div class="nkwapa-register-link">
-                    <a href="${client.baseUrl}">Back to application</a>
-                </div>
-            </#if>
+            <div class="nkwapa-action-stack">
+                <#if realm.resetPasswordAllowed && url.loginResetCredentialsUrl??>
+                    <a class="nkwapa-btn-primary nkwapa-btn-primary--link" href="${url.loginResetCredentialsUrl}">
+                        Request a new reset link
+                    </a>
+                </#if>
+                <a class="nkwapa-secondary-link" href="${url.loginUrl}">
+                    Back to sign in
+                </a>
+                <#if client?? && client.baseUrl?has_content>
+                    <a class="nkwapa-secondary-link" href="${client.baseUrl}">
+                        Back to application
+                    </a>
+                </#if>
+            </div>
         </#if>
     </#if>
 </@layout.registrationLayout>

--- a/infra/nkwapa/keycloak/themes/nkwapa/login/login-update-password.ftl
+++ b/infra/nkwapa/keycloak/themes/nkwapa/login/login-update-password.ftl
@@ -1,0 +1,47 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayMessage=!messagesPerField.existsError('password','password-confirm') displayRequiredFields=true; section>
+    <#if section = "header">
+        choose a new password
+    <#elseif section = "form">
+        <form id="kc-passwd-update-form" action="${url.loginAction}" method="post">
+            <div class="nkwapa-form-group">
+                <label for="password-new" class="nkwapa-label">${msg("passwordNew")}</label>
+                <input
+                    type="password"
+                    id="password-new"
+                    name="password-new"
+                    class="nkwapa-input"
+                    autocomplete="new-password"
+                    autofocus
+                    aria-invalid="<#if messagesPerField.existsError('password','password-confirm')>true</#if>"
+                />
+                <#if messagesPerField.existsError('password')>
+                    <span class="nkwapa-error" aria-live="polite">${kcSanitize(messagesPerField.getFirstError('password'))?no_esc}</span>
+                </#if>
+            </div>
+
+            <div class="nkwapa-form-group">
+                <label for="password-confirm" class="nkwapa-label">${msg("passwordConfirm")}</label>
+                <input
+                    type="password"
+                    id="password-confirm"
+                    name="password-confirm"
+                    class="nkwapa-input"
+                    autocomplete="new-password"
+                    aria-invalid="<#if messagesPerField.existsError('password','password-confirm')>true</#if>"
+                />
+                <#if messagesPerField.existsError('password-confirm')>
+                    <span class="nkwapa-error" aria-live="polite">${kcSanitize(messagesPerField.getFirstError('password-confirm'))?no_esc}</span>
+                </#if>
+            </div>
+
+            <p class="nkwapa-password-requirements">
+                Use at least 12 characters with uppercase and lowercase letters, a number, and a symbol.
+            </p>
+
+            <div class="nkwapa-form-group nkwapa-submit-group">
+                <input class="nkwapa-btn-primary" type="submit" value="${msg("doSubmit")}"/>
+            </div>
+        </form>
+    </#if>
+</@layout.registrationLayout>

--- a/infra/nkwapa/keycloak/themes/nkwapa/login/resources/css/styles.css
+++ b/infra/nkwapa/keycloak/themes/nkwapa/login/resources/css/styles.css
@@ -376,6 +376,13 @@ body.nkwapa-auth-body {
     filter 0.2s ease;
 }
 
+.nkwapa-btn-primary--link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+}
+
 .nkwapa-btn-primary:hover {
   filter: brightness(1.03);
   transform: translateY(-1px);
@@ -394,6 +401,33 @@ body.nkwapa-auth-body {
   color: var(--nkwapa-danger);
   font-size: 0.84rem;
   line-height: 1.45;
+}
+
+.nkwapa-password-requirements {
+  margin: -4px 0 20px;
+  color: var(--nkwapa-muted);
+  font-size: 0.85rem;
+  line-height: 1.55;
+}
+
+.nkwapa-action-stack {
+  display: grid;
+  gap: 12px;
+}
+
+.nkwapa-secondary-link {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  justify-content: center;
+  color: var(--nkwapa-primary);
+  font-size: 0.92rem;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.nkwapa-secondary-link:hover {
+  text-decoration: underline;
 }
 
 .nkwapa-auth-info {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "db:migrate:deploy": "prisma migrate deploy --schema=packages/db/prisma/schema.prisma",
     "db:seed": "ts-node --transpile-only packages/db/prisma/seed.ts",
     "db:assign-system-admin": "ts-node --transpile-only packages/db/prisma/assign-system-admin.ts",
+    "keycloak:validate-realm": "node scripts/validate-keycloak-realm.mjs",
     "security:scan": "node scripts/check-secrets.mjs",
     "security:scan:staged": "node scripts/check-secrets.mjs --staged",
     "lint": "npm run lint --workspaces --if-present",

--- a/scripts/create-keycloak-e2e-user.mjs
+++ b/scripts/create-keycloak-e2e-user.mjs
@@ -12,12 +12,20 @@ const adminUsername =
 const adminPassword =
   process.env.KC_BOOTSTRAP_ADMIN_PASSWORD || process.env.KEYCLOAK_ADMIN_PASSWORD || 'admin';
 
-const e2eUser = {
+const staffUser = {
   id: process.env.E2E_STAFF_SUB || '00000000-0000-4000-8000-000000000042',
   username: process.env.E2E_STAFF_USERNAME || 'e2e.staff',
   password: process.env.E2E_STAFF_PASSWORD || 'NkwapaE2E!23',
   email: process.env.E2E_STAFF_EMAIL || 'e2e.staff@nkwapa.local',
   displayName: process.env.E2E_STAFF_NAME || 'E2E Staff',
+};
+
+const resetUser = {
+  id: process.env.E2E_RESET_SUB || '00000000-0000-4000-8000-000000000043',
+  username: process.env.E2E_RESET_USERNAME || 'e2e.reset',
+  password: process.env.E2E_RESET_PASSWORD || 'NkwapaReset!23',
+  email: process.env.E2E_RESET_EMAIL || 'e2e.reset@nkwapa.local',
+  displayName: process.env.E2E_RESET_NAME || 'E2E Reset',
 };
 
 function splitName(displayName) {
@@ -135,26 +143,27 @@ async function findUserByEmail(accessToken, email) {
   );
 }
 
-async function upsertUser(accessToken) {
-  const existingById = await getUserById(accessToken, e2eUser.id);
+async function upsertUser(accessToken, user) {
+  const existingById = await getUserById(accessToken, user.id);
   const existingByUsername = existingById
     ? null
-    : await findUserByUsername(accessToken, e2eUser.username);
+    : await findUserByUsername(accessToken, user.username);
   const existingByEmail =
-    existingById || existingByUsername ? null : await findUserByEmail(accessToken, e2eUser.email);
-  const targetId = existingById?.id ?? existingByUsername?.id ?? existingByEmail?.id ?? e2eUser.id;
-  const { firstName, lastName } = splitName(e2eUser.displayName);
+    existingById || existingByUsername ? null : await findUserByEmail(accessToken, user.email);
+  const existingUser = existingById ?? existingByUsername ?? existingByEmail;
+  const targetId = existingUser?.id ?? user.id;
+  const { firstName, lastName } = splitName(user.displayName);
   const payload = {
     id: targetId,
-    username: e2eUser.username,
+    username: user.username,
     enabled: true,
     emailVerified: true,
-    email: e2eUser.email,
+    email: user.email,
     firstName,
     lastName,
   };
 
-  if (existingById) {
+  if (existingUser) {
     const response = await fetch(`${keycloakBaseUrl}/admin/realms/${realm}/users/${targetId}`, {
       method: 'PUT',
       headers: {
@@ -179,11 +188,11 @@ async function upsertUser(accessToken) {
   }
 
   const persistedUser =
-    (await findUserByUsername(accessToken, e2eUser.username)) ??
-    (await findUserByEmail(accessToken, e2eUser.email));
+    (await findUserByUsername(accessToken, user.username)) ??
+    (await findUserByEmail(accessToken, user.email));
   if (!persistedUser?.id) {
     throw new Error(
-      `Keycloak created "${e2eUser.username}" but it could not be looked up afterwards.`,
+      `Keycloak created "${user.username}" but it could not be looked up afterwards.`,
     );
   }
 
@@ -197,7 +206,7 @@ async function upsertUser(accessToken) {
       },
       body: JSON.stringify({
         type: 'password',
-        value: e2eUser.password,
+        value: user.password,
         temporary: false,
       }),
     },
@@ -230,19 +239,30 @@ async function appendGithubOutput(name, value) {
 
 async function main() {
   const accessToken = await getAdminAccessToken();
-  const userId = await upsertUser(accessToken);
-  await appendGithubEnv('E2E_STAFF_SUB', userId);
-  await appendGithubOutput('user-id', userId);
+  const staffUserId = await upsertUser(accessToken, staffUser);
+  const resetUserId = await upsertUser(accessToken, resetUser);
+  await appendGithubEnv('E2E_STAFF_SUB', staffUserId);
+  await appendGithubEnv('E2E_RESET_SUB', resetUserId);
+  await appendGithubOutput('staff-user-id', staffUserId);
+  await appendGithubOutput('reset-user-id', resetUserId);
 
   console.log(
     JSON.stringify(
       {
         realm,
         keycloakBaseUrl,
-        requestedUserId: e2eUser.id,
-        userId,
-        username: e2eUser.username,
-        email: e2eUser.email,
+        staff: {
+          requestedUserId: staffUser.id,
+          userId: staffUserId,
+          username: staffUser.username,
+          email: staffUser.email,
+        },
+        reset: {
+          requestedUserId: resetUser.id,
+          userId: resetUserId,
+          username: resetUser.username,
+          email: resetUser.email,
+        },
       },
       null,
       2,

--- a/scripts/create-keycloak-e2e-user.mjs
+++ b/scripts/create-keycloak-e2e-user.mjs
@@ -7,8 +7,10 @@ const keycloakBaseUrl = (
   'http://localhost:8080'
 ).replace(/\/$/, '');
 const realm = process.env.KEYCLOAK_REALM || process.env.NEXT_PUBLIC_KEYCLOAK_REALM || 'nkwapa';
-const adminUsername = process.env.KEYCLOAK_ADMIN || 'admin';
-const adminPassword = process.env.KEYCLOAK_ADMIN_PASSWORD || 'admin';
+const adminUsername =
+  process.env.KC_BOOTSTRAP_ADMIN_USERNAME || process.env.KEYCLOAK_ADMIN || 'admin';
+const adminPassword =
+  process.env.KC_BOOTSTRAP_ADMIN_PASSWORD || process.env.KEYCLOAK_ADMIN_PASSWORD || 'admin';
 
 const e2eUser = {
   id: process.env.E2E_STAFF_SUB || '00000000-0000-4000-8000-000000000042',

--- a/scripts/validate-keycloak-realm.mjs
+++ b/scripts/validate-keycloak-realm.mjs
@@ -1,0 +1,123 @@
+import { readFile } from 'node:fs/promises';
+
+const realmPath = new URL(
+  '../infra/nkwapa/keycloak/realm-export/realm-nkwapa.json',
+  import.meta.url,
+);
+const realm = JSON.parse(await readFile(realmPath, 'utf8'));
+const failures = [];
+
+function assert(condition, message) {
+  if (!condition) {
+    failures.push(message);
+  }
+}
+
+function findFlow(alias) {
+  return realm.authenticationFlows?.find((flow) => flow.alias === alias);
+}
+
+function findExecution(flow, authenticator) {
+  return flow?.authenticationExecutions?.find(
+    (execution) => execution.authenticator === authenticator,
+  );
+}
+
+function assertSmtpPlaceholder(key, envName) {
+  assert(
+    realm.smtpServer?.[key] === `\${${envName}}`,
+    `smtpServer.${key} must use the ${envName} placeholder`,
+  );
+}
+
+assert(realm.realm === 'nkwapa', 'realm must be nkwapa');
+assert(realm.loginTheme === 'nkwapa', 'loginTheme must be nkwapa');
+assert(realm.resetPasswordAllowed === true, 'resetPasswordAllowed must be true');
+assert(realm.verifyEmail === true, 'verifyEmail must be true');
+
+assertSmtpPlaceholder('host', 'KC_SMTP_HOST');
+assertSmtpPlaceholder('port', 'KC_SMTP_PORT');
+assertSmtpPlaceholder('from', 'KC_SMTP_FROM');
+assertSmtpPlaceholder('fromDisplayName', 'KC_SMTP_FROM_DISPLAY_NAME');
+assertSmtpPlaceholder('replyTo', 'KC_SMTP_REPLY_TO');
+assertSmtpPlaceholder('replyToDisplayName', 'KC_SMTP_REPLY_TO_DISPLAY_NAME');
+assertSmtpPlaceholder('envelopeFrom', 'KC_SMTP_ENVELOPE_FROM');
+assertSmtpPlaceholder('auth', 'KC_SMTP_AUTH');
+assertSmtpPlaceholder('starttls', 'KC_SMTP_STARTTLS');
+assertSmtpPlaceholder('ssl', 'KC_SMTP_SSL');
+assertSmtpPlaceholder('user', 'KC_SMTP_USER');
+assertSmtpPlaceholder('password', 'KC_SMTP_PASSWORD');
+
+assert(
+  realm.resetCredentialsFlow === 'reset credentials',
+  'resetCredentialsFlow must use the reset credentials flow',
+);
+
+const resetFlow = findFlow('reset credentials');
+assert(Boolean(resetFlow), 'reset credentials flow must be exported');
+assert(
+  findExecution(resetFlow, 'reset-credentials-choose-user')?.requirement === 'REQUIRED',
+  'reset credentials flow must choose the user',
+);
+
+const resetEmailExecution = findExecution(resetFlow, 'reset-credential-email');
+assert(
+  resetEmailExecution?.requirement === 'REQUIRED',
+  'reset credentials flow must send reset email',
+);
+assert(
+  resetEmailExecution?.authenticatorConfig === 'nkwapa-reset-email-force-login',
+  'reset email execution must use the force-login config',
+);
+assert(
+  findExecution(resetFlow, 'reset-password')?.requirement === 'REQUIRED',
+  'reset credentials flow must include reset-password',
+);
+assert(
+  resetFlow?.authenticationExecutions?.some(
+    (execution) =>
+      execution.flowAlias === 'Reset - Conditional OTP' &&
+      execution.authenticatorFlow === true &&
+      execution.requirement === 'CONDITIONAL',
+  ),
+  'reset credentials flow must include conditional OTP subflow',
+);
+
+const forceLoginConfig = realm.authenticatorConfig?.find(
+  (config) => config.alias === 'nkwapa-reset-email-force-login',
+);
+assert(
+  forceLoginConfig?.config?.['force-login'] === 'true',
+  'reset-credential-email force-login must be true',
+);
+
+const updatePasswordAction = realm.requiredActions?.find(
+  (action) => action.alias === 'UPDATE_PASSWORD',
+);
+assert(updatePasswordAction?.enabled === true, 'UPDATE_PASSWORD required action must be enabled');
+
+const client = realm.clients?.find((candidate) => candidate.clientId === 'nkwapa-web');
+assert(Boolean(client), 'nkwapa-web client must be present');
+for (const redirectUri of [
+  'http://localhost:3000',
+  'http://localhost:3000/*',
+  'https://staging.nkwapa.app',
+  'https://staging.nkwapa.app/*',
+  'https://app.nkwapa.app',
+  'https://app.nkwapa.app/*',
+]) {
+  assert(
+    client?.redirectUris?.includes(redirectUri),
+    `nkwapa-web redirectUris must include ${redirectUri}`,
+  );
+}
+
+if (failures.length > 0) {
+  console.error('Keycloak realm validation failed:');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('Keycloak realm validation passed.');


### PR DESCRIPTION
## Summary
- Upgraded local and deployable Keycloak images to 26.6.2 and added Mailpit for local reset-email QA.
- Configured the Nkwapa realm export with SMTP env placeholders, explicit reset credentials flow, reset email force-login behavior, and enabled UPDATE_PASSWORD.
- Added branded Keycloak update-password and recovery screens for reset links.
- Added validation and e2e coverage for forgot-password email delivery through Mailpit.
- Documented local, staging, production, and admin-triggered password reset operations.

## Testing
- npm run keycloak:validate-realm
- npm run format:check
- npm run lint
- npm run typecheck
- npm run test
- npm run build
- npm run security:scan
- npm run e2e --workspace=@nkwapa/web