### PR TITLE
Feat/appointment operations v2 patient visible history and actions

### DIFF
--- a/apps/api/src/patient-portal/dto/appointment-requests.dto.ts
+++ b/apps/api/src/patient-portal/dto/appointment-requests.dto.ts
@@ -78,6 +78,39 @@ export class ListAppointmentsQueryDto {
   patientSearch?: string;
 }
 
+export class PatientCancelAppointmentRequestDto {
+  @ToSanitizedString({ maxLength: 120 })
+  @IsString()
+  @MaxLength(120)
+  reason!: string;
+
+  @IsOptional()
+  @ToSanitizedString({ maxLength: 2000, preserveNewlines: true })
+  @IsString()
+  @MaxLength(2000)
+  notes?: string;
+}
+
+export class PatientRescheduleAppointmentRequestDto {
+  @IsDateString()
+  preferredStartDate!: string;
+
+  @IsDateString()
+  preferredEndDate!: string;
+
+  @IsOptional()
+  @ToSanitizedString({ maxLength: 120 })
+  @IsString()
+  @MaxLength(120)
+  reason?: string;
+
+  @IsOptional()
+  @ToSanitizedString({ maxLength: 2000, preserveNewlines: true })
+  @IsString()
+  @MaxLength(2000)
+  notes?: string;
+}
+
 export class ConfirmAppointmentRequestDto {
   @IsDateString()
   startsAt!: string;

--- a/apps/api/src/patient-portal/patient-api.controller.spec.ts
+++ b/apps/api/src/patient-portal/patient-api.controller.spec.ts
@@ -54,6 +54,9 @@ describe('PatientApiController', () => {
   let controller: PatientApiController;
   let patientPortalService: {
     listMeasurementsForAuthenticatedPatient: jest.Mock;
+    listAppointmentsForAuthenticatedPatient: jest.Mock;
+    createCancelAppointmentRequestForAuthenticatedPatient: jest.Mock;
+    createRescheduleAppointmentRequestForAuthenticatedPatient: jest.Mock;
     listTrendsForAuthenticatedPatient: jest.Mock;
     listTrendsForStaff: jest.Mock;
   };
@@ -63,6 +66,18 @@ describe('PatientApiController', () => {
   beforeEach(async () => {
     patientPortalService = {
       listMeasurementsForAuthenticatedPatient: jest.fn().mockResolvedValue([]),
+      listAppointmentsForAuthenticatedPatient: jest.fn().mockResolvedValue({
+        range: { from: '2026-03-01', to: '2026-03-31' },
+        timezone: 'Africa/Accra',
+        summary: { total: 0, confirmed: 0, cancelled: 0, completed: 0, noShow: 0 },
+        items: [],
+      }),
+      createCancelAppointmentRequestForAuthenticatedPatient: jest.fn().mockResolvedValue({
+        id: 'cancel-request-1',
+      }),
+      createRescheduleAppointmentRequestForAuthenticatedPatient: jest.fn().mockResolvedValue({
+        id: 'reschedule-request-1',
+      }),
       listTrendsForAuthenticatedPatient: jest.fn().mockResolvedValue({
         bp: [],
         glucose: [],
@@ -115,6 +130,95 @@ describe('PatientApiController', () => {
       'clinic-1',
       'patient-user-1',
       {},
+    );
+  });
+
+  it('lists patient appointments through the authenticated patient route', async () => {
+    const request: RequestShape = {
+      headers: { 'x-clinic-id': 'clinic-1' },
+      query: { from: '2026-03-01', to: '2026-03-31' },
+      user: patientUser,
+    };
+    const context = createExecutionContext(controller, 'listAppointments', request);
+
+    expect(clinicScopeGuard.canActivate(context)).toBe(true);
+    expect(request.clinicId).toBe('clinic-1');
+    expect(rbacGuard.canActivate(context)).toBe(true);
+
+    await controller.listAppointments(
+      { from: '2026-03-01', to: '2026-03-31' },
+      {
+        clinicId: request.clinicId,
+        headers: {},
+        user: request.user,
+      },
+    );
+
+    expect(patientPortalService.listAppointmentsForAuthenticatedPatient).toHaveBeenCalledWith(
+      'clinic-1',
+      'patient-user-1',
+      { from: '2026-03-01', to: '2026-03-31' },
+    );
+  });
+
+  it('creates patient appointment change requests with authenticated user ownership', async () => {
+    const request: RequestShape = {
+      headers: { 'x-clinic-id': 'clinic-1', 'x-request-id': 'req-1' },
+      params: { appointmentId: 'appointment-1' },
+      user: patientUser,
+    };
+    const cancelContext = createExecutionContext(
+      controller,
+      'createCancelAppointmentRequest',
+      request,
+    );
+    const rescheduleContext = createExecutionContext(
+      controller,
+      'createRescheduleAppointmentRequest',
+      request,
+    );
+
+    expect(clinicScopeGuard.canActivate(cancelContext)).toBe(true);
+    expect(rbacGuard.canActivate(cancelContext)).toBe(true);
+    expect(clinicScopeGuard.canActivate(rescheduleContext)).toBe(true);
+    expect(rbacGuard.canActivate(rescheduleContext)).toBe(true);
+
+    await controller.createCancelAppointmentRequest(
+      'appointment-1',
+      { reason: 'Cannot make it' },
+      {
+        clinicId: request.clinicId,
+        headers: { 'x-request-id': 'req-1' },
+        user: request.user,
+      },
+    );
+    await controller.createRescheduleAppointmentRequest(
+      'appointment-1',
+      { preferredStartDate: '2026-04-01', preferredEndDate: '2026-04-03' },
+      {
+        clinicId: request.clinicId,
+        headers: { 'x-request-id': 'req-1' },
+        user: request.user,
+      },
+    );
+
+    expect(
+      patientPortalService.createCancelAppointmentRequestForAuthenticatedPatient,
+    ).toHaveBeenCalledWith(
+      'clinic-1',
+      'patient-user-1',
+      'appointment-1',
+      { reason: 'Cannot make it' },
+      'req-1',
+    );
+    expect(
+      patientPortalService.createRescheduleAppointmentRequestForAuthenticatedPatient,
+    ).toHaveBeenCalledWith(
+      'clinic-1',
+      'patient-user-1',
+      'appointment-1',
+      { preferredStartDate: '2026-04-01', preferredEndDate: '2026-04-03' },
+      'req-1',
     );
   });
 

--- a/apps/api/src/patient-portal/patient-api.controller.ts
+++ b/apps/api/src/patient-portal/patient-api.controller.ts
@@ -24,7 +24,10 @@ import {
 import { ListPatientTrendsQueryDto } from './dto/patient-trends.dto';
 import {
   CreateAppointmentRequestDto,
+  ListAppointmentsQueryDto,
   ListAppointmentRequestsQueryDto,
+  PatientCancelAppointmentRequestDto,
+  PatientRescheduleAppointmentRequestDto,
 } from './dto/appointment-requests.dto';
 import { PatientIdParamDto } from '../common/request-dto';
 import { RateLimit } from '../common/rate-limit.decorator';
@@ -133,6 +136,75 @@ export class PatientApiController {
       req.clinicId,
       req.user.user.id,
       query,
+    );
+  }
+
+  @Get('me/appointments')
+  @ClinicScoped({ type: 'header', headerKey: 'x-clinic-id' })
+  @RequirePermission(PERMISSIONS.PATIENT_PORTAL_READ_SELF)
+  async listAppointments(
+    @Query() query: ListAppointmentsQueryDto,
+    @Request() req: RequestWithUser,
+  ) {
+    if (!req.clinicId) {
+      throw new BadRequestException('X-Clinic-Id header is required');
+    }
+    return this.patientPortalService.listAppointmentsForAuthenticatedPatient(
+      req.clinicId,
+      req.user.user.id,
+      query,
+    );
+  }
+
+  @Post('me/appointments/:appointmentId/cancel-request')
+  @ClinicScoped({ type: 'header', headerKey: 'x-clinic-id' })
+  @RequirePermission(PERMISSIONS.PATIENT_PORTAL_WRITE_SELF_REPORT)
+  @RateLimit({
+    key: 'patient_portal_appointment_change_request_write',
+    limit: 10,
+    windowSeconds: 300,
+    scope: 'user-or-ip',
+  })
+  async createCancelAppointmentRequest(
+    @Param('appointmentId') appointmentId: string,
+    @Body() dto: PatientCancelAppointmentRequestDto,
+    @Request() req: RequestWithUser,
+  ) {
+    if (!req.clinicId) {
+      throw new BadRequestException('X-Clinic-Id header is required');
+    }
+    return this.patientPortalService.createCancelAppointmentRequestForAuthenticatedPatient(
+      req.clinicId,
+      req.user.user.id,
+      appointmentId,
+      dto,
+      req.headers?.['x-request-id'] ?? randomUUID(),
+    );
+  }
+
+  @Post('me/appointments/:appointmentId/reschedule-request')
+  @ClinicScoped({ type: 'header', headerKey: 'x-clinic-id' })
+  @RequirePermission(PERMISSIONS.PATIENT_PORTAL_WRITE_SELF_REPORT)
+  @RateLimit({
+    key: 'patient_portal_appointment_change_request_write',
+    limit: 10,
+    windowSeconds: 300,
+    scope: 'user-or-ip',
+  })
+  async createRescheduleAppointmentRequest(
+    @Param('appointmentId') appointmentId: string,
+    @Body() dto: PatientRescheduleAppointmentRequestDto,
+    @Request() req: RequestWithUser,
+  ) {
+    if (!req.clinicId) {
+      throw new BadRequestException('X-Clinic-Id header is required');
+    }
+    return this.patientPortalService.createRescheduleAppointmentRequestForAuthenticatedPatient(
+      req.clinicId,
+      req.user.user.id,
+      appointmentId,
+      dto,
+      req.headers?.['x-request-id'] ?? randomUUID(),
     );
   }
 

--- a/apps/api/src/patient-portal/patient-portal.service.spec.ts
+++ b/apps/api/src/patient-portal/patient-portal.service.spec.ts
@@ -542,6 +542,8 @@ describe('PatientPortalService', () => {
       id: 'appt-req-1',
       clinicId: 'clinic-1',
       patientId: 'patient-1',
+      requestType: 'NEW_APPOINTMENT',
+      sourceAppointmentId: null,
       preferredStartDate: new Date('2026-03-25T00:00:00.000Z'),
       preferredEndDate: new Date('2026-03-27T00:00:00.000Z'),
       reason: 'Follow-up',
@@ -562,6 +564,7 @@ describe('PatientPortalService', () => {
       },
       triagedBy: null,
       appointment: null,
+      sourceAppointment: null,
     });
 
     const result = await service.createAppointmentRequestForAuthenticatedPatient(
@@ -581,6 +584,233 @@ describe('PatientPortalService', () => {
       expect.objectContaining({ action: 'APPT.REQUEST.CREATE', entityId: 'appt-req-1' }),
     );
     expect(result.status).toBe('REQUESTED');
+  });
+
+  it('lists appointments for the authenticated patient only', async () => {
+    prisma.appointment.findMany.mockResolvedValue([
+      appointmentFixture({
+        startsAt: new Date('2026-03-26T14:00:00.000Z'),
+        endsAt: new Date('2026-03-26T14:30:00.000Z'),
+      }),
+    ]);
+
+    const result = await service.listAppointmentsForAuthenticatedPatient('clinic-1', 'user-1', {
+      from: '2026-03-01',
+      to: '2026-03-31',
+    });
+
+    expect(prisma.appointment.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          clinicId: 'clinic-1',
+          patientId: 'patient-1',
+          startsAt: { lte: new Date('2026-03-31T23:59:59.999Z') },
+          endsAt: { gte: new Date('2026-03-01T00:00:00.000Z') },
+        }),
+        orderBy: [{ startsAt: 'desc' }, { createdAt: 'desc' }],
+      }),
+    );
+    expect(result.summary).toMatchObject({ total: 1, confirmed: 1 });
+    expect(result.items[0]).toMatchObject({
+      id: 'appointment-1',
+      patientId: 'patient-1',
+      status: 'CONFIRMED',
+    });
+  });
+
+  it('creates patient cancellation requests without mutating appointments', async () => {
+    const sourceAppointment = appointmentFixture({
+      startsAt: new Date('2099-03-26T14:00:00.000Z'),
+      endsAt: new Date('2099-03-26T14:30:00.000Z'),
+    });
+    prisma.appointment.findFirst.mockResolvedValue(sourceAppointment);
+    prisma.appointmentRequest.create.mockResolvedValue({
+      id: 'cancel-request-1',
+      clinicId: 'clinic-1',
+      patientId: 'patient-1',
+      requestType: 'CANCEL_APPOINTMENT',
+      sourceAppointmentId: 'appointment-1',
+      preferredStartDate: new Date('2099-03-26T00:00:00.000Z'),
+      preferredEndDate: new Date('2099-03-26T00:00:00.000Z'),
+      reason: 'I cannot make this visit',
+      notes: 'Please cancel it',
+      status: 'REQUESTED',
+      triagedByUserId: null,
+      triagedAt: null,
+      rejectionReason: null,
+      createdAt: new Date('2026-03-21T09:00:00.000Z'),
+      updatedAt: new Date('2026-03-21T09:00:00.000Z'),
+      patient: sourceAppointment.patient,
+      triagedBy: null,
+      appointment: null,
+      sourceAppointment,
+    });
+
+    const result = await service.createCancelAppointmentRequestForAuthenticatedPatient(
+      'clinic-1',
+      'user-1',
+      'appointment-1',
+      { reason: 'I cannot make this visit', notes: 'Please cancel it' },
+      'req-cancel-request',
+    );
+
+    expect(prisma.appointment.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'appointment-1', clinicId: 'clinic-1', patientId: 'patient-1' },
+      }),
+    );
+    expect(prisma.appointmentRequest.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          clinicId: 'clinic-1',
+          patientId: 'patient-1',
+          requestType: 'CANCEL_APPOINTMENT',
+          sourceAppointmentId: 'appointment-1',
+          reason: 'I cannot make this visit',
+          status: 'REQUESTED',
+        }),
+      }),
+    );
+    expect(prisma.appointment.updateMany).not.toHaveBeenCalled();
+    expect(auditService.logWrite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'APPT.REQUEST.CANCEL_REQUEST.CREATE',
+        entityId: 'cancel-request-1',
+      }),
+    );
+    expect(result).toMatchObject({
+      requestType: 'CANCEL_APPOINTMENT',
+      sourceAppointmentId: 'appointment-1',
+      sourceAppointment: { id: 'appointment-1' },
+    });
+  });
+
+  it('creates patient reschedule requests with preferred date windows', async () => {
+    const sourceAppointment = appointmentFixture({
+      startsAt: new Date('2099-03-26T14:00:00.000Z'),
+      endsAt: new Date('2099-03-26T14:30:00.000Z'),
+    });
+    prisma.appointment.findFirst.mockResolvedValue(sourceAppointment);
+    prisma.appointmentRequest.create.mockResolvedValue({
+      id: 'reschedule-request-1',
+      clinicId: 'clinic-1',
+      patientId: 'patient-1',
+      requestType: 'RESCHEDULE_APPOINTMENT',
+      sourceAppointmentId: 'appointment-1',
+      preferredStartDate: new Date('2099-04-01T00:00:00.000Z'),
+      preferredEndDate: new Date('2099-04-03T00:00:00.000Z'),
+      reason: 'Need a morning slot',
+      notes: 'Any day in this range works',
+      status: 'REQUESTED',
+      triagedByUserId: null,
+      triagedAt: null,
+      rejectionReason: null,
+      createdAt: new Date('2026-03-21T09:00:00.000Z'),
+      updatedAt: new Date('2026-03-21T09:00:00.000Z'),
+      patient: sourceAppointment.patient,
+      triagedBy: null,
+      appointment: null,
+      sourceAppointment,
+    });
+
+    const result = await service.createRescheduleAppointmentRequestForAuthenticatedPatient(
+      'clinic-1',
+      'user-1',
+      'appointment-1',
+      {
+        preferredStartDate: '2099-04-01',
+        preferredEndDate: '2099-04-03',
+        reason: 'Need a morning slot',
+        notes: 'Any day in this range works',
+      },
+      'req-reschedule-request',
+    );
+
+    expect(prisma.appointmentRequest.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          requestType: 'RESCHEDULE_APPOINTMENT',
+          sourceAppointmentId: 'appointment-1',
+          preferredStartDate: new Date('2099-04-01T00:00:00.000Z'),
+          preferredEndDate: new Date('2099-04-03T00:00:00.000Z'),
+        }),
+      }),
+    );
+    expect(prisma.appointment.updateMany).not.toHaveBeenCalled();
+    expect(auditService.logWrite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'APPT.REQUEST.RESCHEDULE_REQUEST.CREATE',
+        entityId: 'reschedule-request-1',
+      }),
+    );
+    expect(result.requestType).toBe('RESCHEDULE_APPOINTMENT');
+  });
+
+  it('rejects patient change requests for appointments outside the authenticated chart', async () => {
+    prisma.appointment.findFirst.mockResolvedValue(null);
+
+    await expect(
+      service.createCancelAppointmentRequestForAuthenticatedPatient(
+        'clinic-1',
+        'user-1',
+        'appointment-owned-by-someone-else',
+        { reason: 'Wrong chart attempt' },
+        'req-wrong-chart',
+      ),
+    ).rejects.toThrow(NotFoundException);
+
+    expect(prisma.appointment.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: 'appointment-owned-by-someone-else',
+          clinicId: 'clinic-1',
+          patientId: 'patient-1',
+        },
+      }),
+    );
+    expect(prisma.appointmentRequest.create).not.toHaveBeenCalled();
+    expect(prisma.appointment.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('rejects patient change requests for non-confirmed or past appointments', async () => {
+    prisma.appointment.findFirst.mockResolvedValueOnce(
+      appointmentFixture({
+        status: 'CANCELLED',
+        startsAt: new Date('2099-03-26T14:00:00.000Z'),
+      }),
+    );
+
+    await expect(
+      service.createCancelAppointmentRequestForAuthenticatedPatient(
+        'clinic-1',
+        'user-1',
+        'appointment-1',
+        { reason: 'Already cancelled' },
+        'req-terminal',
+      ),
+    ).rejects.toMatchObject({
+      response: expect.objectContaining({ code: 'APPOINTMENT_CHANGE_REQUEST_NOT_ALLOWED' }),
+    });
+
+    prisma.appointment.findFirst.mockResolvedValueOnce(
+      appointmentFixture({
+        startsAt: new Date('2020-03-26T14:00:00.000Z'),
+      }),
+    );
+
+    await expect(
+      service.createRescheduleAppointmentRequestForAuthenticatedPatient(
+        'clinic-1',
+        'user-1',
+        'appointment-1',
+        { preferredStartDate: '2099-04-01', preferredEndDate: '2099-04-03' },
+        'req-past',
+      ),
+    ).rejects.toMatchObject({
+      response: expect.objectContaining({ code: 'APPOINTMENT_CHANGE_REQUEST_TOO_LATE' }),
+    });
+
+    expect(prisma.appointmentRequest.create).not.toHaveBeenCalled();
   });
 
   it('lists clinic appointments by overlapping date range and preserves clinic isolation', async () => {

--- a/apps/api/src/patient-portal/patient-portal.service.ts
+++ b/apps/api/src/patient-portal/patient-portal.service.ts
@@ -8,6 +8,7 @@ import {
 } from '@nestjs/common';
 import {
   AppointmentRequestStatus,
+  AppointmentRequestType,
   AppointmentStatus,
   EncounterStatus,
   PatientMeasurementSource,
@@ -34,6 +35,8 @@ import type {
   ListAppointmentsQueryDto,
   ListAppointmentRequestsQueryDto,
   MarkNoShowAppointmentDto,
+  PatientCancelAppointmentRequestDto,
+  PatientRescheduleAppointmentRequestDto,
   RejectAppointmentRequestDto,
   RescheduleAppointmentDto,
 } from './dto/appointment-requests.dto';
@@ -56,6 +59,12 @@ const appointmentRequestInclude = {
   },
   triagedBy: { select: { id: true, displayName: true } },
   appointment: {
+    include: {
+      assignedDoctor: { select: { id: true, displayName: true } },
+      assignedVolunteer: { select: { id: true, displayName: true } },
+    },
+  },
+  sourceAppointment: {
     include: {
       assignedDoctor: { select: { id: true, displayName: true } },
       assignedVolunteer: { select: { id: true, displayName: true } },
@@ -317,6 +326,132 @@ export class PatientPortalService {
     });
 
     return items.map((item) => this.serializeAppointmentRequest(item));
+  }
+
+  async listAppointmentsForAuthenticatedPatient(
+    clinicId: string,
+    userId: string,
+    query: ListAppointmentsQueryDto,
+  ) {
+    const patient = await this.resolvePortalPatient(clinicId, userId);
+    const range = this.resolveAppointmentRange(query);
+    const where = this.buildAppointmentWhere(clinicId, query, range, patient.id);
+    const items = await this.prisma.appointment.findMany({
+      where,
+      include: appointmentScheduleInclude,
+      orderBy: [{ startsAt: 'desc' }, { createdAt: 'desc' }],
+    });
+
+    return {
+      range: {
+        from: range.from,
+        to: range.to,
+      },
+      timezone: 'Africa/Accra',
+      summary: this.summarizeAppointments(items),
+      items: items.map((item) => this.serializeAppointment(item)),
+    };
+  }
+
+  async createCancelAppointmentRequestForAuthenticatedPatient(
+    clinicId: string,
+    userId: string,
+    appointmentId: string,
+    dto: PatientCancelAppointmentRequestDto,
+    requestId?: string,
+  ) {
+    const reason = dto.reason?.trim();
+    if (!reason) {
+      throw new BadRequestException({
+        code: 'VALIDATION_ERROR',
+        message: 'Request validation failed.',
+        fieldErrors: [{ field: 'reason', message: 'reason should not be empty' }],
+        recoveryAction: 'Add a cancellation reason and try again.',
+      });
+    }
+
+    const { patient, appointment } = await this.resolvePatientChangeRequestAppointment(
+      clinicId,
+      userId,
+      appointmentId,
+      'cancel',
+    );
+
+    const appointmentDate = this.toDateOnly(appointment.startsAt);
+    const created = await this.prisma.appointmentRequest.create({
+      data: {
+        clinicId,
+        patientId: patient.id,
+        requestType: AppointmentRequestType.CANCEL_APPOINTMENT,
+        sourceAppointmentId: appointment.id,
+        preferredStartDate: appointmentDate,
+        preferredEndDate: appointmentDate,
+        reason,
+        notes: dto.notes?.trim() || null,
+        status: AppointmentRequestStatus.REQUESTED,
+      },
+      include: appointmentRequestInclude,
+    });
+
+    await this.auditService.logWrite({
+      clinicId,
+      actorUserId: userId,
+      action: 'APPT.REQUEST.CANCEL_REQUEST.CREATE',
+      entityType: 'AppointmentRequest',
+      entityId: created.id,
+      afterJson: JSON.stringify(created),
+      requestId,
+    });
+
+    return this.serializeAppointmentRequest(created);
+  }
+
+  async createRescheduleAppointmentRequestForAuthenticatedPatient(
+    clinicId: string,
+    userId: string,
+    appointmentId: string,
+    dto: PatientRescheduleAppointmentRequestDto,
+    requestId?: string,
+  ) {
+    const preferredStartDate = this.parseDateOnly(dto.preferredStartDate, 'preferredStartDate');
+    const preferredEndDate = this.parseDateOnly(dto.preferredEndDate, 'preferredEndDate');
+    if (preferredEndDate < preferredStartDate) {
+      throw new BadRequestException('preferredEndDate must be on or after preferredStartDate');
+    }
+
+    const { patient, appointment } = await this.resolvePatientChangeRequestAppointment(
+      clinicId,
+      userId,
+      appointmentId,
+      'reschedule',
+    );
+
+    const created = await this.prisma.appointmentRequest.create({
+      data: {
+        clinicId,
+        patientId: patient.id,
+        requestType: AppointmentRequestType.RESCHEDULE_APPOINTMENT,
+        sourceAppointmentId: appointment.id,
+        preferredStartDate,
+        preferredEndDate,
+        reason: dto.reason?.trim() || null,
+        notes: dto.notes?.trim() || null,
+        status: AppointmentRequestStatus.REQUESTED,
+      },
+      include: appointmentRequestInclude,
+    });
+
+    await this.auditService.logWrite({
+      clinicId,
+      actorUserId: userId,
+      action: 'APPT.REQUEST.RESCHEDULE_REQUEST.CREATE',
+      entityType: 'AppointmentRequest',
+      entityId: created.id,
+      afterJson: JSON.stringify(created),
+      requestId,
+    });
+
+    return this.serializeAppointmentRequest(created);
   }
 
   async listAppointmentRequestsForClinic(clinicId: string, query: ListAppointmentRequestsQueryDto) {
@@ -1865,11 +2000,13 @@ export class PatientPortalService {
     clinicId: string,
     query: ListAppointmentsQueryDto,
     range: AppointmentRange,
+    patientId?: string,
   ): Prisma.AppointmentWhereInput {
     const patientSearch = query.patientSearch?.trim();
 
     return {
       clinicId,
+      ...(patientId ? { patientId } : {}),
       startsAt: { lte: range.end },
       endsAt: { gte: range.start },
       ...(query.status ? { status: query.status } : {}),
@@ -1887,6 +2024,48 @@ export class PatientPortalService {
           }
         : {}),
     };
+  }
+
+  private async resolvePatientChangeRequestAppointment(
+    clinicId: string,
+    userId: string,
+    appointmentId: string,
+    action: 'cancel' | 'reschedule',
+  ) {
+    const patient = await this.resolvePortalPatient(clinicId, userId);
+    const appointment = await this.prisma.appointment.findFirst({
+      where: {
+        id: appointmentId,
+        clinicId,
+        patientId: patient.id,
+      },
+      include: appointmentScheduleInclude,
+    });
+    if (!appointment) {
+      throw new NotFoundException('Appointment not found');
+    }
+    if (appointment.status !== AppointmentStatus.CONFIRMED) {
+      throw new BadRequestException({
+        code: 'APPOINTMENT_CHANGE_REQUEST_NOT_ALLOWED',
+        message: `Only confirmed appointments can receive patient ${action} requests.`,
+        appointmentId,
+        currentStatus: appointment.status,
+        attemptedAction: action,
+        recoveryAction: 'Refresh appointments and choose an upcoming confirmed appointment.',
+      });
+    }
+    if (appointment.startsAt <= new Date()) {
+      throw new BadRequestException({
+        code: 'APPOINTMENT_CHANGE_REQUEST_TOO_LATE',
+        message: `Patient ${action} requests are only available for future appointments.`,
+        appointmentId,
+        startsAt: appointment.startsAt.toISOString(),
+        attemptedAction: action,
+        recoveryAction: 'Contact the clinic if this appointment already started or passed.',
+      });
+    }
+
+    return { patient, appointment };
   }
 
   private async mutateConfirmedAppointment(params: {
@@ -2239,6 +2418,8 @@ export class PatientPortalService {
             },
           }
         : {}),
+      requestType: request.requestType,
+      sourceAppointmentId: request.sourceAppointmentId ?? null,
       preferredStartDate: request.preferredStartDate.toISOString().slice(0, 10),
       preferredEndDate: request.preferredEndDate.toISOString().slice(0, 10),
       reason: request.reason,
@@ -2252,6 +2433,9 @@ export class PatientPortalService {
       createdAt: request.createdAt.toISOString(),
       updatedAt: request.updatedAt.toISOString(),
       appointment: request.appointment ? this.serializeAppointment(request.appointment) : null,
+      sourceAppointment: request.sourceAppointment
+        ? this.serializeAppointment(request.sourceAppointment)
+        : null,
     };
   }
 
@@ -2468,6 +2652,10 @@ export class PatientPortalService {
       throw new BadRequestException(`${fieldName} must be YYYY-MM-DD`);
     }
     return new Date(`${value}T00:00:00.000Z`);
+  }
+
+  private toDateOnly(value: Date) {
+    return new Date(`${value.toISOString().slice(0, 10)}T00:00:00.000Z`);
   }
 
   private parseDateTime(value: string, fieldName: string) {

--- a/apps/api/src/patient-portal/patient-portal.service.ts
+++ b/apps/api/src/patient-portal/patient-portal.service.ts
@@ -335,8 +335,14 @@ export class PatientPortalService {
     query: ListAppointmentsQueryDto,
   ) {
     const patient = await this.resolvePortalPatient(clinicId, userId);
-    const range = this.resolveAppointmentRange(query);
-    const where = this.buildAppointmentWhere(clinicId, query, range, patient.id);
+    const range = query.from || query.to ? this.resolveAppointmentRange(query) : null;
+    const where: Prisma.AppointmentWhereInput = range
+      ? this.buildAppointmentWhere(clinicId, query, range, patient.id)
+      : {
+          clinicId,
+          patientId: patient.id,
+          ...(query.status ? { status: query.status } : {}),
+        };
     const items = await this.prisma.appointment.findMany({
       where,
       include: appointmentScheduleInclude,
@@ -345,8 +351,8 @@ export class PatientPortalService {
 
     return {
       range: {
-        from: range.from,
-        to: range.to,
+        from: range?.from ?? null,
+        to: range?.to ?? null,
       },
       timezone: 'Africa/Accra',
       summary: this.summarizeAppointments(items),

--- a/apps/api/src/patient-portal/patient-portal.service.ts
+++ b/apps/api/src/patient-portal/patient-portal.service.ts
@@ -290,6 +290,7 @@ export class PatientPortalService {
       data: {
         clinicId: requestClinicId,
         patientId: patient.id,
+        requestType: AppointmentRequestType.NEW_APPOINTMENT,
         preferredStartDate,
         preferredEndDate,
         reason: dto.reason?.trim() || null,

--- a/apps/web/components/portal/AppointmentRequestScreen.tsx
+++ b/apps/web/components/portal/AppointmentRequestScreen.tsx
@@ -15,6 +15,7 @@ import {
   getPortalClinicName,
   type AppointmentRequestRecord,
 } from '@/lib/patient-portal';
+import { getAppointmentRequestTypeLabel } from '@/lib/portal-appointment-status';
 import { RouteGuard } from '@/components/RouteGuard';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -235,7 +236,9 @@ export function AppointmentRequestScreen() {
                   </p>
                   <p className="mt-1 text-sm text-muted-foreground">
                     {latestRequest
-                      ? latestRequest.reason || 'No reason provided'
+                      ? `${getAppointmentRequestTypeLabel(latestRequest.requestType)} - ${
+                          latestRequest.reason || 'No reason provided'
+                        }`
                       : 'Your next request will appear here after submission.'}
                   </p>
                 </div>

--- a/apps/web/components/portal/AppointmentsPortalScreen.tsx
+++ b/apps/web/components/portal/AppointmentsPortalScreen.tsx
@@ -368,13 +368,11 @@ export function AppointmentsPortalScreen() {
     void loadAppointments();
   }, [loadAppointments]);
 
-  const now = useMemo(() => new Date(), [appointments, requests]);
+  const now = new Date();
   const pendingRequestCount = useMemo(() => requests.filter(isPendingRequest).length, [requests]);
-  const upcomingCount = useMemo(
-    () =>
-      appointments.filter((appointment) => isPatientAppointmentActionable(appointment, now)).length,
-    [appointments, now],
-  );
+  const upcomingCount = appointments.filter((appointment) =>
+    isPatientAppointmentActionable(appointment, now),
+  ).length;
   const completedCount = useMemo(
     () => appointments.filter((appointment) => appointment.status === 'COMPLETED').length,
     [appointments],
@@ -386,18 +384,12 @@ export function AppointmentsPortalScreen() {
       ).length,
     [appointments],
   );
-  const nextAppointment = useMemo(
-    () => getNextConfirmedAppointment(appointments, now),
-    [appointments, now],
-  );
+  const nextAppointment = getNextConfirmedAppointment(appointments, now);
   const visibleRequests = useMemo(
     () => getRequestsForTab(requests, activeRequestTab),
     [activeRequestTab, requests],
   );
-  const visibleAppointments = useMemo(
-    () => getAppointmentsForTab(appointments, activeAppointmentTab, now),
-    [activeAppointmentTab, appointments, now],
-  );
+  const visibleAppointments = getAppointmentsForTab(appointments, activeAppointmentTab, now);
   const pendingChangeRequestsByAppointment = useMemo(() => {
     const map = new Map<string, AppointmentRequestRecord>();
     for (const request of requests) {

--- a/apps/web/components/portal/AppointmentsPortalScreen.tsx
+++ b/apps/web/components/portal/AppointmentsPortalScreen.tsx
@@ -1,107 +1,101 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
+  ArrowRight,
   CalendarClock,
   CalendarDays,
   CheckCircle2,
-  CircleSlash,
   Clock3,
   FileClock,
   Plus,
+  RefreshCw,
+  RotateCcw,
+  XCircle,
 } from 'lucide-react';
-import { useAuth } from '@/lib/auth-context';
-import { useBootstrap } from '@/lib/bootstrap-context';
-import {
-  fetchAppointmentRequests,
-  getPortalErrorMessage,
-  formatPortalDate,
-  formatPortalDateTime,
-  getPortalClinicId,
-  getPortalClinicName,
-  isPortalLinkMissingError,
-  type AppointmentRequestRecord,
-} from '@/lib/patient-portal';
+import { InlineErrorState } from '@/components/feedback/AppState';
 import { PortalLinkRequiredState } from '@/components/portal/PortalLinkRequiredState';
 import { RouteGuard } from '@/components/RouteGuard';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Textarea } from '@/components/ui/textarea';
+import { useToast } from '@/components/ui/toast';
+import { useAuth } from '@/lib/auth-context';
+import { useBootstrap } from '@/lib/bootstrap-context';
+import {
+  fetchAppointmentRequests,
+  fetchPatientAppointments,
+  formatPortalDate,
+  formatPortalDateTime,
+  getPortalClinicId,
+  getPortalClinicName,
+  getPortalErrorMessage,
+  isPortalLinkMissingError,
+  requestPatientAppointmentCancellation,
+  requestPatientAppointmentReschedule,
+  type AppointmentRequestRecord,
+  type AppointmentSummary,
+} from '@/lib/patient-portal';
+import {
+  getAppointmentRequestStatusView,
+  getAppointmentRequestTypeLabel,
+  getAppointmentStatusView,
+  getNextConfirmedAppointment,
+  isPatientAppointmentActionable,
+} from '@/lib/portal-appointment-status';
+import { cn } from '@/lib/utils';
 
 type RequestTab = 'all' | 'pending' | 'confirmed' | 'closed';
+type AppointmentTab = 'all' | 'upcoming' | 'completed' | 'closed';
+type ChangeAction = 'cancel' | 'reschedule';
 
-function isPending(request: AppointmentRequestRecord) {
-  return request.status === 'REQUESTED' || request.status === 'TRIAGED';
+interface ChangeDialogState {
+  action: ChangeAction;
+  appointment: AppointmentSummary;
 }
 
-function isClosed(request: AppointmentRequestRecord) {
-  return request.status === 'REJECTED' || request.status === 'CANCELLED';
-}
-
-function getStatusBadgeVariant(
-  status: AppointmentRequestRecord['status'],
-): 'secondary' | 'warning' | 'finalized' | 'destructive' | 'outline' {
-  switch (status) {
-    case 'REQUESTED':
-      return 'secondary';
-    case 'TRIAGED':
-      return 'warning';
-    case 'CONFIRMED':
-      return 'finalized';
-    case 'REJECTED':
-      return 'destructive';
-    case 'CANCELLED':
-      return 'outline';
-  }
-}
-
-function getStatusLabel(status: AppointmentRequestRecord['status']) {
-  switch (status) {
-    case 'REQUESTED':
-      return 'Requested';
-    case 'TRIAGED':
-      return 'Under review';
-    case 'CONFIRMED':
-      return 'Confirmed';
-    case 'REJECTED':
-      return 'Not approved';
-    case 'CANCELLED':
-      return 'Cancelled';
-  }
+function isPendingRequest(request: AppointmentRequestRecord) {
+  return getAppointmentRequestStatusView(request.status).category === 'pending';
 }
 
 function getRequestsForTab(requests: AppointmentRequestRecord[], tab: RequestTab) {
-  switch (tab) {
-    case 'pending':
-      return requests.filter(isPending);
-    case 'confirmed':
-      return requests.filter((request) => request.status === 'CONFIRMED');
-    case 'closed':
-      return requests.filter(isClosed);
-    case 'all':
-    default:
-      return requests;
-  }
+  if (tab === 'all') return requests;
+  return requests.filter(
+    (request) => getAppointmentRequestStatusView(request.status).category === tab,
+  );
 }
 
-function getNextAppointment(requests: AppointmentRequestRecord[]) {
-  const now = Date.now();
-  return (
-    requests
-      .map((request) => request.appointment)
-      .filter((appointment): appointment is NonNullable<AppointmentRequestRecord['appointment']> =>
-        Boolean(appointment),
-      )
-      .filter(
-        (appointment) =>
-          appointment.status === 'CONFIRMED' && new Date(appointment.startsAt).getTime() >= now,
-      )
-      .sort(
-        (left, right) => new Date(left.startsAt).getTime() - new Date(right.startsAt).getTime(),
-      )[0] ?? null
-  );
+function getAppointmentsForTab(appointments: AppointmentSummary[], tab: AppointmentTab, now: Date) {
+  switch (tab) {
+    case 'upcoming':
+      return appointments
+        .filter((appointment) => isPatientAppointmentActionable(appointment, now))
+        .sort(
+          (left, right) => new Date(left.startsAt).getTime() - new Date(right.startsAt).getTime(),
+        );
+    case 'completed':
+      return appointments.filter((appointment) => appointment.status === 'COMPLETED');
+    case 'closed':
+      return appointments.filter(
+        (appointment) => appointment.status === 'CANCELLED' || appointment.status === 'NO_SHOW',
+      );
+    case 'all':
+    default:
+      return appointments;
+  }
 }
 
 function getRequestWindow(request: AppointmentRequestRecord) {
@@ -113,64 +107,389 @@ function getRequestWindow(request: AppointmentRequestRecord) {
   )}`;
 }
 
+function toDateInput(value: string) {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return '';
+  return parsed.toISOString().slice(0, 10);
+}
+
+function addDaysToDateInput(value: string, days: number) {
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  parsed.setUTCDate(parsed.getUTCDate() + days);
+  return parsed.toISOString().slice(0, 10);
+}
+
+function EmptyPanel({
+  icon: Icon,
+  title,
+  description,
+}: {
+  icon: typeof FileClock;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="flex min-h-[220px] flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-border/70 bg-muted/20 px-6 text-center">
+      <Icon className="h-6 w-6 text-muted-foreground" />
+      <div className="space-y-1">
+        <p className="font-medium">{title}</p>
+        <p className="max-w-md text-sm leading-6 text-muted-foreground">{description}</p>
+      </div>
+    </div>
+  );
+}
+
+function AppointmentRow({
+  appointment,
+  pendingChangeRequest,
+  onAction,
+}: {
+  appointment: AppointmentSummary;
+  pendingChangeRequest?: AppointmentRequestRecord;
+  onAction: (action: ChangeAction, appointment: AppointmentSummary) => void;
+}) {
+  const statusView = getAppointmentStatusView(appointment.status);
+  const actionable = isPatientAppointmentActionable(appointment) && !pendingChangeRequest;
+
+  return (
+    <article className="rounded-2xl border border-border/70 bg-background/80 p-4 transition-colors hover:bg-muted/20">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0 space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge
+              variant={statusView.badgeVariant}
+              aria-label={`${statusView.label}: ${statusView.description}`}
+              className="rounded-full"
+            >
+              {statusView.label}
+            </Badge>
+            {pendingChangeRequest ? (
+              <Badge variant="warning" className="rounded-full">
+                {getAppointmentRequestTypeLabel(pendingChangeRequest.requestType)} pending
+              </Badge>
+            ) : null}
+          </div>
+          <div>
+            <p className="font-medium text-foreground">
+              {formatPortalDateTime(appointment.startsAt)}
+            </p>
+            <p className="text-sm text-muted-foreground">
+              Ends {formatPortalDateTime(appointment.endsAt)}
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground">
+            <span>Doctor: {appointment.assignedDoctor?.displayName ?? 'Unassigned'}</span>
+            <span>Volunteer: {appointment.assignedVolunteer?.displayName ?? 'Unassigned'}</span>
+          </div>
+          {appointment.notes ? (
+            <p className="max-w-2xl text-sm leading-6 text-muted-foreground">{appointment.notes}</p>
+          ) : null}
+        </div>
+
+        <div className="flex flex-col gap-2 sm:flex-row lg:flex-col">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="cursor-pointer justify-start"
+            disabled={!actionable}
+            onClick={() => onAction('reschedule', appointment)}
+          >
+            <RotateCcw className="h-4 w-4" />
+            Request reschedule
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="cursor-pointer justify-start text-destructive hover:text-destructive"
+            disabled={!actionable}
+            onClick={() => onAction('cancel', appointment)}
+          >
+            <XCircle className="h-4 w-4" />
+            Request cancellation
+          </Button>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function RequestRow({ request }: { request: AppointmentRequestRecord }) {
+  const statusView = getAppointmentRequestStatusView(request.status);
+  const typeLabel = getAppointmentRequestTypeLabel(request.requestType);
+
+  return (
+    <article className="rounded-2xl border border-border/70 bg-background/80 p-4 transition-colors hover:bg-muted/20">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="outline" className="rounded-full bg-card">
+              {typeLabel}
+            </Badge>
+            <Badge
+              variant={statusView.badgeVariant}
+              aria-label={`${statusView.label}: ${statusView.description}`}
+              className="rounded-full"
+            >
+              {statusView.label}
+            </Badge>
+          </div>
+          <p className="font-medium text-foreground">
+            Preferred window: {getRequestWindow(request)}
+          </p>
+          <p className="text-sm text-muted-foreground">
+            Submitted {formatPortalDate(request.createdAt)}
+          </p>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          {request.triagedAt ? `Updated ${formatPortalDate(request.triagedAt)}` : 'Awaiting review'}
+        </p>
+      </div>
+
+      <div className="mt-4 grid gap-4 lg:grid-cols-[1fr_1fr]">
+        <div className="space-y-3">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              Reason
+            </p>
+            <p className="mt-2 text-sm">{request.reason || 'No reason provided'}</p>
+          </div>
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              Notes
+            </p>
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">
+              {request.notes || 'No notes were added to this request.'}
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          {request.sourceAppointment ? (
+            <div className="rounded-2xl border border-border/70 bg-muted/20 p-4">
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                Related appointment
+              </p>
+              <p className="mt-2 text-sm font-medium">
+                {formatPortalDateTime(request.sourceAppointment.startsAt)}
+              </p>
+              <p className="text-sm text-muted-foreground">
+                Status: {getAppointmentStatusView(request.sourceAppointment.status).label}
+              </p>
+            </div>
+          ) : null}
+
+          {request.appointment ? (
+            <div className="rounded-2xl border border-emerald-200 bg-emerald-50/70 p-4">
+              <div className="flex items-center gap-2">
+                <CalendarDays className="h-4 w-4 text-emerald-700" />
+                <p className="font-medium text-emerald-950">Confirmed visit</p>
+              </div>
+              <p className="mt-2 text-sm text-emerald-950">
+                {formatPortalDateTime(request.appointment.startsAt)}
+              </p>
+              <p className="text-sm text-emerald-900/80">
+                Ends {formatPortalDateTime(request.appointment.endsAt)}
+              </p>
+            </div>
+          ) : null}
+
+          {request.rejectionReason ? (
+            <div className="rounded-2xl border border-destructive/20 bg-destructive/5 p-4">
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-destructive">
+                Clinic note
+              </p>
+              <p className="mt-2 text-sm text-destructive">{request.rejectionReason}</p>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </article>
+  );
+}
+
 export function AppointmentsPortalScreen() {
   const getToken = useAuth();
   const bootstrap = useBootstrap()?.bootstrap ?? null;
   const clinicId = getPortalClinicId(bootstrap);
   const clinicName = getPortalClinicName(bootstrap, clinicId);
+  const { showToast } = useToast();
 
   const [requests, setRequests] = useState<AppointmentRequestRecord[]>([]);
-  const [activeTab, setActiveTab] = useState<RequestTab>('all');
+  const [appointments, setAppointments] = useState<AppointmentSummary[]>([]);
+  const [activeRequestTab, setActiveRequestTab] = useState<RequestTab>('all');
+  const [activeAppointmentTab, setActiveAppointmentTab] = useState<AppointmentTab>('all');
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<unknown | null>(null);
+  const [changeDialog, setChangeDialog] = useState<ChangeDialogState | null>(null);
+  const [cancelReason, setCancelReason] = useState('');
+  const [cancelNotes, setCancelNotes] = useState('');
+  const [rescheduleStartDate, setRescheduleStartDate] = useState('');
+  const [rescheduleEndDate, setRescheduleEndDate] = useState('');
+  const [rescheduleReason, setRescheduleReason] = useState('');
+  const [rescheduleNotes, setRescheduleNotes] = useState('');
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [submittingAction, setSubmittingAction] = useState(false);
 
-  useEffect(() => {
-    let cancelled = false;
-
-    async function load() {
+  const loadAppointments = useCallback(
+    async (options?: { background?: boolean }) => {
       if (!clinicId || !getToken) {
         setLoading(false);
         return;
       }
 
-      setLoading(true);
+      if (options?.background) {
+        setRefreshing(true);
+      } else {
+        setLoading(true);
+      }
       setError(null);
+
       try {
-        const response = await fetchAppointmentRequests(clinicId, getToken);
-        if (!cancelled) {
-          setRequests(response);
-        }
+        const [requestResponse, appointmentResponse] = await Promise.all([
+          fetchAppointmentRequests(clinicId, getToken),
+          fetchPatientAppointments(clinicId, getToken),
+        ]);
+        setRequests(requestResponse);
+        setAppointments(appointmentResponse.items);
       } catch (err) {
-        if (!cancelled) {
-          setError(err);
-        }
+        setError(err);
       } finally {
-        if (!cancelled) {
-          setLoading(false);
-        }
+        setLoading(false);
+        setRefreshing(false);
+      }
+    },
+    [clinicId, getToken],
+  );
+
+  useEffect(() => {
+    void loadAppointments();
+  }, [loadAppointments]);
+
+  const now = useMemo(() => new Date(), [appointments, requests]);
+  const pendingRequestCount = useMemo(() => requests.filter(isPendingRequest).length, [requests]);
+  const upcomingCount = useMemo(
+    () =>
+      appointments.filter((appointment) => isPatientAppointmentActionable(appointment, now)).length,
+    [appointments, now],
+  );
+  const completedCount = useMemo(
+    () => appointments.filter((appointment) => appointment.status === 'COMPLETED').length,
+    [appointments],
+  );
+  const closedCount = useMemo(
+    () =>
+      appointments.filter(
+        (appointment) => appointment.status === 'CANCELLED' || appointment.status === 'NO_SHOW',
+      ).length,
+    [appointments],
+  );
+  const nextAppointment = useMemo(
+    () => getNextConfirmedAppointment(appointments, now),
+    [appointments, now],
+  );
+  const visibleRequests = useMemo(
+    () => getRequestsForTab(requests, activeRequestTab),
+    [activeRequestTab, requests],
+  );
+  const visibleAppointments = useMemo(
+    () => getAppointmentsForTab(appointments, activeAppointmentTab, now),
+    [activeAppointmentTab, appointments, now],
+  );
+  const pendingChangeRequestsByAppointment = useMemo(() => {
+    const map = new Map<string, AppointmentRequestRecord>();
+    for (const request of requests) {
+      if (
+        request.sourceAppointmentId &&
+        request.requestType !== 'NEW_APPOINTMENT' &&
+        isPendingRequest(request)
+      ) {
+        map.set(request.sourceAppointmentId, request);
       }
     }
-
-    load();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [clinicId, getToken]);
-
-  const pendingCount = useMemo(() => requests.filter(isPending).length, [requests]);
-  const confirmedCount = useMemo(
-    () => requests.filter((request) => request.status === 'CONFIRMED').length,
-    [requests],
-  );
-  const closedCount = useMemo(() => requests.filter(isClosed).length, [requests]);
-  const nextAppointment = useMemo(() => getNextAppointment(requests), [requests]);
-  const visibleRequests = useMemo(
-    () => getRequestsForTab(requests, activeTab),
-    [activeTab, requests],
-  );
+    return map;
+  }, [requests]);
   const isLinkMissing = isPortalLinkMissingError(error);
   const errorMessage = error ? getPortalErrorMessage(error) : null;
+
+  function openChangeDialog(action: ChangeAction, appointment: AppointmentSummary) {
+    setChangeDialog({ action, appointment });
+    setActionError(null);
+    setCancelReason('');
+    setCancelNotes('');
+    const startDate = toDateInput(appointment.startsAt);
+    setRescheduleStartDate(startDate);
+    setRescheduleEndDate(startDate ? addDaysToDateInput(startDate, 7) : '');
+    setRescheduleReason('');
+    setRescheduleNotes('');
+  }
+
+  function closeChangeDialog() {
+    if (submittingAction) return;
+    setChangeDialog(null);
+    setActionError(null);
+  }
+
+  async function submitChangeRequest() {
+    if (!clinicId || !getToken || !changeDialog) return;
+
+    setActionError(null);
+    setSubmittingAction(true);
+
+    try {
+      if (changeDialog.action === 'cancel') {
+        const reason = cancelReason.trim();
+        if (!reason) {
+          setActionError('Add a cancellation reason before submitting.');
+          return;
+        }
+        await requestPatientAppointmentCancellation(
+          clinicId,
+          changeDialog.appointment.id,
+          getToken,
+          {
+            reason,
+            notes: cancelNotes.trim() || undefined,
+          },
+        );
+      } else {
+        if (!rescheduleStartDate || !rescheduleEndDate) {
+          setActionError('Choose a preferred start and end date.');
+          return;
+        }
+        if (rescheduleEndDate < rescheduleStartDate) {
+          setActionError('Preferred end date must be on or after the start date.');
+          return;
+        }
+        await requestPatientAppointmentReschedule(clinicId, changeDialog.appointment.id, getToken, {
+          preferredStartDate: rescheduleStartDate,
+          preferredEndDate: rescheduleEndDate,
+          reason: rescheduleReason.trim() || undefined,
+          notes: rescheduleNotes.trim() || undefined,
+        });
+      }
+
+      showToast({
+        title: 'Request sent',
+        description: 'Your clinic can now review this appointment request.',
+        tone: 'success',
+      });
+      setChangeDialog(null);
+      await loadAppointments({ background: true });
+    } catch (err) {
+      const message = getPortalErrorMessage(err);
+      setActionError(message);
+      showToast({
+        title: 'Request could not be sent',
+        description: message,
+        tone: 'error',
+      });
+    } finally {
+      setSubmittingAction(false);
+    }
+  }
 
   if (isLinkMissing && !loading) {
     return (
@@ -185,52 +504,58 @@ export function AppointmentsPortalScreen() {
   return (
     <RouteGuard requiredPermission="PATIENT.PORTAL.READ_SELF">
       <div className="space-y-6">
-        <section className="grid gap-4 lg:grid-cols-[1.2fr_0.8fr]">
-          <Card className="overflow-hidden border-border/70 bg-gradient-to-br from-card via-card to-primary/10">
+        <section className="grid gap-4 xl:grid-cols-[1.15fr_0.85fr]">
+          <Card className="overflow-hidden border-border/70 bg-card/95 shadow-sm">
             <CardHeader className="space-y-4">
               <div className="flex flex-wrap items-center gap-2">
                 <Badge variant="secondary" className="rounded-full px-3 py-1">
                   Appointment center
                 </Badge>
-                {clinicName && (
+                {clinicName ? (
                   <Badge variant="outline" className="rounded-full bg-background/80 px-3 py-1">
                     {clinicName}
                   </Badge>
-                )}
+                ) : null}
               </div>
               <div className="space-y-2">
-                <CardTitle className="text-2xl md:text-3xl">
-                  Keep visit requests and confirmed appointments in one place.
-                </CardTitle>
-                <CardDescription className="max-w-2xl text-sm md:text-base">
-                  Review the status of every request, see your confirmed visit details, and submit a
-                  new scheduling request whenever you need support.
+                <CardTitle className="text-2xl md:text-3xl">Appointments and requests</CardTitle>
+                <CardDescription className="max-w-2xl text-sm leading-6 md:text-base">
+                  Review scheduled visits, previous outcomes, and requests your clinic is triaging.
                 </CardDescription>
               </div>
             </CardHeader>
             <CardContent className="flex flex-wrap gap-3">
-              <Button asChild>
+              <Button asChild className="cursor-pointer">
                 <Link href="/portal/appointments/request">
                   <Plus className="h-4 w-4" />
                   Request a visit
                 </Link>
               </Button>
-              <Button asChild variant="outline">
-                <Link href="/portal/health">Review my health trends</Link>
+              <Button
+                type="button"
+                variant="outline"
+                className="cursor-pointer"
+                onClick={() => void loadAppointments({ background: true })}
+                disabled={refreshing || loading}
+              >
+                <RefreshCw className={cn('h-4 w-4', refreshing && 'animate-spin')} />
+                Refresh
               </Button>
             </CardContent>
           </Card>
 
-          <Card className="border-border/70 bg-card/95">
+          <Card className="border-border/70 bg-card/95 shadow-sm">
             <CardHeader>
               <CardTitle className="text-lg">Next confirmed visit</CardTitle>
               <CardDescription>
-                Your clinic confirms the exact date and time once a request is approved.
+                {nextAppointment
+                  ? 'Your next active appointment on the clinic schedule.'
+                  : 'No future confirmed appointment is currently scheduled.'}
               </CardDescription>
             </CardHeader>
             <CardContent>
               {nextAppointment ? (
-                <div className="space-y-4 rounded-2xl border border-border/70 bg-background/70 p-4">
+                <div className="space-y-4 rounded-2xl border border-border/70 bg-background/80 p-4">
                   <div className="flex items-start justify-between gap-3">
                     <div>
                       <p className="font-medium">
@@ -240,99 +565,150 @@ export function AppointmentsPortalScreen() {
                         Ends {formatPortalDateTime(nextAppointment.endsAt)}
                       </p>
                     </div>
-                    <Badge variant="finalized" className="rounded-full">
+                    <Badge variant="secondary" className="rounded-full">
                       Confirmed
                     </Badge>
                   </div>
-                  {nextAppointment.notes && (
-                    <p className="text-sm text-muted-foreground">{nextAppointment.notes}</p>
-                  )}
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="w-full cursor-pointer justify-between"
+                    onClick={() => openChangeDialog('reschedule', nextAppointment)}
+                    disabled={Boolean(pendingChangeRequestsByAppointment.get(nextAppointment.id))}
+                  >
+                    Request a change
+                    <ArrowRight className="h-4 w-4" />
+                  </Button>
                 </div>
               ) : (
                 <div className="rounded-2xl border border-dashed border-border/70 bg-muted/20 p-5 text-sm text-muted-foreground">
-                  No confirmed visit is scheduled yet.
+                  Request a visit when you need a follow-up or check-in.
                 </div>
               )}
             </CardContent>
           </Card>
         </section>
 
-        <section className="grid gap-4 md:grid-cols-3">
+        <section className="grid gap-4 md:grid-cols-4">
           <Card className="border-border/70 bg-card/95">
             <CardHeader className="space-y-3">
-              <div className="flex items-center justify-between">
-                <Clock3 className="h-5 w-5 text-primary" />
-                <Badge variant="secondary" className="rounded-full">
-                  Pending
-                </Badge>
-              </div>
+              <CalendarClock className="h-5 w-5 text-primary" />
               <div>
-                <CardTitle className="text-2xl">{pendingCount}</CardTitle>
-                <CardDescription>Requests waiting for clinic review or scheduling.</CardDescription>
+                <CardTitle className="text-2xl">{upcomingCount}</CardTitle>
+                <CardDescription>Upcoming confirmed</CardDescription>
               </div>
             </CardHeader>
           </Card>
-
           <Card className="border-border/70 bg-card/95">
             <CardHeader className="space-y-3">
-              <div className="flex items-center justify-between">
-                <CheckCircle2 className="h-5 w-5 text-emerald-600" />
-                <Badge variant="finalized" className="rounded-full">
-                  Confirmed
-                </Badge>
-              </div>
+              <FileClock className="h-5 w-5 text-primary" />
               <div>
-                <CardTitle className="text-2xl">{confirmedCount}</CardTitle>
-                <CardDescription>Requests that have turned into scheduled visits.</CardDescription>
+                <CardTitle className="text-2xl">{pendingRequestCount}</CardTitle>
+                <CardDescription>Requests pending</CardDescription>
               </div>
             </CardHeader>
           </Card>
-
           <Card className="border-border/70 bg-card/95">
             <CardHeader className="space-y-3">
-              <div className="flex items-center justify-between">
-                <CircleSlash className="h-5 w-5 text-destructive" />
-                <Badge variant="outline" className="rounded-full">
-                  Closed
-                </Badge>
+              <CheckCircle2 className="h-5 w-5 text-emerald-600" />
+              <div>
+                <CardTitle className="text-2xl">{completedCount}</CardTitle>
+                <CardDescription>Completed visits</CardDescription>
               </div>
+            </CardHeader>
+          </Card>
+          <Card className="border-border/70 bg-card/95">
+            <CardHeader className="space-y-3">
+              <Clock3 className="h-5 w-5 text-muted-foreground" />
               <div>
                 <CardTitle className="text-2xl">{closedCount}</CardTitle>
-                <CardDescription>
-                  Requests that were closed, declined, or cancelled.
-                </CardDescription>
+                <CardDescription>Cancelled or no-show</CardDescription>
               </div>
             </CardHeader>
           </Card>
         </section>
 
-        {loading && (
-          <div className="grid gap-4 md:grid-cols-2">
-            {Array.from({ length: 2 }).map((_, index) => (
+        {loading ? (
+          <div className="grid gap-4 lg:grid-cols-2">
+            {Array.from({ length: 4 }).map((_, index) => (
               <Card key={index} className="h-40 animate-pulse border-border/70 bg-muted/30" />
             ))}
           </div>
-        )}
-
-        {error ? (
-          <div className="rounded-2xl border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
-            {errorMessage}
-          </div>
         ) : null}
 
-        {!loading && !error && (
-          <section className="grid gap-4 lg:grid-cols-[1.25fr_0.75fr]">
-            <Card className="border-border/70 bg-card/95">
+        {error ? (
+          <InlineErrorState
+            title="Appointments could not load"
+            description={errorMessage ?? 'Check your connection and try again.'}
+            onRetry={() => void loadAppointments()}
+            retryLabel="Reload appointments"
+          />
+        ) : null}
+
+        {!loading && !error ? (
+          <section className="grid gap-4 xl:grid-cols-[1.1fr_0.9fr]">
+            <Card className="border-border/70 bg-card/95 shadow-sm">
+              <CardHeader>
+                <CardTitle className="text-lg">Confirmed appointment history</CardTitle>
+                <CardDescription>
+                  Scheduled visits across upcoming, completed, cancelled, and missed outcomes.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <Tabs
+                  value={activeAppointmentTab}
+                  onValueChange={(value) => setActiveAppointmentTab(value as AppointmentTab)}
+                >
+                  <TabsList className="grid h-auto w-full grid-cols-2 gap-2 rounded-2xl border border-border/70 bg-background p-2 md:grid-cols-4">
+                    <TabsTrigger value="all" className="rounded-xl">
+                      All
+                    </TabsTrigger>
+                    <TabsTrigger value="upcoming" className="rounded-xl">
+                      Upcoming
+                    </TabsTrigger>
+                    <TabsTrigger value="completed" className="rounded-xl">
+                      Completed
+                    </TabsTrigger>
+                    <TabsTrigger value="closed" className="rounded-xl">
+                      Closed
+                    </TabsTrigger>
+                  </TabsList>
+                </Tabs>
+
+                {visibleAppointments.length === 0 ? (
+                  <EmptyPanel
+                    icon={CalendarDays}
+                    title="No appointments in this view"
+                    description="Confirmed appointments and past outcomes will appear here after your clinic schedules them."
+                  />
+                ) : (
+                  <div className="space-y-3">
+                    {visibleAppointments.map((appointment) => (
+                      <AppointmentRow
+                        key={appointment.id}
+                        appointment={appointment}
+                        pendingChangeRequest={pendingChangeRequestsByAppointment.get(
+                          appointment.id,
+                        )}
+                        onAction={openChangeDialog}
+                      />
+                    ))}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card className="border-border/70 bg-card/95 shadow-sm">
               <CardHeader>
                 <CardTitle className="text-lg">Request history</CardTitle>
                 <CardDescription>
-                  Track your preferred dates, clinic decisions, and confirmed appointments.
+                  New visit, cancellation, and reschedule requests your clinic can triage.
                 </CardDescription>
               </CardHeader>
-              <CardContent>
+              <CardContent className="space-y-4">
                 <Tabs
-                  value={activeTab}
-                  onValueChange={(value) => setActiveTab(value as RequestTab)}
+                  value={activeRequestTab}
+                  onValueChange={(value) => setActiveRequestTab(value as RequestTab)}
                 >
                   <TabsList className="grid h-auto w-full grid-cols-2 gap-2 rounded-2xl border border-border/70 bg-background p-2 md:grid-cols-4">
                     <TabsTrigger value="all" className="rounded-xl">
@@ -348,171 +724,156 @@ export function AppointmentsPortalScreen() {
                       Closed
                     </TabsTrigger>
                   </TabsList>
-
-                  <TabsContent value={activeTab} className="mt-4">
-                    {visibleRequests.length === 0 ? (
-                      <div className="flex min-h-[240px] flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-border/70 bg-muted/20 px-6 text-center">
-                        <FileClock className="h-6 w-6 text-muted-foreground" />
-                        <div className="space-y-1">
-                          <p className="font-medium">No requests in this view</p>
-                          <p className="text-sm text-muted-foreground">
-                            Submit a new appointment request when you need a follow-up or check-in.
-                          </p>
-                        </div>
-                      </div>
-                    ) : (
-                      <div className="space-y-3">
-                        {visibleRequests.map((request) => (
-                          <div
-                            key={request.id}
-                            className="rounded-2xl border border-border/70 bg-background/70 p-4"
-                          >
-                            <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-                              <div className="space-y-2">
-                                <div className="flex flex-wrap items-center gap-2">
-                                  <Badge
-                                    variant={getStatusBadgeVariant(request.status)}
-                                    className="rounded-full"
-                                  >
-                                    {getStatusLabel(request.status)}
-                                  </Badge>
-                                  <span className="text-sm font-medium">
-                                    Preferred window: {getRequestWindow(request)}
-                                  </span>
-                                </div>
-                                <p className="text-sm text-muted-foreground">
-                                  Submitted {formatPortalDate(request.createdAt)}
-                                </p>
-                              </div>
-                              <div className="text-sm text-muted-foreground">
-                                {request.triagedAt
-                                  ? `Updated ${formatPortalDate(request.triagedAt)}`
-                                  : 'Awaiting review'}
-                              </div>
-                            </div>
-
-                            <div className="mt-4 grid gap-4 md:grid-cols-[1fr_1fr]">
-                              <div className="space-y-3">
-                                <div>
-                                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                                    Visit reason
-                                  </p>
-                                  <p className="mt-2 text-sm">
-                                    {request.reason || 'No reason provided'}
-                                  </p>
-                                </div>
-                                <div>
-                                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                                    Notes
-                                  </p>
-                                  <p className="mt-2 text-sm text-muted-foreground">
-                                    {request.notes || 'No notes were added to this request.'}
-                                  </p>
-                                </div>
-                              </div>
-
-                              <div className="space-y-3">
-                                {request.appointment ? (
-                                  <div className="rounded-2xl border border-emerald-200 bg-emerald-50/60 p-4">
-                                    <div className="flex items-center gap-2">
-                                      <CalendarDays className="h-4 w-4 text-emerald-700" />
-                                      <p className="font-medium text-emerald-900">
-                                        Confirmed visit
-                                      </p>
-                                    </div>
-                                    <p className="mt-2 text-sm text-emerald-900">
-                                      {formatPortalDateTime(request.appointment.startsAt)}
-                                    </p>
-                                    <p className="text-sm text-emerald-800/80">
-                                      Ends {formatPortalDateTime(request.appointment.endsAt)}
-                                    </p>
-                                    {request.appointment.notes && (
-                                      <p className="mt-2 text-sm text-emerald-800/80">
-                                        {request.appointment.notes}
-                                      </p>
-                                    )}
-                                  </div>
-                                ) : (
-                                  <div className="rounded-2xl border border-dashed border-border/70 bg-muted/20 p-4 text-sm text-muted-foreground">
-                                    The clinic has not attached a confirmed visit to this request
-                                    yet.
-                                  </div>
-                                )}
-
-                                {request.rejectionReason && (
-                                  <div className="rounded-2xl border border-destructive/20 bg-destructive/5 p-4">
-                                    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-destructive">
-                                      Clinic note
-                                    </p>
-                                    <p className="mt-2 text-sm text-destructive">
-                                      {request.rejectionReason}
-                                    </p>
-                                  </div>
-                                )}
-                              </div>
-                            </div>
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                  </TabsContent>
                 </Tabs>
+
+                {visibleRequests.length === 0 ? (
+                  <EmptyPanel
+                    icon={FileClock}
+                    title="No requests in this view"
+                    description="Appointment requests will appear here after you send them to your clinic."
+                  />
+                ) : (
+                  <div className="space-y-3">
+                    {visibleRequests.map((request) => (
+                      <RequestRow key={request.id} request={request} />
+                    ))}
+                  </div>
+                )}
               </CardContent>
             </Card>
-
-            <div className="space-y-4">
-              <Card className="border-border/70 bg-card/95">
-                <CardHeader>
-                  <CardTitle className="text-lg">How scheduling works</CardTitle>
-                  <CardDescription>
-                    A quick guide to what happens after you submit a request.
-                  </CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <div className="rounded-2xl border border-border/70 bg-background/70 p-4">
-                    <p className="font-medium">1. Share your preferred dates</p>
-                    <p className="mt-2 text-sm text-muted-foreground">
-                      Pick the days that work best and tell your clinic why you need a visit.
-                    </p>
-                  </div>
-                  <div className="rounded-2xl border border-border/70 bg-background/70 p-4">
-                    <p className="font-medium">2. Clinic review</p>
-                    <p className="mt-2 text-sm text-muted-foreground">
-                      Staff review your request and may add scheduling notes or confirm a specific
-                      slot.
-                    </p>
-                  </div>
-                  <div className="rounded-2xl border border-border/70 bg-background/70 p-4">
-                    <p className="font-medium">3. Confirmation and reminder</p>
-                    <p className="mt-2 text-sm text-muted-foreground">
-                      Once confirmed, your appointment details appear here and reminder messages are
-                      scheduled automatically.
-                    </p>
-                  </div>
-                </CardContent>
-              </Card>
-
-              <Card className="border-border/70 bg-gradient-to-br from-secondary/10 via-card to-card">
-                <CardHeader>
-                  <CardTitle className="text-lg">Need a new visit?</CardTitle>
-                  <CardDescription>
-                    Start a new request with your preferred timing and a short description of what
-                    you need.
-                  </CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <Button asChild className="w-full justify-between">
-                    <Link href="/portal/appointments/request">
-                      Request an appointment
-                      <CalendarClock className="h-4 w-4" />
-                    </Link>
-                  </Button>
-                </CardContent>
-              </Card>
-            </div>
           </section>
-        )}
+        ) : null}
       </div>
+
+      <Dialog
+        open={changeDialog !== null}
+        onOpenChange={(open) => {
+          if (!open) closeChangeDialog();
+        }}
+      >
+        <DialogContent className="max-w-xl rounded-[28px] border-border/80">
+          <DialogHeader>
+            <DialogTitle className="text-2xl">
+              {changeDialog?.action === 'cancel' ? 'Request cancellation' : 'Request reschedule'}
+            </DialogTitle>
+            <DialogDescription className="leading-6">
+              {changeDialog
+                ? formatPortalDateTime(changeDialog.appointment.startsAt)
+                : 'Appointment request'}
+            </DialogDescription>
+          </DialogHeader>
+
+          {changeDialog?.action === 'cancel' ? (
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="cancel-reason">Cancellation reason</Label>
+                <Input
+                  id="cancel-reason"
+                  value={cancelReason}
+                  onChange={(event) => setCancelReason(event.target.value)}
+                  maxLength={120}
+                  disabled={submittingAction}
+                  placeholder="Example: I cannot attend this visit"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="cancel-notes">Additional notes</Label>
+                <Textarea
+                  id="cancel-notes"
+                  value={cancelNotes}
+                  onChange={(event) => setCancelNotes(event.target.value)}
+                  rows={4}
+                  maxLength={2000}
+                  disabled={submittingAction}
+                  placeholder="Optional details for your clinic"
+                />
+              </div>
+            </div>
+          ) : null}
+
+          {changeDialog?.action === 'reschedule' ? (
+            <div className="space-y-4">
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="reschedule-start">Preferred start date</Label>
+                  <Input
+                    id="reschedule-start"
+                    type="date"
+                    value={rescheduleStartDate}
+                    onChange={(event) => {
+                      const nextValue = event.target.value;
+                      setRescheduleStartDate(nextValue);
+                      if (rescheduleEndDate && rescheduleEndDate < nextValue) {
+                        setRescheduleEndDate(nextValue);
+                      }
+                    }}
+                    disabled={submittingAction}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="reschedule-end">Preferred end date</Label>
+                  <Input
+                    id="reschedule-end"
+                    type="date"
+                    value={rescheduleEndDate}
+                    min={rescheduleStartDate}
+                    onChange={(event) => setRescheduleEndDate(event.target.value)}
+                    disabled={submittingAction}
+                  />
+                </div>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="reschedule-reason">Reason</Label>
+                <Input
+                  id="reschedule-reason"
+                  value={rescheduleReason}
+                  onChange={(event) => setRescheduleReason(event.target.value)}
+                  maxLength={120}
+                  disabled={submittingAction}
+                  placeholder="Example: need a morning appointment"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="reschedule-notes">Additional notes</Label>
+                <Textarea
+                  id="reschedule-notes"
+                  value={rescheduleNotes}
+                  onChange={(event) => setRescheduleNotes(event.target.value)}
+                  rows={4}
+                  maxLength={2000}
+                  disabled={submittingAction}
+                  placeholder="Optional availability details"
+                />
+              </div>
+            </div>
+          ) : null}
+
+          {actionError ? (
+            <div className="rounded-2xl border border-destructive/25 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+              {actionError}
+            </div>
+          ) : null}
+
+          <DialogFooter className="mt-2 gap-2 sm:gap-0">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={closeChangeDialog}
+              disabled={submittingAction}
+            >
+              Keep visit unchanged
+            </Button>
+            <Button
+              type="button"
+              onClick={() => void submitChangeRequest()}
+              disabled={submittingAction}
+              variant={changeDialog?.action === 'cancel' ? 'destructive' : 'default'}
+            >
+              {submittingAction ? 'Sending...' : 'Send request'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </RouteGuard>
   );
 }

--- a/apps/web/lib/patient-portal.test.ts
+++ b/apps/web/lib/patient-portal.test.ts
@@ -2,12 +2,16 @@ import {
   cancelStaffAppointment,
   completeStaffAppointment,
   fetchAppointmentStaffOptions,
+  fetchPatientAppointments,
   fetchPatientTrends,
   fetchStaffAppointments,
   fetchStaffPatientTrends,
   markStaffAppointmentNoShow,
+  requestPatientAppointmentCancellation,
+  requestPatientAppointmentReschedule,
   rescheduleStaffAppointment,
   type AppointmentStaffOptionsResponse,
+  type PatientAppointmentsResponse,
   type PatientTrendsResponse,
   type StaffAppointmentRecord,
   type StaffAppointmentsResponse,
@@ -38,6 +42,34 @@ const appointmentsResponse: StaffAppointmentsResponse = {
   items: [],
 };
 
+const patientAppointmentsResponse: PatientAppointmentsResponse = {
+  range: { from: '2026-03-01', to: '2026-03-31' },
+  timezone: 'Africa/Accra',
+  summary: {
+    total: 1,
+    confirmed: 1,
+    cancelled: 0,
+    completed: 0,
+    noShow: 0,
+  },
+  items: [
+    {
+      id: 'appointment-1',
+      clinicId: 'clinic-2',
+      patientId: 'patient-1',
+      startsAt: '2026-03-26T14:00:00.000Z',
+      endsAt: '2026-03-26T14:30:00.000Z',
+      status: 'CONFIRMED',
+      linkedRequestId: 'appt-req-1',
+      assignedDoctor: null,
+      assignedVolunteer: null,
+      notes: null,
+      createdAt: '2026-03-21T09:00:00.000Z',
+      updatedAt: '2026-03-21T09:00:00.000Z',
+    },
+  ],
+};
+
 const staffOptionsResponse: AppointmentStaffOptionsResponse = {
   doctors: [],
   volunteers: [],
@@ -63,6 +95,26 @@ const appointmentRecord: StaffAppointmentRecord = {
   notes: null,
   createdAt: '2026-03-21T09:00:00.000Z',
   updatedAt: '2026-03-21T09:00:00.000Z',
+};
+
+const appointmentRequestRecord = {
+  id: 'change-request-1',
+  clinicId: 'clinic-2',
+  patientId: 'patient-1',
+  requestType: 'CANCEL_APPOINTMENT' as const,
+  sourceAppointmentId: 'appointment-1',
+  preferredStartDate: '2026-03-26',
+  preferredEndDate: '2026-03-26',
+  reason: 'Cannot make it',
+  notes: null,
+  status: 'REQUESTED' as const,
+  triagedAt: null,
+  triagedBy: null,
+  rejectionReason: null,
+  createdAt: '2026-03-21T09:00:00.000Z',
+  updatedAt: '2026-03-21T09:00:00.000Z',
+  appointment: null,
+  sourceAppointment: patientAppointmentsResponse.items[0],
 };
 
 describe('patient portal trend fetch helpers', () => {
@@ -131,6 +183,29 @@ describe('patient portal trend fetch helpers', () => {
 
     expect(global.fetch).toHaveBeenCalledWith(
       'http://localhost:4000/clinics/clinic-2/appointments?from=2026-03-26&to=2026-03-27&status=CONFIRMED&assignedDoctorId=doctor-1&assignedVolunteerId=volunteer-1&patientSearch=Ama+Mensah',
+      expect.any(Object),
+    );
+
+    const init = (global.fetch as jest.Mock).mock.calls[0][1] as RequestInit;
+    const headers = new Headers(init.headers);
+    expect(headers.get('Authorization')).toBe('Bearer token-123');
+    expect(headers.get('X-Clinic-Id')).toBe('clinic-2');
+  });
+
+  it('builds patient appointment history queries with clinic header scoping', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue(patientAppointmentsResponse),
+    } as unknown as Response);
+
+    await fetchPatientAppointments('clinic-2', getToken, {
+      from: '2026-03-01',
+      to: '2026-03-31',
+      status: 'CONFIRMED',
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:4000/patients/me/appointments?from=2026-03-01&to=2026-03-31&status=CONFIRMED',
       expect.any(Object),
     );
 
@@ -226,6 +301,55 @@ describe('patient portal trend fetch helpers', () => {
       expect.objectContaining({
         method: 'POST',
         body: JSON.stringify({ reason: 'Patient did not arrive' }),
+      }),
+    );
+
+    for (const [, init] of (global.fetch as jest.Mock).mock.calls) {
+      const headers = new Headers((init as RequestInit).headers);
+      expect(headers.get('Authorization')).toBe('Bearer token-123');
+      expect(headers.get('X-Clinic-Id')).toBe('clinic-2');
+    }
+  });
+
+  it('creates patient-safe cancel and reschedule requests without staff mutation endpoints', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue(appointmentRequestRecord),
+    } as unknown as Response);
+
+    await requestPatientAppointmentCancellation('clinic-2', 'appointment-1', getToken, {
+      reason: 'Cannot make it',
+      notes: 'Please cancel this visit',
+    });
+    await requestPatientAppointmentReschedule('clinic-2', 'appointment-1', getToken, {
+      preferredStartDate: '2026-04-01',
+      preferredEndDate: '2026-04-03',
+      reason: 'Need a morning slot',
+      notes: 'Any day works',
+    });
+
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      1,
+      'http://localhost:4000/patients/me/appointments/appointment-1/cancel-request',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          reason: 'Cannot make it',
+          notes: 'Please cancel this visit',
+        }),
+      }),
+    );
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      2,
+      'http://localhost:4000/patients/me/appointments/appointment-1/reschedule-request',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          preferredStartDate: '2026-04-01',
+          preferredEndDate: '2026-04-03',
+          reason: 'Need a morning slot',
+          notes: 'Any day works',
+        }),
       }),
     );
 

--- a/apps/web/lib/patient-portal.ts
+++ b/apps/web/lib/patient-portal.ts
@@ -61,6 +61,11 @@ export interface AppointmentSummary {
   updatedAt: string;
 }
 
+export type AppointmentRequestType =
+  | 'NEW_APPOINTMENT'
+  | 'CANCEL_APPOINTMENT'
+  | 'RESCHEDULE_APPOINTMENT';
+
 export type StaffAppointmentStatus = 'CONFIRMED' | 'CANCELLED' | 'COMPLETED' | 'NO_SHOW';
 
 export interface StaffAppointmentPatientSummary {
@@ -101,6 +106,22 @@ export interface StaffAppointmentsResponse {
     noShow: number;
   };
   items: StaffAppointmentRecord[];
+}
+
+export interface PatientAppointmentsResponse {
+  range: {
+    from: string;
+    to: string;
+  };
+  timezone: string;
+  summary: {
+    total: number;
+    confirmed: number;
+    cancelled: number;
+    completed: number;
+    noShow: number;
+  };
+  items: AppointmentSummary[];
 }
 
 export interface AppointmentStaffOption {
@@ -145,6 +166,8 @@ export interface AppointmentRequestRecord {
   id: string;
   clinicId: string;
   patientId: string;
+  requestType: AppointmentRequestType;
+  sourceAppointmentId: string | null;
   preferredStartDate: string;
   preferredEndDate: string;
   reason: string | null;
@@ -156,6 +179,7 @@ export interface AppointmentRequestRecord {
   createdAt: string;
   updatedAt: string;
   appointment: AppointmentSummary | null;
+  sourceAppointment: AppointmentSummary | null;
 }
 
 export interface LegacySelfReport {
@@ -330,6 +354,23 @@ export async function fetchAppointmentRequests(clinicId: string, getToken: GetTo
   return parsePortalResponse<AppointmentRequestRecord[]>(res);
 }
 
+export async function fetchPatientAppointments(
+  clinicId: string,
+  getToken: GetToken,
+  params?: { from?: string; to?: string; status?: AppointmentSummary['status'] },
+) {
+  const search = new URLSearchParams();
+  if (params?.from) search.set('from', params.from);
+  if (params?.to) search.set('to', params.to);
+  if (params?.status) search.set('status', params.status);
+  const suffix = search.toString() ? `?${search.toString()}` : '';
+  const res = await apiFetch(`/patients/me/appointments${suffix}`, {
+    getToken,
+    activeClinicId: clinicId,
+  });
+  return parsePortalResponse<PatientAppointmentsResponse>(res);
+}
+
 export async function fetchStaffAppointments(
   clinicId: string,
   getToken: GetToken,
@@ -464,6 +505,47 @@ export async function createAppointmentRequest(
     getToken,
     activeClinicId: clinicId,
   });
+  return parsePortalResponse<AppointmentRequestRecord>(res);
+}
+
+export async function requestPatientAppointmentCancellation(
+  clinicId: string,
+  appointmentId: string,
+  getToken: GetToken,
+  body: { reason: string; notes?: string },
+) {
+  const res = await apiFetch(
+    `/patients/me/appointments/${encodeURIComponent(appointmentId)}/cancel-request`,
+    {
+      method: 'POST',
+      body: JSON.stringify(body),
+      getToken,
+      activeClinicId: clinicId,
+    },
+  );
+  return parsePortalResponse<AppointmentRequestRecord>(res);
+}
+
+export async function requestPatientAppointmentReschedule(
+  clinicId: string,
+  appointmentId: string,
+  getToken: GetToken,
+  body: {
+    preferredStartDate: string;
+    preferredEndDate: string;
+    reason?: string;
+    notes?: string;
+  },
+) {
+  const res = await apiFetch(
+    `/patients/me/appointments/${encodeURIComponent(appointmentId)}/reschedule-request`,
+    {
+      method: 'POST',
+      body: JSON.stringify(body),
+      getToken,
+      activeClinicId: clinicId,
+    },
+  );
   return parsePortalResponse<AppointmentRequestRecord>(res);
 }
 

--- a/apps/web/lib/patient-portal.ts
+++ b/apps/web/lib/patient-portal.ts
@@ -110,8 +110,8 @@ export interface StaffAppointmentsResponse {
 
 export interface PatientAppointmentsResponse {
   range: {
-    from: string;
-    to: string;
+    from: string | null;
+    to: string | null;
   };
   timezone: string;
   summary: {

--- a/apps/web/lib/portal-appointment-status.test.ts
+++ b/apps/web/lib/portal-appointment-status.test.ts
@@ -1,0 +1,119 @@
+import {
+  getAppointmentRequestStatusView,
+  getAppointmentRequestTypeLabel,
+  getAppointmentStatusView,
+  getNextConfirmedAppointment,
+  isPatientAppointmentActionable,
+} from '@/lib/portal-appointment-status';
+import type { AppointmentSummary } from '@/lib/patient-portal';
+
+function appointment(overrides: Partial<AppointmentSummary>): AppointmentSummary {
+  return {
+    id: 'appointment-1',
+    clinicId: 'clinic-1',
+    patientId: 'patient-1',
+    startsAt: '2099-03-26T14:00:00.000Z',
+    endsAt: '2099-03-26T14:30:00.000Z',
+    status: 'CONFIRMED',
+    linkedRequestId: null,
+    assignedDoctor: null,
+    assignedVolunteer: null,
+    notes: null,
+    createdAt: '2026-03-21T09:00:00.000Z',
+    updatedAt: '2026-03-21T09:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('portal appointment status helpers', () => {
+  it('maps appointment request statuses to accessible status views', () => {
+    expect(getAppointmentRequestStatusView('REQUESTED')).toMatchObject({
+      label: 'Requested',
+      badgeVariant: 'secondary',
+      category: 'pending',
+    });
+    expect(getAppointmentRequestStatusView('TRIAGED')).toMatchObject({
+      label: 'Under review',
+      badgeVariant: 'warning',
+      category: 'pending',
+    });
+    expect(getAppointmentRequestStatusView('CONFIRMED')).toMatchObject({
+      label: 'Confirmed',
+      badgeVariant: 'finalized',
+      category: 'confirmed',
+    });
+    expect(getAppointmentRequestStatusView('REJECTED')).toMatchObject({
+      label: 'Not approved',
+      badgeVariant: 'destructive',
+      category: 'closed',
+    });
+    expect(getAppointmentRequestStatusView('CANCELLED')).toMatchObject({
+      label: 'Cancelled',
+      badgeVariant: 'outline',
+      category: 'closed',
+    });
+    expect(getAppointmentRequestStatusView('STAFF_ESCALATED')).toMatchObject({
+      label: 'Staff Escalated',
+      badgeVariant: 'outline',
+    });
+  });
+
+  it('maps confirmed appointment outcomes to accessible status views', () => {
+    expect(getAppointmentStatusView('CONFIRMED')).toMatchObject({
+      label: 'Confirmed',
+      badgeVariant: 'secondary',
+      category: 'upcoming',
+    });
+    expect(getAppointmentStatusView('COMPLETED')).toMatchObject({
+      label: 'Completed',
+      badgeVariant: 'finalized',
+      category: 'completed',
+    });
+    expect(getAppointmentStatusView('CANCELLED')).toMatchObject({
+      label: 'Cancelled',
+      badgeVariant: 'destructive',
+      category: 'cancelled',
+    });
+    expect(getAppointmentStatusView('NO_SHOW')).toMatchObject({
+      label: 'No-show',
+      badgeVariant: 'warning',
+      category: 'no-show',
+    });
+    expect(getAppointmentStatusView('DELAYED')).toMatchObject({
+      label: 'Delayed',
+      badgeVariant: 'outline',
+    });
+  });
+
+  it('labels appointment request types for staff-triageable patient actions', () => {
+    expect(getAppointmentRequestTypeLabel('NEW_APPOINTMENT')).toBe('New appointment request');
+    expect(getAppointmentRequestTypeLabel('CANCEL_APPOINTMENT')).toBe('Cancellation request');
+    expect(getAppointmentRequestTypeLabel('RESCHEDULE_APPOINTMENT')).toBe('Reschedule request');
+  });
+
+  it('selects the next future confirmed appointment only', () => {
+    const now = new Date('2026-03-21T12:00:00.000Z');
+    const completed = appointment({
+      id: 'completed-1',
+      status: 'COMPLETED',
+      startsAt: '2026-03-22T12:00:00.000Z',
+    });
+    const past = appointment({
+      id: 'past-1',
+      startsAt: '2026-03-20T12:00:00.000Z',
+    });
+    const later = appointment({
+      id: 'later-1',
+      startsAt: '2026-04-01T12:00:00.000Z',
+    });
+    const next = appointment({
+      id: 'next-1',
+      startsAt: '2026-03-25T12:00:00.000Z',
+    });
+
+    expect(isPatientAppointmentActionable(next, now)).toBe(true);
+    expect(isPatientAppointmentActionable(past, now)).toBe(false);
+    expect(isPatientAppointmentActionable(completed, now)).toBe(false);
+    expect(getNextConfirmedAppointment([completed, past, later, next], now)?.id).toBe('next-1');
+  });
+});

--- a/apps/web/lib/portal-appointment-status.ts
+++ b/apps/web/lib/portal-appointment-status.ts
@@ -1,0 +1,154 @@
+import type { AppointmentRequestRecord, AppointmentSummary } from '@/lib/patient-portal';
+
+export type PortalStatusBadgeVariant =
+  | 'secondary'
+  | 'warning'
+  | 'finalized'
+  | 'destructive'
+  | 'outline';
+
+export type AppointmentRequestCategory = 'pending' | 'confirmed' | 'closed';
+export type AppointmentCategory = 'upcoming' | 'completed' | 'cancelled' | 'no-show';
+
+export interface PortalStatusView<TCategory extends string> {
+  label: string;
+  description: string;
+  badgeVariant: PortalStatusBadgeVariant;
+  category: TCategory;
+}
+
+export function getAppointmentRequestStatusView(
+  status: AppointmentRequestRecord['status'] | string,
+): PortalStatusView<AppointmentRequestCategory> {
+  switch (status) {
+    case 'REQUESTED':
+      return {
+        label: 'Requested',
+        description: 'Sent to the clinic and waiting for review.',
+        badgeVariant: 'secondary',
+        category: 'pending',
+      };
+    case 'TRIAGED':
+      return {
+        label: 'Under review',
+        description: 'Clinic staff have started reviewing this request.',
+        badgeVariant: 'warning',
+        category: 'pending',
+      };
+    case 'CONFIRMED':
+      return {
+        label: 'Confirmed',
+        description: 'The clinic approved this request and attached an appointment.',
+        badgeVariant: 'finalized',
+        category: 'confirmed',
+      };
+    case 'REJECTED':
+      return {
+        label: 'Not approved',
+        description: 'The clinic could not approve this request.',
+        badgeVariant: 'destructive',
+        category: 'closed',
+      };
+    case 'CANCELLED':
+      return {
+        label: 'Cancelled',
+        description: 'This request was closed before completion.',
+        badgeVariant: 'outline',
+        category: 'closed',
+      };
+    default:
+      return {
+        label: formatUnknownStatus(status),
+        description: 'The clinic returned a status this portal does not recognize yet.',
+        badgeVariant: 'outline',
+        category: 'closed',
+      };
+  }
+}
+
+export function getAppointmentStatusView(
+  status: AppointmentSummary['status'] | string,
+): PortalStatusView<AppointmentCategory> {
+  switch (status) {
+    case 'CONFIRMED':
+      return {
+        label: 'Confirmed',
+        description: 'Scheduled and still active.',
+        badgeVariant: 'secondary',
+        category: 'upcoming',
+      };
+    case 'COMPLETED':
+      return {
+        label: 'Completed',
+        description: 'The clinic marked this visit complete.',
+        badgeVariant: 'finalized',
+        category: 'completed',
+      };
+    case 'CANCELLED':
+      return {
+        label: 'Cancelled',
+        description: 'This appointment was cancelled.',
+        badgeVariant: 'destructive',
+        category: 'cancelled',
+      };
+    case 'NO_SHOW':
+      return {
+        label: 'No-show',
+        description: 'The clinic marked this visit as missed.',
+        badgeVariant: 'warning',
+        category: 'no-show',
+      };
+    default:
+      return {
+        label: formatUnknownStatus(status),
+        description: 'The clinic returned a status this portal does not recognize yet.',
+        badgeVariant: 'outline',
+        category: 'cancelled',
+      };
+  }
+}
+
+export function getAppointmentRequestTypeLabel(
+  requestType: AppointmentRequestRecord['requestType'] | string,
+) {
+  switch (requestType) {
+    case 'CANCEL_APPOINTMENT':
+      return 'Cancellation request';
+    case 'RESCHEDULE_APPOINTMENT':
+      return 'Reschedule request';
+    case 'NEW_APPOINTMENT':
+      return 'New appointment request';
+    default:
+      return formatUnknownStatus(requestType);
+  }
+}
+
+export function isPatientAppointmentActionable(
+  appointment: AppointmentSummary,
+  now: Date = new Date(),
+) {
+  return (
+    appointment.status === 'CONFIRMED' && new Date(appointment.startsAt).getTime() > now.getTime()
+  );
+}
+
+export function getNextConfirmedAppointment(
+  appointments: AppointmentSummary[],
+  now: Date = new Date(),
+) {
+  return (
+    appointments
+      .filter((appointment) => isPatientAppointmentActionable(appointment, now))
+      .sort(
+        (left, right) => new Date(left.startsAt).getTime() - new Date(right.startsAt).getTime(),
+      )[0] ?? null
+  );
+}
+
+function formatUnknownStatus(status: string) {
+  return status
+    .split('_')
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(' ');
+}

--- a/packages/db/prisma/migrations/20260615090000_patient_appointment_change_requests/migration.sql
+++ b/packages/db/prisma/migrations/20260615090000_patient_appointment_change_requests/migration.sql
@@ -1,0 +1,13 @@
+-- CreateEnum
+CREATE TYPE "AppointmentRequestType" AS ENUM ('NEW_APPOINTMENT', 'CANCEL_APPOINTMENT', 'RESCHEDULE_APPOINTMENT');
+
+-- AlterTable
+ALTER TABLE "AppointmentRequest"
+ADD COLUMN "requestType" "AppointmentRequestType" NOT NULL DEFAULT 'NEW_APPOINTMENT',
+ADD COLUMN "sourceAppointmentId" UUID;
+
+-- CreateIndex
+CREATE INDEX "AppointmentRequest_sourceAppointmentId_idx" ON "AppointmentRequest"("sourceAppointmentId");
+
+-- AddForeignKey
+ALTER TABLE "AppointmentRequest" ADD CONSTRAINT "AppointmentRequest_sourceAppointmentId_fkey" FOREIGN KEY ("sourceAppointmentId") REFERENCES "Appointment"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -102,6 +102,12 @@ enum AppointmentRequestStatus {
   CANCELLED
 }
 
+enum AppointmentRequestType {
+  NEW_APPOINTMENT
+  CANCEL_APPOINTMENT
+  RESCHEDULE_APPOINTMENT
+}
+
 enum AppointmentStatus {
   CONFIRMED
   CANCELLED
@@ -723,27 +729,31 @@ model PatientMeasurement {
 }
 
 model AppointmentRequest {
-  id                 String                   @id @default(uuid()) @db.Uuid
-  clinicId           String                   @db.Uuid
-  patientId          String                   @db.Uuid
-  preferredStartDate DateTime
-  preferredEndDate   DateTime
-  reason             String?                  @db.VarChar(120)
-  notes              String?                  @db.Text
-  status             AppointmentRequestStatus @default(REQUESTED)
-  triagedByUserId    String?                  @db.Uuid
-  triagedAt          DateTime?
-  rejectionReason    String?                  @db.Text
-  createdAt          DateTime                 @default(now())
-  updatedAt          DateTime                 @updatedAt
+  id                  String                   @id @default(uuid()) @db.Uuid
+  clinicId            String                   @db.Uuid
+  patientId           String                   @db.Uuid
+  requestType         AppointmentRequestType   @default(NEW_APPOINTMENT)
+  sourceAppointmentId String?                  @db.Uuid
+  preferredStartDate  DateTime
+  preferredEndDate    DateTime
+  reason              String?                  @db.VarChar(120)
+  notes               String?                  @db.Text
+  status              AppointmentRequestStatus @default(REQUESTED)
+  triagedByUserId     String?                  @db.Uuid
+  triagedAt           DateTime?
+  rejectionReason     String?                  @db.Text
+  createdAt           DateTime                 @default(now())
+  updatedAt           DateTime                 @updatedAt
 
-  clinic      Clinic       @relation(fields: [clinicId], references: [id], onDelete: Cascade)
-  patient     Patient      @relation(fields: [patientId], references: [id], onDelete: Cascade)
-  triagedBy   User?        @relation("AppointmentRequestTriagedBy", fields: [triagedByUserId], references: [id], onDelete: SetNull)
-  appointment Appointment?
+  clinic            Clinic       @relation(fields: [clinicId], references: [id], onDelete: Cascade)
+  patient           Patient      @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  triagedBy         User?        @relation("AppointmentRequestTriagedBy", fields: [triagedByUserId], references: [id], onDelete: SetNull)
+  appointment       Appointment? @relation("AppointmentLinkedRequest")
+  sourceAppointment Appointment? @relation("AppointmentSourceChangeRequest", fields: [sourceAppointmentId], references: [id], onDelete: SetNull)
 
   @@index([clinicId, status, createdAt])
   @@index([patientId, createdAt])
+  @@index([sourceAppointmentId])
 }
 
 model Appointment {
@@ -760,11 +770,12 @@ model Appointment {
   createdAt           DateTime          @default(now())
   updatedAt           DateTime          @updatedAt
 
-  clinic            Clinic              @relation(fields: [clinicId], references: [id], onDelete: Cascade)
-  patient           Patient             @relation(fields: [patientId], references: [id], onDelete: Cascade)
-  linkedRequest     AppointmentRequest? @relation(fields: [linkedRequestId], references: [id], onDelete: SetNull)
-  assignedDoctor    User?               @relation("AppointmentAssignedDoctor", fields: [assignedDoctorId], references: [id], onDelete: SetNull)
-  assignedVolunteer User?               @relation("AppointmentAssignedVolunteer", fields: [assignedVolunteerId], references: [id], onDelete: SetNull)
+  clinic            Clinic               @relation(fields: [clinicId], references: [id], onDelete: Cascade)
+  patient           Patient              @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  linkedRequest     AppointmentRequest?  @relation("AppointmentLinkedRequest", fields: [linkedRequestId], references: [id], onDelete: SetNull)
+  changeRequests    AppointmentRequest[] @relation("AppointmentSourceChangeRequest")
+  assignedDoctor    User?                @relation("AppointmentAssignedDoctor", fields: [assignedDoctorId], references: [id], onDelete: SetNull)
+  assignedVolunteer User?                @relation("AppointmentAssignedVolunteer", fields: [assignedVolunteerId], references: [id], onDelete: SetNull)
 
   @@index([clinicId, startsAt])
   @@index([patientId, startsAt])


### PR DESCRIPTION
## Summary
- Added structured appointment request metadata for new, cancellation, and reschedule requests.
- Added patient-scoped appointment history and safe cancel/reschedule request APIs.
- Rebuilt `/portal/appointments` into a unified appointment center with separate appointment history and request history.
- Added reusable portal appointment status mapping helpers and tests.

## Details
- Added `AppointmentRequestType`, `requestType`, and `sourceAppointmentId` so staff can triage patient change requests reliably.
- Added `GET /patients/me/appointments`.
- Added `POST /patients/me/appointments/:appointmentId/cancel-request`.
- Added `POST /patients/me/appointments/:appointmentId/reschedule-request`.
- Enforced linked patient ownership, active clinic scope, future-only policy, and confirmed-only eligibility.
- Patient actions create appointment requests only; they never directly mutate appointment records.
- Updated portal UI with accessible status badges, next appointment summary, responsive history sections, retry messaging, and patient-safe action dialogs.

## Tests
- Added API ownership and change-request tests.
- Added web helper tests for status mapping, next appointment selection, and patient appointment helper endpoints.
- Ran db generation, tests, lint, typecheck, build, security scan, and e2e attempt.

Closes #4 