### PR TITLE
Enhance/auth and patient data validate email addresses beyond syntax

### DIFF
--- a/apps/api/src/auth/jwt.strategy.spec.ts
+++ b/apps/api/src/auth/jwt.strategy.spec.ts
@@ -1,0 +1,51 @@
+import { JwtStrategy } from './jwt.strategy';
+
+describe('JwtStrategy', () => {
+  it('passes verified Keycloak emails into local user sync', async () => {
+    const userService = {
+      findOrCreateByKeycloakSub: jest.fn().mockResolvedValue({ user: {}, roles: [] }),
+    };
+    const strategy = new JwtStrategy(userService as never);
+
+    await strategy.validate({
+      sub: 'kc-sub-1',
+      preferred_username: 'ama',
+      email: 'ama@example.com',
+      email_verified: true,
+      given_name: 'Ama',
+      family_name: 'Mensah',
+      phone_number: '+233240000000',
+    });
+
+    expect(userService.findOrCreateByKeycloakSub).toHaveBeenCalledWith(
+      'kc-sub-1',
+      'ama',
+      'ama@example.com',
+      'Ama',
+      'Mensah',
+      '+233240000000',
+    );
+  });
+
+  it('does not pass unverified Keycloak emails into local user sync', async () => {
+    const userService = {
+      findOrCreateByKeycloakSub: jest.fn().mockResolvedValue({ user: {}, roles: [] }),
+    };
+    const strategy = new JwtStrategy(userService as never);
+
+    await strategy.validate({
+      sub: 'kc-sub-1',
+      email: 'unverified@example.com',
+      email_verified: false,
+    });
+
+    expect(userService.findOrCreateByKeycloakSub).toHaveBeenCalledWith(
+      'kc-sub-1',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    );
+  });
+});

