### PR TITLE
UI bug/increase chat widget and message box size

### DIFF
--- a/apps/web/components/chat/ChatConversation.tsx
+++ b/apps/web/components/chat/ChatConversation.tsx
@@ -13,6 +13,16 @@ import { apiFetch } from '@/lib/api';
 import { getChatSocket } from '@/lib/chat-socket';
 import { ChatMessageBubble } from './ChatMessageBubble';
 
+function TypingDots() {
+  return (
+    <span className="inline-flex items-center gap-0.5" aria-hidden="true">
+      <span className="h-1 w-1 animate-bounce rounded-full bg-muted-foreground [animation-delay:-0.2s]" />
+      <span className="h-1 w-1 animate-bounce rounded-full bg-muted-foreground [animation-delay:-0.1s]" />
+      <span className="h-1 w-1 animate-bounce rounded-full bg-muted-foreground" />
+    </span>
+  );
+}
+
 export function ChatConversation({
   conversation,
   onBack,
@@ -148,7 +158,8 @@ export function ChatConversation({
       <div className="flex items-center gap-2 border-b px-3 py-2.5">
         <button
           onClick={onBack}
-          className="cursor-pointer rounded-md p-1 transition-colors duration-150 hover:bg-muted"
+          className="cursor-pointer rounded-md p-1 transition-colors duration-150 hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          aria-label="Back to conversations"
         >
           <ArrowLeft className="h-4 w-4" />
         </button>
@@ -183,9 +194,15 @@ export function ChatConversation({
 
       {/* Typing indicator */}
       {typingList.length > 0 && (
-        <div className="px-3 pb-1 text-[11px] text-muted-foreground">
-          {typingList.map((t) => t.displayName).join(', ')} {typingList.length === 1 ? 'is' : 'are'}{' '}
-          typing...
+        <div
+          className="flex items-center gap-1.5 px-3 pb-1 text-[11px] text-muted-foreground"
+          aria-live="polite"
+        >
+          <span className="truncate">
+            {typingList.map((t) => t.displayName).join(', ')}{' '}
+            {typingList.length === 1 ? 'is' : 'are'} typing
+          </span>
+          <TypingDots />
         </div>
       )}
 
@@ -203,7 +220,8 @@ export function ChatConversation({
           <button
             onClick={handleSend}
             disabled={!input.trim()}
-            className="cursor-pointer rounded-lg bg-primary p-2 text-primary-foreground transition-colors duration-150 hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+            className="touch-target cursor-pointer rounded-lg bg-primary p-2 text-primary-foreground transition-colors duration-150 hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+            aria-label="Send message"
           >
             <Send className="h-4 w-4" />
           </button>

--- a/apps/web/components/chat/ChatConversation.tsx
+++ b/apps/web/components/chat/ChatConversation.tsx
@@ -198,7 +198,7 @@ export function ChatConversation({
             onKeyDown={handleKeyDown}
             placeholder="Type a message..."
             rows={1}
-            className="max-h-20 min-h-[36px] flex-1 resize-none rounded-lg border bg-background px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-primary"
+            className="max-h-32 min-h-[44px] flex-1 resize-none rounded-lg border bg-background px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-primary"
           />
           <button
             onClick={handleSend}

--- a/apps/web/components/chat/ChatConversation.tsx
+++ b/apps/web/components/chat/ChatConversation.tsx
@@ -11,7 +11,62 @@ import {
 } from '@/lib/chat-context';
 import { apiFetch } from '@/lib/api';
 import { getChatSocket } from '@/lib/chat-socket';
-import { ChatMessageBubble } from './ChatMessageBubble';
+import { ChatMessageBubble, type ChatMessageView } from './ChatMessageBubble';
+
+type MessageErrorPayload = {
+  conversationId?: string;
+  error?: string;
+};
+
+function createOptimisticId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `optimistic-${crypto.randomUUID()}`;
+  }
+  return `optimistic-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function findOptimisticMessageIndex(
+  messages: ChatMessageView[],
+  conversationId: string,
+  senderUserId: string | undefined,
+  content?: string,
+  deliveryStates: Array<NonNullable<ChatMessageView['deliveryState']>> = ['pending', 'failed'],
+) {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    const isOptimistic = message.deliveryState
+      ? deliveryStates.includes(message.deliveryState)
+      : false;
+    const sameConversation = message.conversationId === conversationId;
+    const sameSender = !senderUserId || message.senderUserId === senderUserId;
+    const sameContent = !content || message.content.trim() === content.trim();
+
+    if (isOptimistic && sameConversation && sameSender && sameContent) {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+function reconcileIncomingMessage(messages: ChatMessageView[], incoming: ChatMessage) {
+  if (messages.some((message) => message.id === incoming.id)) {
+    return messages;
+  }
+
+  const optimisticIndex = findOptimisticMessageIndex(
+    messages,
+    incoming.conversationId,
+    incoming.senderUserId,
+    incoming.content,
+  );
+
+  if (optimisticIndex === -1) {
+    return [incoming, ...messages];
+  }
+
+  return messages.map((message, index) => (index === optimisticIndex ? incoming : message));
+}
 
 function TypingDots() {
   return (
@@ -32,11 +87,12 @@ export function ChatConversation({
 }) {
   const getToken = useAuth();
   const bootstrapCtx = useBootstrap();
+  const bootstrap = bootstrapCtx?.bootstrap;
   const activeClinicId = bootstrapCtx?.activeClinicId;
-  const currentUserId = bootstrapCtx?.bootstrap?.userId;
+  const currentUserId = bootstrap?.userId;
   const chat = useChatContext();
 
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [messages, setMessages] = useState<ChatMessageView[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(true);
   const [hasMore, setHasMore] = useState(false);
@@ -98,31 +154,116 @@ export function ChatConversation({
     const handler = (message: ChatMessage) => {
       if (message.conversationId === conversation.id) {
         setMessages((prev) => {
-          if (prev.some((m) => m.id === message.id)) return prev;
-          return [message, ...prev];
+          return reconcileIncomingMessage(prev, message);
         });
         chat?.markRead(conversation.id);
       }
     };
 
+    const errorHandler = (payload?: MessageErrorPayload) => {
+      if (payload?.conversationId && payload.conversationId !== conversation.id) return;
+
+      setMessages((prev) => {
+        const failedIndex = findOptimisticMessageIndex(
+          prev,
+          conversation.id,
+          currentUserId,
+          undefined,
+          ['pending'],
+        );
+        if (failedIndex === -1) return prev;
+
+        return prev.map((message, index) =>
+          index === failedIndex
+            ? { ...message, deliveryState: 'failed' as const, status: 'failed' }
+            : message,
+        );
+      });
+    };
+
     socket.on('message:new', handler);
+    socket.on('message:error', errorHandler);
     return () => {
       socket.off('message:new', handler);
+      socket.off('message:error', errorHandler);
     };
-  }, [conversation.id, chat]);
+  }, [conversation.id, chat, currentUserId]);
 
   // Scroll to bottom on new messages
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages.length]);
 
+  const queueMessage = useCallback(
+    (content: string) => {
+      if (!chat || !currentUserId) return false;
+
+      const optimisticId = createOptimisticId();
+      const optimisticMessage: ChatMessageView = {
+        id: optimisticId,
+        optimisticId,
+        conversationId: conversation.id,
+        senderUserId: currentUserId,
+        clinicId: activeClinicId ?? conversation.clinicId,
+        content,
+        encrypted: false,
+        status: 'sending',
+        createdAt: new Date().toISOString(),
+        sender: {
+          id: currentUserId,
+          displayName: bootstrap?.displayName ?? 'You',
+          firstName: null,
+          lastName: null,
+        },
+        deliveryState: 'pending',
+      };
+
+      setMessages((prev) => [optimisticMessage, ...prev]);
+
+      const queued = chat.sendMessage(conversation.id, content);
+      if (!queued) {
+        setMessages((prev) =>
+          prev.map((message) =>
+            message.optimisticId === optimisticId
+              ? { ...message, deliveryState: 'failed' as const, status: 'failed' }
+              : message,
+          ),
+        );
+      }
+
+      return true;
+    },
+    [
+      activeClinicId,
+      bootstrap?.displayName,
+      chat,
+      conversation.clinicId,
+      conversation.id,
+      currentUserId,
+    ],
+  );
+
   const handleSend = useCallback(() => {
     const trimmed = input.trim();
-    if (!trimmed || !chat) return;
-    chat.sendMessage(conversation.id, trimmed);
-    setInput('');
-    chat.sendTypingStop(conversation.id);
-  }, [input, chat, conversation.id]);
+    if (!trimmed) return;
+
+    if (queueMessage(trimmed)) {
+      setInput('');
+      chat?.sendTypingStop(conversation.id);
+    }
+  }, [input, queueMessage, chat, conversation.id]);
+
+  const handleRetry = useCallback(
+    (message: ChatMessageView) => {
+      const trimmed = message.content.trim();
+      if (!trimmed || !queueMessage(trimmed)) return;
+
+      setMessages((prev) =>
+        prev.filter((item) => item.optimisticId !== message.optimisticId && item.id !== message.id),
+      );
+    },
+    [queueMessage],
+  );
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -179,6 +320,7 @@ export function ChatConversation({
             key={msg.id}
             message={msg}
             isMine={msg.senderUserId === currentUserId}
+            onRetry={handleRetry}
           />
         ))}
         {hasMore && (

--- a/apps/web/components/chat/ChatConversationList.tsx
+++ b/apps/web/components/chat/ChatConversationList.tsx
@@ -41,8 +41,9 @@ export function ChatConversationList({
         <h3 className="text-sm font-semibold">Messages</h3>
         <button
           onClick={onNewMessage}
-          className="cursor-pointer rounded-md p-1.5 transition-colors duration-150 hover:bg-muted"
+          className="cursor-pointer rounded-md p-1.5 transition-colors duration-150 hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
           title="New message"
+          aria-label="New message"
         >
           <MessageSquarePlus className="h-4 w-4" />
         </button>
@@ -53,7 +54,7 @@ export function ChatConversationList({
             <p className="text-xs text-muted-foreground">No conversations yet.</p>
             <button
               onClick={onNewMessage}
-              className="mt-2 cursor-pointer text-xs font-medium text-primary hover:underline"
+              className="mt-2 cursor-pointer rounded-sm text-xs font-medium text-primary hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
             >
               Start a new conversation
             </button>
@@ -68,7 +69,7 @@ export function ChatConversationList({
               <button
                 key={conv.id}
                 onClick={() => onSelect(conv)}
-                className="flex w-full cursor-pointer items-center gap-3 px-3 py-2.5 text-left transition-colors duration-150 hover:bg-muted"
+                className="flex w-full cursor-pointer items-center gap-3 px-3 py-2.5 text-left transition-colors duration-150 hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring"
               >
                 <div className="relative flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-primary/10 text-sm font-semibold text-primary">
                   {(other?.user.firstName?.[0] ?? name[0]).toUpperCase()}

--- a/apps/web/components/chat/ChatMessageBubble.tsx
+++ b/apps/web/components/chat/ChatMessageBubble.tsx
@@ -2,32 +2,59 @@
 
 import type { ChatMessage } from '@/lib/chat-context';
 
+export type ChatMessageView = ChatMessage & {
+  optimisticId?: string;
+  deliveryState?: 'pending' | 'failed';
+};
+
 function formatTime(dateStr: string) {
   const d = new Date(dateStr);
   return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 }
 
-export function ChatMessageBubble({ message, isMine }: { message: ChatMessage; isMine: boolean }) {
+export function ChatMessageBubble({
+  message,
+  isMine,
+  onRetry,
+}: {
+  message: ChatMessageView;
+  isMine: boolean;
+  onRetry?: (message: ChatMessageView) => void;
+}) {
+  const isPending = isMine && message.deliveryState === 'pending';
+  const isFailed = isMine && message.deliveryState === 'failed';
+  const bubbleClassName = isFailed
+    ? 'border border-destructive/40 bg-destructive/10 text-foreground rounded-br-md'
+    : isMine
+      ? 'bg-primary text-primary-foreground rounded-br-md'
+      : 'bg-muted text-foreground rounded-bl-md';
+
   return (
     <div className={`flex ${isMine ? 'justify-end' : 'justify-start'} mb-1.5`}>
       <div
-        className={`max-w-[80%] rounded-2xl px-3.5 py-2 ${
-          isMine
-            ? 'bg-primary text-primary-foreground rounded-br-md'
-            : 'bg-muted text-foreground rounded-bl-md'
-        }`}
+        className={`max-w-[80%] rounded-2xl px-3.5 py-2 ${bubbleClassName} ${isPending ? 'opacity-80' : ''}`}
       >
         {!isMine && (
           <p className="mb-0.5 text-[11px] font-medium opacity-70">{message.sender.displayName}</p>
         )}
         <p className="whitespace-pre-wrap break-words text-sm leading-relaxed">{message.content}</p>
-        <p
-          className={`mt-0.5 text-[10px] ${
-            isMine ? 'text-primary-foreground/60' : 'text-muted-foreground'
-          } text-right`}
-        >
-          {formatTime(message.createdAt)}
-        </p>
+        {isFailed ? (
+          <button
+            type="button"
+            onClick={() => onRetry?.(message)}
+            className="mt-1 block cursor-pointer text-left text-[10px] font-medium text-destructive underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          >
+            Could not send. Try again.
+          </button>
+        ) : (
+          <p
+            className={`mt-0.5 text-right text-[10px] ${
+              isMine ? 'text-primary-foreground/60' : 'text-muted-foreground'
+            }`}
+          >
+            {isPending ? 'Sending...' : formatTime(message.createdAt)}
+          </p>
+        )}
       </div>
     </div>
   );

--- a/apps/web/components/chat/ChatUserPicker.tsx
+++ b/apps/web/components/chat/ChatUserPicker.tsx
@@ -67,7 +67,8 @@ export function ChatUserPicker({
       <div className="flex items-center gap-2 border-b px-3 py-2.5">
         <button
           onClick={onBack}
-          className="cursor-pointer rounded-md p-1 transition-colors duration-150 hover:bg-muted"
+          className="cursor-pointer rounded-md p-1 transition-colors duration-150 hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          aria-label="Back to conversations"
         >
           <ArrowLeft className="h-4 w-4" />
         </button>
@@ -95,7 +96,7 @@ export function ChatUserPicker({
             <button
               key={user.id}
               onClick={() => handleSelect(user)}
-              className="flex w-full cursor-pointer items-center gap-3 px-3 py-2.5 text-left transition-colors duration-150 hover:bg-muted"
+              className="flex w-full cursor-pointer items-center gap-3 px-3 py-2.5 text-left transition-colors duration-150 hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring"
             >
               <div className="relative flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
                 {(user.firstName?.[0] ?? user.displayName[0]).toUpperCase()}

--- a/apps/web/components/chat/ChatWidget.tsx
+++ b/apps/web/components/chat/ChatWidget.tsx
@@ -71,7 +71,7 @@ function ChatPanel() {
       {isOpen && (
         <div
           data-testid="chat-panel"
-          className="absolute bottom-[calc(100%+0.75rem)] right-0 flex h-[min(560px,calc(100vh-7.5rem))] w-[min(400px,calc(100vw-1.5rem))] max-w-[calc(100vw-1.5rem)] flex-col overflow-hidden rounded-[24px] border border-border/80 bg-background shadow-2xl shadow-black/20 sm:h-[min(560px,calc(100vh-8rem))] sm:w-[min(400px,calc(100vw-2.5rem))]"
+          className="absolute bottom-[calc(100%+0.75rem)] right-0 flex h-[min(620px,calc(100dvh-7.5rem))] max-h-[calc(100vh-7.5rem)] w-[min(420px,calc(100vw-1.5rem))] max-w-[calc(100vw-1.5rem)] flex-col overflow-hidden rounded-[24px] border border-border/80 bg-background shadow-2xl shadow-black/20 sm:h-[min(660px,calc(100dvh-8rem))] sm:max-h-[calc(100vh-8rem)] sm:w-[min(460px,calc(100vw-2.5rem))]"
         >
           {/* Connection indicator */}
           {chat && !chat.isConnected && (

--- a/apps/web/components/chat/ChatWidget.tsx
+++ b/apps/web/components/chat/ChatWidget.tsx
@@ -54,7 +54,7 @@ function ChatPanel() {
       <button
         onClick={() => setIsOpen((prev) => !prev)}
         data-testid="chat-toggle"
-        className="relative flex h-[3.25rem] w-[3.25rem] cursor-pointer items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg shadow-primary/20 transition-transform duration-200 hover:scale-105 active:scale-95 sm:h-14 sm:w-14"
+        className="relative flex h-[3.25rem] w-[3.25rem] cursor-pointer items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg shadow-primary/20 transition-transform duration-200 hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 active:scale-95 sm:h-14 sm:w-14"
         aria-label={isOpen ? 'Close chat' : 'Open chat'}
       >
         {isOpen ? (

--- a/apps/web/lib/chat-context.tsx
+++ b/apps/web/lib/chat-context.tsx
@@ -62,7 +62,7 @@ interface ChatContextValue {
   onlineUserIds: Set<string>;
   activeConversationId: string | null;
   setActiveConversationId: (id: string | null) => void;
-  sendMessage: (conversationId: string, content: string) => void;
+  sendMessage: (conversationId: string, content: string) => boolean;
   markRead: (conversationId: string) => void;
   startConversation: (participantUserId: string) => Promise<ChatConversation>;
   joinConversation: (conversationId: string) => void;
@@ -257,7 +257,9 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     const sock = getChatSocket();
     if (sock?.connected) {
       sock.emit('message:send', { conversationId, content });
+      return true;
     }
+    return false;
   }, []);
 
   const markRead = useCallback((conversationId: string) => {


### PR DESCRIPTION
## Summary
- Enlarged the floating chat panel and composer for more comfortable desktop reading and writing while preserving mobile viewport constraints.
- Added keyboard-visible focus states across chat controls.
- Replaced plain typing text with an accessible three-dot typing indicator.
- Added optimistic outbound messages with “Sending...” feedback, success reconciliation from `message:new`, and clear retry UI for failed sends.

## Details
- Increased chat panel sizing toward `460px` wide and `660px` tall on desktop, with `100dvh`/viewport clamps to avoid overflow.
- Increased composer height and kept the message list as the flexible scroll area.
- Updated chat sending to report whether a message was queued over the socket.
- Added local UI-only delivery metadata for pending and failed chat bubbles without changing backend APIs or persisted message schemas.

## Testing
- Passed web typecheck, lint, unit tests, production build, secret scan, and Playwright e2e.
- Playwright responsive coverage verified chat panel bounds at 375px, 768px, 1024px, and 1440px.