--- a/apps/api/src/auth/jwt.strategy.ts
+++ b/apps/api/src/auth/jwt.strategy.ts
@@ -10,6 +10,7 @@ export interface JwtPayload {
   given_name?: string;
   family_name?: string;
   email?: string;
+  email_verified?: boolean;
   phone_number?: string;
   realm_access?: { roles?: string[] };
   resource_access?: Record<string, { roles?: string[] }>;
@@ -43,7 +44,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     return this.userService.findOrCreateByKeycloakSub(
       payload.sub,
       payload.preferred_username ?? undefined,
-      payload.email ?? undefined,
+      payload.email_verified === true ? (payload.email ?? undefined) : undefined,
       payload.given_name ?? undefined,
       payload.family_name ?? undefined,
       payload.phone_number ?? undefined,

--- a/apps/api/src/common/email-policy.spec.ts
+++ b/apps/api/src/common/email-policy.spec.ts
@@ -1,0 +1,106 @@
+import { plainToInstance } from 'class-transformer';
+import { IsEmail, validate } from 'class-validator';
+import type { MxRecord } from 'dns';
+import { ToNormalizedEmail, normalizeEmailInput } from './validation';
+import {
+  classifyEmailDomain,
+  EmailDeliverabilityService,
+  IsAllowedEmailDomain,
+} from './email-policy';
+
+class EmailDto {
+  @ToNormalizedEmail()
+  @IsEmail()
+  @IsAllowedEmailDomain()
+  email!: string;
+}
+
+class TestEmailDeliverabilityService extends EmailDeliverabilityService {
+  readonly queriedDomains: string[] = [];
+
+  constructor(private readonly result: MxRecord[] | Error) {
+    super();
+  }
+
+  protected override async resolveMxRecords(domain: string) {
+    this.queriedDomains.push(domain);
+    if (this.result instanceof Error) {
+      throw this.result;
+    }
+    return this.result;
+  }
+}
+
+describe('email policy', () => {
+  it('normalizes email input by trimming and lowercasing', () => {
+    expect(normalizeEmailInput('  Ama.Patient@Example.ORG  ')).toBe('ama.patient@example.org');
+  });
+
+  it('accepts normal email domains through DTO validation', async () => {
+    const dto = plainToInstance(EmailDto, { email: ' Ama.Patient@Nkwapa.Health ' });
+
+    const errors = await validate(dto);
+
+    expect(dto.email).toBe('ama.patient@nkwapa.health');
+    expect(errors).toHaveLength(0);
+  });
+
+  it.each([
+    ['malformed', 'not-an-email'],
+    ['reserved exact', 'patient@example.com'],
+    ['reserved suffix', 'patient@clinic.test'],
+    ['localhost', 'patient@localhost'],
+    ['localhost suffix', 'patient@mail.localhost'],
+    ['ip literal', 'patient@[192.0.2.1]'],
+    ['disposable', 'patient@mailinator.com'],
+  ])('rejects %s email domains through DTO validation', async (_label, email) => {
+    const dto = plainToInstance(EmailDto, { email });
+
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.property).toBe('email');
+  });
+
+  it.each([
+    ['patient@clinic.example', 'reserved-domain'],
+    ['patient@[2001:db8::1]', 'ip-literal'],
+    ['patient@yopmail.com', 'disposable-domain'],
+  ] as const)('classifies %s as %s', (email, reason) => {
+    expect(classifyEmailDomain(email)).toMatchObject({ allowed: false, reason });
+  });
+});
+
+describe('EmailDeliverabilityService', () => {
+  it('accepts a domain with MX records', async () => {
+    const service = new TestEmailDeliverabilityService([
+      { exchange: 'mx.nkwapa.health', priority: 10 },
+    ]);
+
+    await expect(
+      service.assertDomainAcceptsEmail('patient@nkwapa.health'),
+    ).resolves.toBeUndefined();
+
+    expect(service.queriedDomains).toEqual(['nkwapa.health']);
+  });
+
+  it('rejects a domain with no MX records', async () => {
+    const service = new TestEmailDeliverabilityService([]);
+
+    await expect(service.assertDomainAcceptsEmail('patient@nkwapa.health')).rejects.toMatchObject({
+      response: expect.objectContaining({
+        fieldErrors: [{ field: 'email', message: 'email domain does not accept email' }],
+      }),
+    });
+  });
+
+  it('rejects DNS lookup failures in fail-closed mode', async () => {
+    const service = new TestEmailDeliverabilityService(new Error('resolver unavailable'));
+
+    await expect(service.assertDomainAcceptsEmail('patient@nkwapa.health')).rejects.toMatchObject({
+      response: expect.objectContaining({
+        fieldErrors: [{ field: 'email', message: 'email domain could not be verified' }],
+      }),
+    });
+  });
+});

--- a/apps/api/src/common/email-policy.ts
+++ b/apps/api/src/common/email-policy.ts
@@ -1,0 +1,137 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import {
+  registerDecorator,
+  type ValidationArguments,
+  type ValidationOptions,
+} from 'class-validator';
+import { resolveMx } from 'dns/promises';
+import { isIP } from 'net';
+
+const DISALLOWED_EXACT_DOMAINS = new Set([
+  'localhost',
+  'example.com',
+  'example.net',
+  'example.org',
+  'mailinator.com',
+  '10minutemail.com',
+  'guerrillamail.com',
+  'tempmail.com',
+  'yopmail.com',
+]);
+
+const DISALLOWED_DOMAIN_SUFFIXES = ['.localhost', '.test', '.invalid', '.example'];
+
+export interface EmailDomainPolicyResult {
+  allowed: boolean;
+  domain: string | null;
+  reason?: 'missing-domain' | 'reserved-domain' | 'ip-literal' | 'disposable-domain';
+}
+
+export function getEmailDomain(email: string): string | null {
+  const atIndex = email.lastIndexOf('@');
+  if (atIndex < 0 || atIndex === email.length - 1) {
+    return null;
+  }
+
+  return email
+    .slice(atIndex + 1)
+    .trim()
+    .toLowerCase();
+}
+
+export function classifyEmailDomain(email: string): EmailDomainPolicyResult {
+  const domain = getEmailDomain(email);
+  if (!domain) {
+    return { allowed: false, domain: null, reason: 'missing-domain' };
+  }
+
+  const unwrappedDomain =
+    domain.startsWith('[') && domain.endsWith(']') ? domain.slice(1, -1) : domain;
+
+  if (isIP(unwrappedDomain)) {
+    return { allowed: false, domain, reason: 'ip-literal' };
+  }
+
+  if (DISALLOWED_EXACT_DOMAINS.has(domain)) {
+    const reason =
+      domain.includes('mailinator') ||
+      domain.includes('10minutemail') ||
+      domain.includes('guerrillamail') ||
+      domain.includes('tempmail') ||
+      domain.includes('yopmail')
+        ? 'disposable-domain'
+        : 'reserved-domain';
+    return { allowed: false, domain, reason };
+  }
+
+  if (DISALLOWED_DOMAIN_SUFFIXES.some((suffix) => domain.endsWith(suffix))) {
+    return { allowed: false, domain, reason: 'reserved-domain' };
+  }
+
+  return { allowed: true, domain };
+}
+
+export function IsAllowedEmailDomain(validationOptions?: ValidationOptions) {
+  return (object: object, propertyName: string) => {
+    registerDecorator({
+      name: 'isAllowedEmailDomain',
+      target: object.constructor,
+      propertyName,
+      options: {
+        message: `${propertyName} uses an email domain that is not allowed`,
+        ...validationOptions,
+      },
+      validator: {
+        validate(value: unknown) {
+          if (value === undefined || value === null || value === '') {
+            return true;
+          }
+          if (typeof value !== 'string') {
+            return false;
+          }
+
+          return classifyEmailDomain(value).allowed;
+        },
+        defaultMessage(args: ValidationArguments) {
+          return `${args.property} uses an email domain that is not allowed`;
+        },
+      },
+    });
+  };
+}
+
+@Injectable()
+export class EmailDeliverabilityService {
+  protected resolveMxRecords(domain: string) {
+    return resolveMx(domain);
+  }
+
+  async assertDomainAcceptsEmail(email: string, field = 'email') {
+    const policy = classifyEmailDomain(email);
+    if (!policy.allowed || !policy.domain) {
+      throw this.validationError(field, `${field} uses an email domain that is not allowed`);
+    }
+
+    try {
+      const records = await this.resolveMxRecords(policy.domain);
+      if (records.length === 0) {
+        throw this.validationError(field, `${field} domain does not accept email`);
+      }
+    } catch (error) {
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
+
+      throw this.validationError(field, `${field} domain could not be verified`);
+    }
+  }
+
+  private validationError(field: string, message: string) {
+    return new BadRequestException({
+      code: 'VALIDATION_ERROR',
+      message: 'Request validation failed.',
+      fieldErrors: [{ field, message }],
+      recoveryAction: 'Use an email address with a domain that can receive mail.',
+    });
+  }
+}

--- a/apps/api/src/patient-portal/dto/portal-invite.dto.spec.ts
+++ b/apps/api/src/patient-portal/dto/portal-invite.dto.spec.ts
@@ -1,0 +1,31 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { CreatePatientPortalInviteDto } from './portal-invite.dto';
+
+describe('CreatePatientPortalInviteDto', () => {
+  it('normalizes and accepts a normal invite email', async () => {
+    const dto = plainToInstance(CreatePatientPortalInviteDto, {
+      email: '  Ama.Patient@Nkwapa.Health  ',
+    });
+
+    const errors = await validate(dto);
+
+    expect(dto.email).toBe('ama.patient@nkwapa.health');
+    expect(errors).toHaveLength(0);
+  });
+
+  it.each([
+    ['malformed email', 'not-an-email'],
+    ['reserved domain', 'patient@example.com'],
+    ['localhost domain', 'patient@mail.localhost'],
+    ['ip-literal domain', 'patient@[192.0.2.1]'],
+    ['disposable domain', 'patient@mailinator.com'],
+  ])('rejects %s', async (_label, email) => {
+    const dto = plainToInstance(CreatePatientPortalInviteDto, { email });
+
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.property).toBe('email');
+  });
+});

--- a/apps/api/src/patient-portal/dto/portal-invite.dto.ts
+++ b/apps/api/src/patient-portal/dto/portal-invite.dto.ts
@@ -1,10 +1,12 @@
 import { IsDateString, IsEmail, IsOptional, IsString, MaxLength } from 'class-validator';
+import { IsAllowedEmailDomain } from '../../common/email-policy';
 import { ToNormalizedEmail, ToSanitizedString } from '../../common/validation';
 
 export class CreatePatientPortalInviteDto {
   @IsOptional()
   @ToNormalizedEmail()
   @IsEmail()
+  @IsAllowedEmailDomain()
   @MaxLength(320)
   email?: string;
 

--- a/apps/api/src/patient-portal/patient-portal.module.ts
+++ b/apps/api/src/patient-portal/patient-portal.module.ts
@@ -3,6 +3,7 @@ import { PrismaModule } from '../prisma/prisma.module';
 import { AuthModule } from '../auth/auth.module';
 import { AuditModule } from '../audit/audit.module';
 import { ReminderModule } from '../reminders/reminder.module';
+import { EmailDeliverabilityService } from '../common/email-policy';
 import { PatientPortalController } from './patient-portal.controller';
 import { PatientApiController } from './patient-api.controller';
 import { ClinicAppointmentRequestsController } from './clinic-appointment-requests.controller';
@@ -17,7 +18,7 @@ import { PatientPortalService } from './patient-portal.service';
     ClinicAppointmentRequestsController,
     PatientClaimController,
   ],
-  providers: [PatientPortalService],
+  providers: [EmailDeliverabilityService, PatientPortalService],
   exports: [PatientPortalService],
 })
 export class PatientPortalModule {}

--- a/apps/api/src/patient-portal/patient-portal.service.spec.ts
+++ b/apps/api/src/patient-portal/patient-portal.service.spec.ts
@@ -4,6 +4,7 @@ import { PATIENT_PORTAL_LINK_MISSING, PatientPortalService } from './patient-por
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
 import { ReminderService } from '../reminders/reminder.service';
+import { EmailDeliverabilityService } from '../common/email-policy';
 
 function createPrismaMock() {
   const prisma = {
@@ -91,6 +92,7 @@ describe('PatientPortalService', () => {
   let service: PatientPortalService;
   let prisma: ReturnType<typeof createPrismaMock>;
   let auditService: { logWrite: jest.Mock };
+  let emailDeliverabilityService: { assertDomainAcceptsEmail: jest.Mock };
   let reminderService: {
     scheduleAppointmentReminder: jest.Mock;
     scheduleAppointmentEmailReminder: jest.Mock;
@@ -100,6 +102,9 @@ describe('PatientPortalService', () => {
   beforeEach(async () => {
     prisma = createPrismaMock();
     auditService = { logWrite: jest.fn().mockResolvedValue(undefined) };
+    emailDeliverabilityService = {
+      assertDomainAcceptsEmail: jest.fn().mockResolvedValue(undefined),
+    };
     reminderService = {
       scheduleAppointmentReminder: jest.fn().mockResolvedValue(undefined),
       scheduleAppointmentEmailReminder: jest.fn().mockResolvedValue(undefined),
@@ -154,6 +159,7 @@ describe('PatientPortalService', () => {
         { provide: PrismaService, useValue: prisma },
         { provide: AuditService, useValue: auditService },
         { provide: ReminderService, useValue: reminderService },
+        { provide: EmailDeliverabilityService, useValue: emailDeliverabilityService },
       ],
     }).compile();
 
@@ -546,12 +552,106 @@ describe('PatientPortalService', () => {
         }),
       }),
     );
+    expect(emailDeliverabilityService.assertDomainAcceptsEmail).toHaveBeenCalledWith(
+      'ama@example.com',
+    );
     expect(prisma.patientPortalInvite.create).toHaveBeenCalled();
     expect(result).toMatchObject({
       patientId: 'patient-1',
       clinicId: 'clinic-1',
       status: 'PENDING',
       email: 'ama@example.com',
+    });
+  });
+
+  it('rejects portal invite email domains that fail MX deliverability checks', async () => {
+    prisma.patient.findFirst.mockResolvedValue({
+      id: 'patient-1',
+      portalUserId: null,
+    });
+    emailDeliverabilityService.assertDomainAcceptsEmail.mockRejectedValueOnce(
+      new BadRequestException({
+        code: 'VALIDATION_ERROR',
+        message: 'Request validation failed.',
+        fieldErrors: [{ field: 'email', message: 'email domain does not accept email' }],
+      }),
+    );
+
+    await expect(
+      service.createPortalInvite(
+        'clinic-1',
+        'patient-1',
+        {
+          email: 'ama@no-mx.testmail',
+        },
+        'manager-1',
+        'req-portal-invite',
+      ),
+    ).rejects.toMatchObject({
+      response: expect.objectContaining({
+        fieldErrors: [{ field: 'email', message: 'email domain does not accept email' }],
+      }),
+    });
+
+    expect(prisma.patientPortalInvite.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects portal invite email domains when DNS verification fails', async () => {
+    prisma.patient.findFirst.mockResolvedValue({
+      id: 'patient-1',
+      portalUserId: null,
+    });
+    emailDeliverabilityService.assertDomainAcceptsEmail.mockRejectedValueOnce(
+      new BadRequestException({
+        code: 'VALIDATION_ERROR',
+        message: 'Request validation failed.',
+        fieldErrors: [{ field: 'email', message: 'email domain could not be verified' }],
+      }),
+    );
+
+    await expect(
+      service.createPortalInvite(
+        'clinic-1',
+        'patient-1',
+        {
+          email: 'ama@dns-failure.testmail',
+        },
+        'manager-1',
+        'req-portal-invite',
+      ),
+    ).rejects.toMatchObject({
+      response: expect.objectContaining({
+        fieldErrors: [{ field: 'email', message: 'email domain could not be verified' }],
+      }),
+    });
+
+    expect(prisma.patientPortalInvite.create).not.toHaveBeenCalled();
+  });
+
+  it('does not run email deliverability checks for phone-only portal invites', async () => {
+    prisma.patient.findFirst.mockResolvedValue({
+      id: 'patient-1',
+      portalUserId: null,
+    });
+    prisma.patientAccountLink.findUnique.mockResolvedValue(null);
+
+    const result = await service.createPortalInvite(
+      'clinic-1',
+      'patient-1',
+      {
+        phoneE164: '+233240000000',
+      },
+      'manager-1',
+      'req-portal-invite',
+    );
+
+    expect(emailDeliverabilityService.assertDomainAcceptsEmail).not.toHaveBeenCalled();
+    expect(prisma.patientPortalInvite.create).toHaveBeenCalled();
+    expect(result).toMatchObject({
+      patientId: 'patient-1',
+      clinicId: 'clinic-1',
+      status: 'PENDING',
+      phoneE164: '+233240000000',
     });
   });
 

--- a/apps/api/src/patient-portal/patient-portal.service.ts
+++ b/apps/api/src/patient-portal/patient-portal.service.ts
@@ -19,6 +19,7 @@ import {
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
 import { ReminderService } from '../reminders/reminder.service';
+import { EmailDeliverabilityService } from '../common/email-policy';
 import type { CreateSelfReportDto } from './dto/create-self-report.dto';
 import type {
   CreatePatientMeasurementDto,
@@ -111,6 +112,7 @@ export class PatientPortalService {
     private readonly prisma: PrismaService,
     private readonly auditService: AuditService,
     private readonly reminderService: ReminderService,
+    private readonly emailDeliverabilityService: EmailDeliverabilityService,
   ) {}
 
   async getMe(clinicId: string, userId: string) {
@@ -810,6 +812,9 @@ export class PatientPortalService {
 
     if (!email && !phoneE164) {
       throw new BadRequestException('Provide an email or phone number to create a portal invite');
+    }
+    if (email) {
+      await this.emailDeliverabilityService.assertDomainAcceptsEmail(email);
     }
 
     const existingLink = await this.prisma.patientAccountLink.findUnique({

--- a/apps/api/src/patients/dto/create-patient-body.dto.ts
+++ b/apps/api/src/patients/dto/create-patient-body.dto.ts
@@ -1,5 +1,6 @@
 import { NationalIdType, Sex } from '@prisma/client';
 import { IsDateString, IsEmail, IsEnum, IsOptional, IsString, MaxLength } from 'class-validator';
+import { IsAllowedEmailDomain } from '../../common/email-policy';
 import { ToNormalizedEmail, ToSanitizedString } from '../../common/validation';
 
 /** Body DTO for POST /clinics/:clinicId/patients; primaryClinicId from route. */
@@ -31,6 +32,7 @@ export class CreatePatientBodyDto {
   @IsOptional()
   @ToNormalizedEmail()
   @IsEmail()
+  @IsAllowedEmailDomain()
   @MaxLength(320)
   email?: string;
 

--- a/apps/api/src/patients/dto/update-patient-body.dto.ts
+++ b/apps/api/src/patients/dto/update-patient-body.dto.ts
@@ -1,5 +1,6 @@
 import { Sex } from '@prisma/client';
 import { IsDateString, IsEmail, IsEnum, IsOptional, IsString, MaxLength } from 'class-validator';
+import { IsAllowedEmailDomain } from '../../common/email-policy';
 import { ToNormalizedEmail, ToSanitizedString } from '../../common/validation';
 
 /** Body DTO for PATCH /clinics/:clinicId/patients/:patientId. National ID is immutable. */
@@ -33,6 +34,7 @@ export class UpdatePatientBodyDto {
   @IsOptional()
   @ToNormalizedEmail()
   @IsEmail()
+  @IsAllowedEmailDomain()
   @MaxLength(320)
   email?: string;
 }

--- a/apps/api/src/users/user.service.spec.ts
+++ b/apps/api/src/users/user.service.spec.ts
@@ -2,6 +2,18 @@ import { DisabledUserException } from '../auth/disabled-user.exception';
 import { UserService } from './user.service';
 
 describe('UserService', () => {
+  function activeUser(overrides?: Record<string, unknown>) {
+    return {
+      id: 'user-1',
+      keycloakSub: 'test-sub',
+      displayName: 'Test User',
+      email: null,
+      isActive: true,
+      clinicRoles: [],
+      ...overrides,
+    };
+  }
+
   it('throws DisabledUserException for an inactive existing user', async () => {
     const userRepository = {
       findByKeycloakSub: jest.fn().mockResolvedValue({
@@ -23,5 +35,51 @@ describe('UserService', () => {
     ).rejects.toBeInstanceOf(DisabledUserException);
     expect(userRepository.syncKeycloakProfile).not.toHaveBeenCalled();
     expect(userRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('syncs verified Keycloak email when an existing active user logs in', async () => {
+    const existing = activeUser();
+    const updated = activeUser({ email: 'ama@example.com' });
+    const userRepository = {
+      findByKeycloakSub: jest.fn().mockResolvedValue(existing),
+      syncKeycloakProfile: jest.fn().mockResolvedValue(updated),
+      create: jest.fn(),
+    };
+    const service = new UserService(userRepository as never);
+
+    const result = await service.findOrCreateByKeycloakSub('test-sub', 'Ama', 'ama@example.com');
+
+    expect(userRepository.syncKeycloakProfile).toHaveBeenCalledWith('user-1', {
+      firstName: undefined,
+      lastName: undefined,
+      email: 'ama@example.com',
+      phoneE164: null,
+    });
+    expect(result.user).toBe(updated);
+  });
+
+  it('does not use unverified Keycloak email as the display fallback for new users', async () => {
+    const userRepository = {
+      findByKeycloakSub: jest.fn().mockResolvedValue(null),
+      syncKeycloakProfile: jest.fn(),
+      create: jest.fn().mockImplementation(async (data) => ({
+        id: 'user-1',
+        isActive: true,
+        clinicRoles: [],
+        ...data,
+      })),
+    };
+    const service = new UserService(userRepository as never);
+
+    await service.findOrCreateByKeycloakSub('test-sub', null, undefined);
+
+    expect(userRepository.create).toHaveBeenCalledWith({
+      keycloakSub: 'test-sub',
+      displayName: 'test-sub',
+      email: undefined,
+      firstName: undefined,
+      lastName: undefined,
+      phoneE164: null,
+    });
   });
 });

--- a/docs/USER_AND_ROLE_SETUP_GUIDE.md
+++ b/docs/USER_AND_ROLE_SETUP_GUIDE.md
@@ -311,7 +311,42 @@ replace this with a custom Nkwapa app form.
 
 ---
 
-## 11. Key Reminders
+## 11. Email Quality Policy
+
+Nkwapa validates email quality in two layers:
+
+- DTO validation normalizes email input by trimming whitespace and lowercasing the address.
+- DTO validation rejects malformed addresses and conservative disallowed domains before service
+  logic runs.
+
+Disallowed domains include:
+
+- `localhost` and `.localhost`
+- reserved or documentation domains such as `.test`, `.invalid`, `.example`, `example.com`,
+  `example.net`, and `example.org`
+- IP-literal domains
+- the initial disposable-domain denylist used by the API
+
+Portal invites are deliverability-sensitive. When an invite includes an email address, the API
+performs a fail-closed MX lookup before creating the invite. A domain with no MX records, or a DNS
+lookup failure, returns a field-level validation error for `email`.
+
+This is a domain-level deliverability guarantee only. It confirms that the domain appears able to
+receive email. It does not prove that a specific mailbox exists. Do not describe patient portal
+invites, password resets, verification emails, or reminders as guaranteed to reach a mailbox unless
+Nkwapa later integrates a vetted email validation provider with mailbox-level checks.
+
+For login accounts, Keycloak remains the source of truth for email verification. The realm export
+sets `verifyEmail: true` and enables the `VERIFY_EMAIL` required action. The API only syncs the
+Keycloak email claim into the local `User` record when the token includes `email_verified: true`.
+Unverified Keycloak emails are not used as a local contact email or display-name fallback.
+
+Sensitive telemetry must not include full email addresses. API request and exception logging already
+redacts email-shaped values; avoid adding logs that serialize raw invite payloads or token claims.
+
+---
+
+## 12. Key Reminders
 
 - Keycloak manages passwords, reset tokens, and session expiry.
 - Nkwapa manages permissions, memberships, and clinic scope.


### PR DESCRIPTION
## Summary

- Added a reusable API email policy for normalization, disallowed-domain checks, and MX-based deliverability validation.
- Applied conservative email domain validation to patient create/update DTOs and portal invite DTOs.
- Added fail-closed MX checks before creating email-based portal invites, returning field-level validation errors for `email`.
- Updated Keycloak JWT handling so local users only sync email addresses when `email_verified: true`.
- Documented the email quality policy, including the explicit limitation that MX checks do not prove mailbox existence.

## Testing

- `npm run lint --workspace @nkwapa/api`
- `npm run typecheck --workspace @nkwapa/api`
- `npm test --workspace @nkwapa/api`
- `npm run build --workspace @nkwapa/api`

## Notes

- The deliverability check validates domain-level mail acceptance via MX records only.
- No third-party mailbox validation provider was added.
- Existing email redaction remains in place for request and exception telemetry.