### PR TITLE
Feat/appointment operations v2 reminder lifecycle automation

### DIFF
--- a/apps/api/src/patient-portal/patient-portal.service.spec.ts
+++ b/apps/api/src/patient-portal/patient-portal.service.spec.ts
@@ -836,6 +836,26 @@ describe('PatientPortalService', () => {
         },
         assignedDoctor: { id: 'doctor-1', displayName: 'Dr One' },
         assignedVolunteer: { id: 'volunteer-1', displayName: 'Volunteer One' },
+        reminders: [
+          {
+            id: 'reminder-1',
+            status: 'QUEUED',
+            channel: 'SMS',
+            scheduledAt: new Date('2026-03-25T14:00:00.000Z'),
+            failureReason: null,
+            createdAt: new Date('2026-03-21T09:00:00.000Z'),
+            updatedAt: new Date('2026-03-21T09:00:00.000Z'),
+          },
+          {
+            id: 'reminder-2',
+            status: 'FAILED',
+            channel: 'EMAIL',
+            scheduledAt: new Date('2026-03-25T14:00:00.000Z'),
+            failureReason: 'NO_CONTACT_METHOD',
+            createdAt: new Date('2026-03-21T09:01:00.000Z'),
+            updatedAt: new Date('2026-03-21T09:02:00.000Z'),
+          },
+        ],
       },
     ]);
 
@@ -864,6 +884,14 @@ describe('PatientPortalService', () => {
       },
       assignedDoctor: { id: 'doctor-1', displayName: 'Dr One' },
       assignedVolunteer: { id: 'volunteer-1', displayName: 'Volunteer One' },
+      reminderSummary: {
+        total: 2,
+        queued: 1,
+        failed: 1,
+        nextQueuedAt: '2026-03-25T14:00:00.000Z',
+        channels: ['EMAIL', 'SMS'],
+        latestFailureReason: 'NO_CONTACT_METHOD',
+      },
     });
   });
 
@@ -1236,6 +1264,82 @@ describe('PatientPortalService', () => {
     );
     expect(reminderService.scheduleAppointmentReminder).toHaveBeenCalled();
     expect(result.request.status).toBe('CONFIRMED');
+  });
+
+  it('confirms appointment requests with visible failed reminders when contact methods are missing', async () => {
+    const existingRequest = {
+      id: 'appt-req-no-contact',
+      clinicId: 'clinic-1',
+      patientId: 'patient-1',
+      preferredStartDate: new Date('2026-03-25T00:00:00.000Z'),
+      preferredEndDate: new Date('2026-03-27T00:00:00.000Z'),
+      reason: 'Follow-up',
+      notes: null,
+      status: 'REQUESTED',
+      triagedByUserId: null,
+      triagedAt: null,
+      rejectionReason: null,
+      createdAt: new Date('2026-03-21T09:00:00.000Z'),
+      updatedAt: new Date('2026-03-21T09:00:00.000Z'),
+      patient: {
+        id: 'patient-1',
+        patientCode: 'NKP-2026-000001',
+        firstName: 'Ama',
+        lastName: 'Mensah',
+        phoneE164: null,
+        email: null,
+      },
+      triagedBy: null,
+      appointment: null,
+    };
+    const appointment = {
+      id: 'appointment-1',
+      clinicId: 'clinic-1',
+      patientId: 'patient-1',
+      startsAt: new Date('2026-03-26T14:00:00.000Z'),
+      endsAt: new Date('2026-03-26T14:30:00.000Z'),
+      status: 'CONFIRMED',
+      linkedRequestId: 'appt-req-no-contact',
+      assignedDoctorId: null,
+      assignedVolunteerId: null,
+      notes: null,
+      createdAt: new Date('2026-03-21T09:10:00.000Z'),
+      updatedAt: new Date('2026-03-21T09:10:00.000Z'),
+    };
+    prisma.appointmentRequest.findFirst.mockResolvedValue(existingRequest);
+    prisma.appointment.create.mockResolvedValue(appointment);
+    prisma.appointmentRequest.update.mockResolvedValue({
+      ...existingRequest,
+      status: 'CONFIRMED',
+      triagedByUserId: 'manager-1',
+      triagedAt: new Date('2026-03-21T09:10:00.000Z'),
+      appointment: { ...appointment, assignedDoctor: null, assignedVolunteer: null },
+      triagedBy: { id: 'manager-1', displayName: 'Manager One' },
+    });
+
+    await service.confirmAppointmentRequest(
+      'clinic-1',
+      'appt-req-no-contact',
+      'manager-1',
+      {
+        startsAt: '2026-03-26T14:00:00.000Z',
+        endsAt: '2026-03-26T14:30:00.000Z',
+      },
+      'req-no-contact',
+    );
+
+    expect(reminderService.scheduleAppointmentReminderNoContact).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clinicId: 'clinic-1',
+        patientId: 'patient-1',
+        patientCode: 'NKP-2026-000001',
+        appointmentId: 'appointment-1',
+        startsAt: new Date('2026-03-26T14:00:00.000Z'),
+        requestId: 'req-no-contact',
+      }),
+    );
+    expect(reminderService.scheduleAppointmentReminder).not.toHaveBeenCalled();
+    expect(reminderService.scheduleAppointmentEmailReminder).not.toHaveBeenCalled();
   });
 
   it('rejects appointment requests and records the rejection reason', async () => {

--- a/apps/api/src/patient-portal/patient-portal.service.ts
+++ b/apps/api/src/patient-portal/patient-portal.service.ts
@@ -147,7 +147,7 @@ interface FollowUpSummary {
   closed: number;
 }
 
-interface AppointmentReminderSummary {
+export interface AppointmentReminderSummary {
   total: number;
   queued: number;
   sent: number;

--- a/apps/api/src/patient-portal/patient-portal.service.ts
+++ b/apps/api/src/patient-portal/patient-portal.service.ts
@@ -85,6 +85,18 @@ const appointmentScheduleInclude = {
   },
   assignedDoctor: { select: { id: true, displayName: true } },
   assignedVolunteer: { select: { id: true, displayName: true } },
+  reminders: {
+    select: {
+      id: true,
+      status: true,
+      channel: true,
+      scheduledAt: true,
+      failureReason: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+    orderBy: { createdAt: 'desc' },
+  },
 } satisfies Prisma.AppointmentInclude;
 
 type AppointmentRequestWithRelations = Prisma.AppointmentRequestGetPayload<{
@@ -133,6 +145,17 @@ interface FollowUpSummary {
   completed: number;
   noShow: number;
   closed: number;
+}
+
+interface AppointmentReminderSummary {
+  total: number;
+  queued: number;
+  sent: number;
+  delivered: number;
+  failed: number;
+  nextQueuedAt: string | null;
+  channels: string[];
+  latestFailureReason: string | null;
 }
 
 interface AppointmentRange {
@@ -2525,9 +2548,66 @@ export class PatientPortalService {
           ? { id: appointment.assignedVolunteerId, displayName: null }
           : null,
       notes: appointment.notes,
+      reminderSummary: this.summarizeAppointmentReminders(appointment.reminders ?? []),
       createdAt: appointment.createdAt.toISOString(),
       updatedAt: appointment.updatedAt.toISOString(),
     };
+  }
+
+  private summarizeAppointmentReminders(
+    reminders: Array<{
+      status: string;
+      channel: string;
+      scheduledAt: Date;
+      failureReason: string | null;
+      updatedAt: Date;
+    }>,
+  ): AppointmentReminderSummary {
+    const summary: AppointmentReminderSummary = {
+      total: reminders.length,
+      queued: 0,
+      sent: 0,
+      delivered: 0,
+      failed: 0,
+      nextQueuedAt: null,
+      channels: [],
+      latestFailureReason: null,
+    };
+    const channels = new Set<string>();
+    let nextQueuedAt: Date | null = null;
+    let latestFailedAt: Date | null = null;
+
+    for (const reminder of reminders) {
+      channels.add(reminder.channel);
+      switch (reminder.status) {
+        case 'QUEUED':
+          summary.queued += 1;
+          if (!nextQueuedAt || reminder.scheduledAt < nextQueuedAt) {
+            nextQueuedAt = reminder.scheduledAt;
+          }
+          break;
+        case 'SENT':
+          summary.sent += 1;
+          break;
+        case 'DELIVERED':
+          summary.delivered += 1;
+          break;
+        case 'FAILED':
+          summary.failed += 1;
+          if (
+            reminder.failureReason &&
+            (!latestFailedAt || reminder.updatedAt.getTime() > latestFailedAt.getTime())
+          ) {
+            latestFailedAt = reminder.updatedAt;
+            summary.latestFailureReason = reminder.failureReason;
+          }
+          break;
+      }
+    }
+
+    summary.channels = [...channels].sort();
+    summary.nextQueuedAt = nextQueuedAt?.toISOString() ?? null;
+    return summary;
   }
 
   private summarizeAppointments(appointments: Array<{ status: AppointmentStatus }>) {

--- a/apps/api/src/reminders/reminder.service.spec.ts
+++ b/apps/api/src/reminders/reminder.service.spec.ts
@@ -1,0 +1,232 @@
+import { ReminderService } from './reminder.service';
+
+function createReminder(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'reminder-1',
+    clinicId: 'clinic-1',
+    patientId: 'patient-1',
+    encounterId: null,
+    appointmentId: 'appointment-1',
+    channel: 'SMS',
+    toAddress: '+233240000000',
+    templateKey: 'APPOINTMENT_REMINDER_V1',
+    payloadJson: JSON.stringify({
+      patientCode: 'NKP-2026-000001',
+      clinicName: 'Clinic One',
+      patientId: 'patient-1',
+      appointmentId: 'appointment-1',
+      startsAt: '2026-03-26T14:00:00.000Z',
+    }),
+    scheduledAt: new Date('2026-03-25T14:00:00.000Z'),
+    sentAt: null,
+    status: 'QUEUED',
+    providerMessageId: null,
+    failureReason: null,
+    createdAt: new Date('2026-03-21T09:00:00.000Z'),
+    updatedAt: new Date('2026-03-21T09:00:00.000Z'),
+    appointment: {
+      id: 'appointment-1',
+      status: 'CONFIRMED',
+      startsAt: new Date('2026-03-26T14:00:00.000Z'),
+    },
+    ...overrides,
+  };
+}
+
+describe('ReminderService', () => {
+  let prisma: {
+    reminder: {
+      create: jest.Mock;
+      findMany: jest.Mock;
+      findFirst: jest.Mock;
+      findUnique: jest.Mock;
+      update: jest.Mock;
+    };
+    appointment: { findFirst: jest.Mock };
+  };
+  let auditService: { logWrite: jest.Mock };
+  let smsProvider: { send: jest.Mock };
+  let emailProvider: { send: jest.Mock };
+  let reminderQueue: { add: jest.Mock; getJob: jest.Mock };
+  let service: ReminderService;
+
+  beforeEach(() => {
+    prisma = {
+      reminder: {
+        create: jest.fn(async ({ data }) => createReminder({ ...data, id: 'reminder-1' })),
+        findMany: jest.fn(),
+        findFirst: jest.fn(),
+        findUnique: jest.fn(),
+        update: jest.fn(async ({ where, data }) => createReminder({ id: where.id, ...data })),
+      },
+      appointment: { findFirst: jest.fn() },
+    };
+    auditService = { logWrite: jest.fn().mockResolvedValue(undefined) };
+    smsProvider = {
+      send: jest.fn().mockResolvedValue({ success: true, providerMessageId: 'sms-1' }),
+    };
+    emailProvider = {
+      send: jest.fn().mockResolvedValue({ success: true, providerMessageId: 'email-1' }),
+    };
+    reminderQueue = {
+      add: jest.fn().mockResolvedValue({ id: 'reminder:reminder-1' }),
+      getJob: jest.fn().mockResolvedValue({ remove: jest.fn().mockResolvedValue(undefined) }),
+    };
+    service = new ReminderService(
+      prisma as never,
+      auditService as never,
+      smsProvider,
+      emailProvider,
+      reminderQueue as never,
+    );
+  });
+
+  it('creates predictable SMS appointment reminder records and deterministic jobs', async () => {
+    await service.scheduleAppointmentReminder({
+      clinicId: 'clinic-1',
+      clinicName: 'Clinic One',
+      patientId: 'patient-1',
+      patientCode: 'NKP-2026-000001',
+      phoneE164: '+233240000000',
+      appointmentId: 'appointment-1',
+      startsAt: new Date('2026-03-26T14:00:00.000Z'),
+      actorUserId: 'manager-1',
+      requestId: 'req-1',
+    });
+
+    expect(prisma.reminder.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        appointmentId: 'appointment-1',
+        channel: 'SMS',
+        toAddress: '+233240000000',
+        templateKey: 'APPOINTMENT_REMINDER_V1',
+        status: 'QUEUED',
+      }),
+    });
+    expect(JSON.parse(prisma.reminder.create.mock.calls[0][0].data.payloadJson)).toMatchObject({
+      appointmentId: 'appointment-1',
+      startsAt: '2026-03-26T14:00:00.000Z',
+    });
+    expect(reminderQueue.add).toHaveBeenCalledWith(
+      'send',
+      { reminderId: 'reminder-1', clinicId: 'clinic-1' },
+      expect.objectContaining({ jobId: 'reminder:reminder-1' }),
+    );
+  });
+
+  it('creates visible failed appointment records when no contact method exists', async () => {
+    await service.scheduleAppointmentReminderNoContact({
+      clinicId: 'clinic-1',
+      patientId: 'patient-1',
+      patientCode: 'NKP-2026-000001',
+      appointmentId: 'appointment-1',
+      startsAt: new Date('2026-03-26T14:00:00.000Z'),
+      actorUserId: 'manager-1',
+      requestId: 'req-1',
+    });
+
+    expect(prisma.reminder.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        appointmentId: 'appointment-1',
+        status: 'FAILED',
+        failureReason: 'NO_CONTACT_METHOD',
+        toAddress: 'N/A',
+      }),
+    });
+    expect(reminderQueue.add).not.toHaveBeenCalled();
+  });
+
+  it('suppresses queued appointment reminders and removes deterministic jobs', async () => {
+    prisma.reminder.findMany.mockResolvedValue([
+      createReminder({ id: 'reminder-1' }),
+      createReminder({ id: 'reminder-2' }),
+    ]);
+
+    await service.suppressQueuedAppointmentReminders(
+      'clinic-1',
+      'appointment-1',
+      'manager-1',
+      'APPOINTMENT_RESCHEDULED',
+      'req-1',
+    );
+
+    expect(prisma.reminder.findMany).toHaveBeenCalledWith({
+      where: expect.objectContaining({
+        clinicId: 'clinic-1',
+        status: 'QUEUED',
+        templateKey: 'APPOINTMENT_REMINDER_V1',
+        OR: expect.arrayContaining([expect.objectContaining({ appointmentId: 'appointment-1' })]),
+      }),
+    });
+    expect(prisma.reminder.update).toHaveBeenCalledTimes(2);
+    expect(prisma.reminder.update).toHaveBeenCalledWith({
+      where: { id: 'reminder-1' },
+      data: { status: 'FAILED', failureReason: 'APPOINTMENT_RESCHEDULED' },
+    });
+    expect(reminderQueue.getJob).toHaveBeenCalledWith('reminder:reminder-1');
+    expect(reminderQueue.getJob).toHaveBeenCalledWith('reminder:reminder-2');
+  });
+
+  it('does not send appointment reminders for cancelled appointments', async () => {
+    prisma.reminder.findUnique.mockResolvedValue(
+      createReminder({ appointment: { id: 'appointment-1', status: 'CANCELLED' } }),
+    );
+
+    await service.processReminder('reminder-1');
+
+    expect(smsProvider.send).not.toHaveBeenCalled();
+    expect(prisma.reminder.update).toHaveBeenCalledWith({
+      where: { id: 'reminder-1' },
+      data: { status: 'FAILED', failureReason: 'APPOINTMENT_NOT_CONFIRMED:CANCELLED' },
+    });
+  });
+
+  it('does not send stale appointment reminders after reschedule', async () => {
+    prisma.reminder.findUnique.mockResolvedValue(
+      createReminder({
+        appointment: {
+          id: 'appointment-1',
+          status: 'CONFIRMED',
+          startsAt: new Date('2026-03-27T14:00:00.000Z'),
+        },
+      }),
+    );
+
+    await service.processReminder('reminder-1');
+
+    expect(smsProvider.send).not.toHaveBeenCalled();
+    expect(prisma.reminder.update).toHaveBeenCalledWith({
+      where: { id: 'reminder-1' },
+      data: { status: 'FAILED', failureReason: 'APPOINTMENT_RESCHEDULED' },
+    });
+  });
+
+  it('sends current appointment reminders through the configured provider', async () => {
+    prisma.reminder.findUnique.mockResolvedValue(createReminder());
+
+    await service.processReminder('reminder-1');
+
+    expect(smsProvider.send).toHaveBeenCalledWith(
+      '+233240000000',
+      expect.stringContaining('your appointment is scheduled'),
+    );
+    expect(prisma.reminder.update).toHaveBeenCalledWith({
+      where: { id: 'reminder-1' },
+      data: expect.objectContaining({ status: 'SENT', providerMessageId: 'sms-1' }),
+    });
+  });
+
+  it('records delivery status callbacks through existing reminder statuses', async () => {
+    prisma.reminder.findFirst.mockResolvedValue(createReminder({ providerMessageId: 'sms-1' }));
+
+    await service.updateDeliveryStatus('sms-1', 'FAILED', '30005');
+
+    expect(prisma.reminder.update).toHaveBeenCalledWith({
+      where: { id: 'reminder-1' },
+      data: { status: 'FAILED', failureReason: 'DELIVERY_FAILED:30005' },
+    });
+    expect(auditService.logWrite).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'REMINDER.DELIVERY_UPDATE' }),
+    );
+  });
+});

--- a/apps/api/src/reminders/reminder.service.ts
+++ b/apps/api/src/reminders/reminder.service.ts
@@ -12,6 +12,9 @@ const REMINDER_QUEUE_NAME = 'reminders';
 const FOLLOWUP_TEMPLATE_KEY = 'FOLLOWUP_REMINDER_V1';
 const APPOINTMENT_TEMPLATE_KEY = 'APPOINTMENT_REMINDER_V1';
 const REMINDER_SEND_FAILED = 'SEND_FAILED';
+const APPOINTMENT_NOT_FOUND = 'APPOINTMENT_NOT_FOUND';
+const APPOINTMENT_NOT_CONFIRMED = 'APPOINTMENT_NOT_CONFIRMED';
+const APPOINTMENT_RESCHEDULED = 'APPOINTMENT_RESCHEDULED';
 
 export interface ScheduleFollowUpParams {
   clinicId: string;
@@ -96,6 +99,7 @@ export interface ListRemindersResult {
     clinicId: string;
     patientId: string;
     encounterId: string | null;
+    appointmentId: string | null;
     channel: string;
     toAddress: string;
     templateKey: string;
@@ -106,6 +110,7 @@ export interface ListRemindersResult {
     providerMessageId: string | null;
     failureReason: string | null;
     createdAt: Date;
+    updatedAt: Date;
   }>;
   nextCursor: string | null;
 }
@@ -114,6 +119,23 @@ type ReminderMessage = {
   subject: string;
   smsBody: string;
   emailHtml: string;
+};
+
+type AppointmentReminderChannel = 'SMS' | 'EMAIL';
+
+type ScheduleAppointmentReminderRecordParams = {
+  clinicId: string;
+  clinicName?: string;
+  patientId: string;
+  patientCode: string;
+  appointmentId: string;
+  startsAt: Date;
+  actorUserId: string;
+  requestId?: string;
+  channel: AppointmentReminderChannel;
+  toAddress: string;
+  status: ReminderStatus;
+  failureReason?: string;
 };
 
 function decodeCursor(cursor: string): { createdAt: Date; id: string } | null {
@@ -242,87 +264,55 @@ export class ReminderService {
   }
 
   async scheduleAppointmentReminder(params: ScheduleAppointmentReminderParams): Promise<void> {
-    const scheduledAt = this.getAppointmentReminderTime(params.startsAt);
-    const payloadJson = JSON.stringify({
-      patientCode: params.patientCode,
+    await this.scheduleAppointmentReminderRecord({
+      clinicId: params.clinicId,
       clinicName: params.clinicName,
-      startsAt: params.startsAt.toISOString(),
       patientId: params.patientId,
+      patientCode: params.patientCode,
       appointmentId: params.appointmentId,
+      startsAt: params.startsAt,
+      actorUserId: params.actorUserId,
+      requestId: params.requestId,
+      channel: 'SMS',
+      toAddress: params.phoneE164,
+      status: 'QUEUED',
     });
-
-    const reminder = await this.prisma.reminder.create({
-      data: {
-        clinicId: params.clinicId,
-        patientId: params.patientId,
-        channel: 'SMS',
-        toAddress: params.phoneE164,
-        templateKey: APPOINTMENT_TEMPLATE_KEY,
-        payloadJson,
-        scheduledAt,
-        status: 'QUEUED',
-      },
-    });
-
-    await this.auditReminderCreate(params.clinicId, params.actorUserId, reminder, params.requestId);
-    await this.queueReminder(reminder.id, scheduledAt, params.clinicId);
   }
 
   async scheduleAppointmentEmailReminder(
     params: ScheduleAppointmentEmailReminderParams,
   ): Promise<void> {
-    const scheduledAt = this.getAppointmentReminderTime(params.startsAt);
-    const payloadJson = JSON.stringify({
-      patientCode: params.patientCode,
+    await this.scheduleAppointmentReminderRecord({
+      clinicId: params.clinicId,
       clinicName: params.clinicName,
-      startsAt: params.startsAt.toISOString(),
       patientId: params.patientId,
+      patientCode: params.patientCode,
       appointmentId: params.appointmentId,
+      startsAt: params.startsAt,
+      actorUserId: params.actorUserId,
+      requestId: params.requestId,
+      channel: 'EMAIL',
+      toAddress: params.email,
+      status: 'QUEUED',
     });
-
-    const reminder = await this.prisma.reminder.create({
-      data: {
-        clinicId: params.clinicId,
-        patientId: params.patientId,
-        channel: 'EMAIL',
-        toAddress: params.email,
-        templateKey: APPOINTMENT_TEMPLATE_KEY,
-        payloadJson,
-        scheduledAt,
-        status: 'QUEUED',
-      },
-    });
-
-    await this.auditReminderCreate(params.clinicId, params.actorUserId, reminder, params.requestId);
-    await this.queueReminder(reminder.id, scheduledAt, params.clinicId);
   }
 
   async scheduleAppointmentReminderNoContact(
     params: ScheduleAppointmentNoContactParams,
   ): Promise<void> {
-    const scheduledAt = this.getAppointmentReminderTime(params.startsAt);
-    const payloadJson = JSON.stringify({
-      patientCode: params.patientCode,
-      startsAt: params.startsAt.toISOString(),
+    await this.scheduleAppointmentReminderRecord({
+      clinicId: params.clinicId,
       patientId: params.patientId,
+      patientCode: params.patientCode,
       appointmentId: params.appointmentId,
+      startsAt: params.startsAt,
+      actorUserId: params.actorUserId,
+      requestId: params.requestId,
+      channel: 'SMS',
+      toAddress: 'N/A',
+      status: 'FAILED',
+      failureReason: 'NO_CONTACT_METHOD',
     });
-
-    const reminder = await this.prisma.reminder.create({
-      data: {
-        clinicId: params.clinicId,
-        patientId: params.patientId,
-        channel: 'SMS',
-        toAddress: 'N/A',
-        templateKey: APPOINTMENT_TEMPLATE_KEY,
-        payloadJson,
-        scheduledAt,
-        status: 'FAILED',
-        failureReason: 'NO_CONTACT_METHOD',
-      },
-    });
-
-    await this.auditReminderCreate(params.clinicId, params.actorUserId, reminder, params.requestId);
   }
 
   async suppressQueuedAppointmentReminders(
@@ -337,7 +327,13 @@ export class ReminderService {
         clinicId,
         status: 'QUEUED',
         templateKey: APPOINTMENT_TEMPLATE_KEY,
-        payloadJson: { contains: `"appointmentId":"${appointmentId}"` },
+        OR: [
+          { appointmentId },
+          {
+            appointmentId: null,
+            payloadJson: { contains: `"appointmentId":"${appointmentId}"` },
+          },
+        ],
       },
     });
 
@@ -360,6 +356,8 @@ export class ReminderService {
         afterJson: JSON.stringify(updated),
         requestId,
       });
+
+      await this.removeQueuedReminderJob(reminder.id);
     }
   }
 
@@ -404,6 +402,7 @@ export class ReminderService {
         clinicId: r.clinicId,
         patientId: r.patientId,
         encounterId: r.encounterId,
+        appointmentId: r.appointmentId,
         channel: r.channel,
         toAddress: r.toAddress,
         templateKey: r.templateKey,
@@ -414,6 +413,7 @@ export class ReminderService {
         providerMessageId: r.providerMessageId,
         failureReason: r.failureReason,
         createdAt: r.createdAt,
+        updatedAt: r.updatedAt,
       })),
       nextCursor,
     };
@@ -454,12 +454,20 @@ export class ReminderService {
   async processReminder(reminderId: string): Promise<void> {
     const reminder = await this.prisma.reminder.findUnique({
       where: { id: reminderId },
-      include: { clinic: true, patient: true },
+      include: { clinic: true, patient: true, appointment: true },
     });
     if (!reminder || reminder.status !== 'QUEUED') return;
     if (reminder.scheduledAt > new Date()) return;
 
     const payload = JSON.parse(reminder.payloadJson) as Record<string, unknown>;
+    const appointmentSuppressionReason = await this.getAppointmentSendSuppressionReason(
+      reminder,
+      payload,
+    );
+    if (appointmentSuppressionReason) {
+      await this.failReminder(reminder, appointmentSuppressionReason, 'REMINDER.SUPPRESS');
+      return;
+    }
 
     try {
       const message = this.buildMessage(reminder.templateKey, payload);
@@ -509,24 +517,7 @@ export class ReminderService {
             }),
           );
         }
-        await this.prisma.reminder.update({
-          where: { id: reminderId },
-          data: {
-            status: 'FAILED',
-            failureReason: REMINDER_SEND_FAILED,
-          },
-        });
-        await this.auditService.logWrite({
-          clinicId: reminder.clinicId,
-          actorUserId: 'system',
-          action: 'REMINDER.SEND_FAILED',
-          entityType: 'Reminder',
-          entityId: reminderId,
-          afterJson: JSON.stringify({
-            status: 'FAILED',
-            failureReason: REMINDER_SEND_FAILED,
-          }),
-        });
+        await this.failReminder(reminder, REMINDER_SEND_FAILED, 'REMINDER.SEND_FAILED');
       }
     } catch (err) {
       this.logger.warn(
@@ -538,18 +529,7 @@ export class ReminderService {
           error: redactLogValue(err),
         }),
       );
-      await this.prisma.reminder.update({
-        where: { id: reminderId },
-        data: { status: 'FAILED', failureReason: REMINDER_SEND_FAILED },
-      });
-      await this.auditService.logWrite({
-        clinicId: reminder.clinicId,
-        actorUserId: 'system',
-        action: 'REMINDER.SEND_FAILED',
-        entityType: 'Reminder',
-        entityId: reminderId,
-        afterJson: JSON.stringify({ status: 'FAILED', failureReason: REMINDER_SEND_FAILED }),
-      });
+      await this.failReminder(reminder, REMINDER_SEND_FAILED, 'REMINDER.SEND_FAILED');
     }
   }
 
@@ -560,6 +540,103 @@ export class ReminderService {
     });
 
     return reminder?.clinicId ?? null;
+  }
+
+  private async scheduleAppointmentReminderRecord(
+    params: ScheduleAppointmentReminderRecordParams,
+  ): Promise<void> {
+    const scheduledAt = this.getAppointmentReminderTime(params.startsAt);
+    const payloadJson = JSON.stringify({
+      patientCode: params.patientCode,
+      clinicName: params.clinicName,
+      startsAt: params.startsAt.toISOString(),
+      patientId: params.patientId,
+      appointmentId: params.appointmentId,
+    });
+
+    const reminder = await this.prisma.reminder.create({
+      data: {
+        clinicId: params.clinicId,
+        patientId: params.patientId,
+        appointmentId: params.appointmentId,
+        channel: params.channel,
+        toAddress: params.toAddress,
+        templateKey: APPOINTMENT_TEMPLATE_KEY,
+        payloadJson,
+        scheduledAt,
+        status: params.status,
+        failureReason: params.failureReason,
+      },
+    });
+
+    await this.auditReminderCreate(params.clinicId, params.actorUserId, reminder, params.requestId);
+    if (params.status === 'QUEUED') {
+      await this.queueReminder(reminder.id, scheduledAt, params.clinicId);
+    }
+  }
+
+  private async getAppointmentSendSuppressionReason(
+    reminder: {
+      clinicId: string;
+      templateKey: string;
+      appointmentId: string | null;
+      appointment?: { id: string; status: string; startsAt: Date } | null;
+    },
+    payload: Record<string, unknown>,
+  ): Promise<string | null> {
+    if (reminder.templateKey !== APPOINTMENT_TEMPLATE_KEY) {
+      return null;
+    }
+
+    const payloadAppointmentId =
+      typeof payload.appointmentId === 'string' ? payload.appointmentId : null;
+    const appointmentId = reminder.appointmentId ?? payloadAppointmentId;
+    if (!appointmentId) {
+      return APPOINTMENT_NOT_FOUND;
+    }
+
+    const appointment =
+      reminder.appointment ??
+      (await this.prisma.appointment.findFirst({
+        where: { id: appointmentId, clinicId: reminder.clinicId },
+        select: { id: true, status: true, startsAt: true },
+      }));
+    if (!appointment) {
+      return APPOINTMENT_NOT_FOUND;
+    }
+    if (appointment.status !== 'CONFIRMED') {
+      return `${APPOINTMENT_NOT_CONFIRMED}:${appointment.status}`;
+    }
+
+    const payloadStartsAt =
+      typeof payload.startsAt === 'string' ? new Date(payload.startsAt) : null;
+    if (!payloadStartsAt || Number.isNaN(payloadStartsAt.getTime())) {
+      return APPOINTMENT_RESCHEDULED;
+    }
+    if (payloadStartsAt.getTime() !== appointment.startsAt.getTime()) {
+      return APPOINTMENT_RESCHEDULED;
+    }
+
+    return null;
+  }
+
+  private async failReminder(
+    reminder: { id: string; clinicId: string },
+    failureReason: string,
+    action: 'REMINDER.SEND_FAILED' | 'REMINDER.SUPPRESS',
+  ): Promise<void> {
+    await this.prisma.reminder.update({
+      where: { id: reminder.id },
+      data: { status: 'FAILED', failureReason },
+    });
+    await this.auditService.logWrite({
+      clinicId: reminder.clinicId,
+      actorUserId: 'system',
+      action,
+      entityType: 'Reminder',
+      entityId: reminder.id,
+      afterJson: JSON.stringify({ status: 'FAILED', failureReason }),
+    });
   }
 
   private getAppointmentReminderTime(startsAt: Date) {
@@ -573,11 +650,31 @@ export class ReminderService {
       'send',
       { reminderId, clinicId },
       {
+        jobId: this.getReminderJobId(reminderId),
         delay: delayMs,
         attempts: 3,
         backoff: { type: 'exponential', delay: 60_000 },
       },
     );
+  }
+
+  private async removeQueuedReminderJob(reminderId: string): Promise<void> {
+    try {
+      const job = await this.reminderQueue.getJob(this.getReminderJobId(reminderId));
+      await job?.remove();
+    } catch (err) {
+      this.logger.warn(
+        JSON.stringify({
+          message: 'Unable to remove queued reminder job',
+          reminderId,
+          error: redactLogValue(err),
+        }),
+      );
+    }
+  }
+
+  private getReminderJobId(reminderId: string): string {
+    return `reminder:${reminderId}`;
   }
 
   private async auditReminderCreate(

--- a/apps/api/src/reminders/templates/appointment-reminder.html
+++ b/apps/api/src/reminders/templates/appointment-reminder.html
@@ -6,9 +6,9 @@
   </head>
   <body style="font-family: Arial, sans-serif; line-height: 1.5; color: #111827">
     <h2 style="color: #0f766e">Appointment Reminder</h2>
-    <p>This is a reminder from <strong>{{clinicName}}</strong> about your upcoming appointment.</p>
+    <p>This is a reminder from <strong>{{clinicName}}</strong> about your currently scheduled appointment.</p>
     <p><strong>Patient:</strong> {{patientCode}}</p>
     <p><strong>Scheduled time:</strong> {{startsAt}}</p>
-    <p>If you need to reschedule, please contact the clinic directly.</p>
+    <p>If your appointment has already changed, please follow the latest update from the clinic.</p>
   </body>
 </html>

--- a/apps/api/src/reminders/templates/appointment-reminder.html
+++ b/apps/api/src/reminders/templates/appointment-reminder.html
@@ -6,7 +6,10 @@
   </head>
   <body style="font-family: Arial, sans-serif; line-height: 1.5; color: #111827">
     <h2 style="color: #0f766e">Appointment Reminder</h2>
-    <p>This is a reminder from <strong>{{clinicName}}</strong> about your currently scheduled appointment.</p>
+    <p>
+      This is a reminder from <strong>{{clinicName}}</strong> about your currently scheduled
+      appointment.
+    </p>
     <p><strong>Patient:</strong> {{patientCode}}</p>
     <p><strong>Scheduled time:</strong> {{startsAt}}</p>
     <p>If your appointment has already changed, please follow the latest update from the clinic.</p>

--- a/apps/web/app/(workspace)/appointments/page.tsx
+++ b/apps/web/app/(workspace)/appointments/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Ban,
+  BellRing,
   CalendarClock,
   CalendarDays,
   ChevronLeft,
@@ -213,6 +214,60 @@ function staffName(staff: StaffAppointmentRecord['assignedDoctor']) {
   return staff?.displayName ?? (staff?.id ? 'Assigned staff' : 'Unassigned');
 }
 
+function formatReminderFailure(reason: string | null) {
+  if (!reason) return null;
+  return reason
+    .split(':')[0]
+    .replaceAll('_', ' ')
+    .toLowerCase()
+    .replace(/^\w/, (letter) => letter.toUpperCase());
+}
+
+function AppointmentReminderStatus({
+  appointment,
+  timezone,
+}: {
+  appointment: StaffAppointmentRecord;
+  timezone: string;
+}) {
+  const summary = appointment.reminderSummary;
+  if (!summary || summary.total === 0) {
+    return (
+      <Badge variant="outline" className="w-fit gap-1 rounded-full bg-background/80">
+        <BellRing className="h-3.5 w-3.5" />
+        No reminders
+      </Badge>
+    );
+  }
+
+  const label = summary.failed
+    ? (formatReminderFailure(summary.latestFailureReason) ?? 'Reminder failed')
+    : summary.queued && summary.nextQueuedAt
+      ? `Queued ${formatOpsDateTime(summary.nextQueuedAt, timezone)}`
+      : summary.delivered
+        ? `${summary.delivered} delivered`
+        : summary.sent
+          ? `${summary.sent} sent`
+          : `${summary.total} tracked`;
+  const variant: 'destructive' | 'secondary' | 'finalized' = summary.failed
+    ? 'destructive'
+    : summary.queued
+      ? 'secondary'
+      : 'finalized';
+
+  return (
+    <div className="flex flex-col gap-1">
+      <Badge variant={variant} className="w-fit gap-1 rounded-full">
+        <BellRing className="h-3.5 w-3.5" />
+        {label}
+      </Badge>
+      {summary.channels.length ? (
+        <span className="text-xs text-muted-foreground">{summary.channels.join(' + ')}</span>
+      ) : null}
+    </div>
+  );
+}
+
 function groupAppointmentsByDay(
   items: StaffAppointmentRecord[],
   range: { from: string; to: string },
@@ -349,6 +404,7 @@ function AppointmentMobileCard({
             Volunteer: {staffName(appointment.assignedVolunteer)}
           </p>
         </div>
+        <AppointmentReminderStatus appointment={appointment} timezone={timezone} />
         {appointment.notes ? (
           <p className="rounded-2xl bg-muted/40 p-3 text-muted-foreground">{appointment.notes}</p>
         ) : null}
@@ -842,12 +898,13 @@ export default function StaffAppointmentsPage() {
                         </div>
 
                         <div className="hidden overflow-x-auto rounded-2xl border border-border/80 md:block">
-                          <table className="w-full min-w-[980px] border-collapse text-sm">
+                          <table className="w-full min-w-[1080px] border-collapse text-sm">
                             <thead className="bg-muted/50 text-left text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
                               <tr>
                                 <th className="px-4 py-3">Time</th>
                                 <th className="px-4 py-3">Patient</th>
                                 <th className="px-4 py-3">Status</th>
+                                <th className="px-4 py-3">Reminders</th>
                                 <th className="px-4 py-3">Doctor</th>
                                 <th className="px-4 py-3">Volunteer</th>
                                 <th className="px-4 py-3">Notes</th>
@@ -876,6 +933,12 @@ export default function StaffAppointmentsPage() {
                                     <Badge variant={getStatusVariant(appointment.status)}>
                                       {getStatusLabel(appointment.status)}
                                     </Badge>
+                                  </td>
+                                  <td className="px-4 py-3">
+                                    <AppointmentReminderStatus
+                                      appointment={appointment}
+                                      timezone={timezone}
+                                    />
                                   </td>
                                   <td className="px-4 py-3 text-muted-foreground">
                                     {staffName(appointment.assignedDoctor)}

--- a/apps/web/app/(workspace)/reminders/page.tsx
+++ b/apps/web/app/(workspace)/reminders/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { Bell, Clock3, SendHorizontal } from 'lucide-react';
+import { Bell, CheckCheck, Clock3, SendHorizontal } from 'lucide-react';
 import { useBootstrap } from '@/lib/bootstrap-context';
 import { useAuth } from '@/lib/auth-context';
 import { apiFetch } from '@/lib/api';
@@ -34,6 +34,7 @@ interface ReminderRow {
   clinicId: string;
   patientId: string;
   encounterId: string | null;
+  appointmentId: string | null;
   channel: string;
   toAddress: string;
   templateKey: string;
@@ -43,6 +44,27 @@ interface ReminderRow {
   providerMessageId: string | null;
   failureReason: string | null;
   createdAt: string;
+  updatedAt: string;
+}
+
+function maskAddress(value: string) {
+  return value && value.length > 8 ? `${value.slice(0, 4)}***${value.slice(-4)}` : value;
+}
+
+function formatFailureReason(reason: string | null) {
+  if (!reason) return '';
+  return reason
+    .split(':')[0]
+    .replaceAll('_', ' ')
+    .toLowerCase()
+    .replace(/^\w/, (letter) => letter.toUpperCase());
+}
+
+function getStatusVariant(status: string): 'finalized' | 'secondary' | 'destructive' | 'draft' {
+  if (status === 'DELIVERED') return 'finalized';
+  if (status === 'SENT') return 'secondary';
+  if (status === 'FAILED') return 'destructive';
+  return 'draft';
 }
 
 export default function RemindersPage() {
@@ -121,30 +143,37 @@ export default function RemindersPage() {
     {
       field: 'status',
       headerName: 'Status',
-      width: 100,
+      width: 120,
       renderCell: (params) => (
-        <Badge
-          variant={
-            params.value === 'SENT'
-              ? 'finalized'
-              : params.value === 'FAILED'
-                ? 'destructive'
-                : 'draft'
-          }
-        >
-          {String(params.value)}
-        </Badge>
+        <Badge variant={getStatusVariant(String(params.value))}>{String(params.value)}</Badge>
       ),
     },
+    { field: 'channel', headerName: 'Channel', width: 110 },
     { field: 'templateKey', headerName: 'Template', width: 180 },
+    {
+      field: 'appointmentId',
+      headerName: 'Appointment',
+      width: 140,
+      valueFormatter: (v) => (v ? String(v).slice(0, 8) : ''),
+    },
     {
       field: 'toAddress',
       headerName: 'To',
       width: 140,
-      valueFormatter: (v) =>
-        v && String(v).length > 8 ? `${String(v).slice(0, 4)}***${String(v).slice(-4)}` : String(v),
+      valueFormatter: (v) => maskAddress(String(v)),
     },
-    { field: 'failureReason', headerName: 'Failure', width: 150 },
+    {
+      field: 'failureReason',
+      headerName: 'Failure',
+      width: 190,
+      valueFormatter: (v) => formatFailureReason(v ? String(v) : null),
+    },
+    {
+      field: 'updatedAt',
+      headerName: 'Updated',
+      width: 160,
+      valueFormatter: (v) => (v ? new Date(v as string).toLocaleString() : ''),
+    },
   ];
 
   if (!clinicId) {
@@ -159,19 +188,20 @@ export default function RemindersPage() {
 
   const queuedCount = rows.filter((row) => row.status === 'QUEUED').length;
   const sentCount = rows.filter((row) => row.status === 'SENT').length;
+  const deliveredCount = rows.filter((row) => row.status === 'DELIVERED').length;
 
   return (
     <RouteGuard requiredPermission="REMINDER.READ">
       <div className="space-y-6">
         <AppPageHeader
-          eyebrow="Follow-up delivery"
+          eyebrow="Reminder delivery"
           title="Reminders"
-          description="Review follow-up delivery at a glance."
+          description="Review follow-up and appointment reminder delivery at a glance."
           helpTitle="How reminder history works"
-          helpText="Use the filters to narrow reminder history by status and date, then inspect queued, sent, or failed messages."
+          helpText="Use filters to narrow reminder history by status and date, then inspect queued, sent, delivered, or failed messages."
         />
 
-        <div className="grid gap-4 md:grid-cols-3">
+        <div className="grid gap-4 md:grid-cols-4">
           <AppMetricCard
             title="Visible reminders"
             value={rows.length}
@@ -188,7 +218,13 @@ export default function RemindersPage() {
             title="Sent"
             value={sentCount}
             icon={SendHorizontal}
-            detail="Reminders already delivered successfully."
+            detail="Reminders accepted by the configured provider."
+          />
+          <AppMetricCard
+            title="Delivered"
+            value={deliveredCount}
+            icon={CheckCheck}
+            detail="Provider callbacks marked these reminders as delivered."
           />
         </div>
 
@@ -212,6 +248,7 @@ export default function RemindersPage() {
                     <SelectItem value="ALL">All</SelectItem>
                     <SelectItem value="QUEUED">Queued</SelectItem>
                     <SelectItem value="SENT">Sent</SelectItem>
+                    <SelectItem value="DELIVERED">Delivered</SelectItem>
                     <SelectItem value="FAILED">Failed</SelectItem>
                   </SelectContent>
                 </Select>
@@ -312,21 +349,20 @@ export default function RemindersPage() {
                             {new Date(row.scheduledAt).toLocaleString()}
                           </p>
                         </div>
-                        <Badge
-                          variant={
-                            row.status === 'SENT'
-                              ? 'finalized'
-                              : row.status === 'FAILED'
-                                ? 'destructive'
-                                : 'draft'
-                          }
-                        >
-                          {row.status}
-                        </Badge>
+                        <Badge variant={getStatusVariant(row.status)}>{row.status}</Badge>
                       </div>
-                      <p className="mt-3 text-sm text-muted-foreground">{row.toAddress}</p>
+                      <div className="mt-3 grid gap-1 text-sm text-muted-foreground">
+                        <p>
+                          {row.channel} to {maskAddress(row.toAddress)}
+                        </p>
+                        {row.appointmentId ? (
+                          <p>Appointment {row.appointmentId.slice(0, 8)}</p>
+                        ) : null}
+                      </div>
                       {row.failureReason ? (
-                        <p className="mt-2 text-sm text-destructive">{row.failureReason}</p>
+                        <p className="mt-2 text-sm text-destructive">
+                          {formatFailureReason(row.failureReason)}
+                        </p>
                       ) : null}
                     </article>
                   ))}

--- a/apps/web/lib/patient-portal.test.ts
+++ b/apps/web/lib/patient-portal.test.ts
@@ -93,6 +93,16 @@ const appointmentRecord: StaffAppointmentRecord = {
   assignedDoctor: null,
   assignedVolunteer: null,
   notes: null,
+  reminderSummary: {
+    total: 0,
+    queued: 0,
+    sent: 0,
+    delivered: 0,
+    failed: 0,
+    nextQueuedAt: null,
+    channels: [],
+    latestFailureReason: null,
+  },
   createdAt: '2026-03-21T09:00:00.000Z',
   updatedAt: '2026-03-21T09:00:00.000Z',
 };

--- a/apps/web/lib/patient-portal.ts
+++ b/apps/web/lib/patient-portal.ts
@@ -76,6 +76,17 @@ export interface StaffAppointmentPatientSummary {
   displayName: string;
 }
 
+export interface AppointmentReminderSummary {
+  total: number;
+  queued: number;
+  sent: number;
+  delivered: number;
+  failed: number;
+  nextQueuedAt: string | null;
+  channels: string[];
+  latestFailureReason: string | null;
+}
+
 export interface StaffAppointmentRecord {
   id: string;
   clinicId: string;
@@ -88,6 +99,7 @@ export interface StaffAppointmentRecord {
   assignedDoctor: { id: string; displayName: string | null } | null;
   assignedVolunteer: { id: string; displayName: string | null } | null;
   notes: string | null;
+  reminderSummary: AppointmentReminderSummary;
   createdAt: string;
   updatedAt: string;
 }

--- a/docs/FEATURE_WORKFLOWS_GUIDE.md
+++ b/docs/FEATURE_WORKFLOWS_GUIDE.md
@@ -210,9 +210,18 @@ Gate checks:
 3. Reminder records are created.
 4. BullMQ workers deliver them through the configured SMS or email provider.
 
+### Appointment reminders
+
+1. Staff confirm an appointment request.
+2. Reminder records are created for available contact channels and linked to the appointment.
+3. Rescheduling suppresses queued reminders for the previous appointment time and creates replacement reminders for the new time.
+4. Cancellation, completion, and no-show states suppress future queued appointment reminders.
+5. If a patient has no usable contact method, a failed reminder record is kept with `NO_CONTACT_METHOD`.
+6. Workers re-check appointment state before sending, so cancelled, completed, no-show, or stale rescheduled reminders are not delivered.
+
 ### Status review
 
-Staff can inspect queued, sent, delivered, or failed reminders from the reminder list.
+Staff can inspect queued, sent, delivered, or failed reminders from the reminder list. Appointment rows also summarize reminder state with queued, delivered, and failed counts so operators can spot delivery issues without leaving the schedule.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2709,39 +2709,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -10539,27 +10506,6 @@
         "xmlhttprequest-ssl": "~2.1.1"
       }
     },
-    "node_modules/engine.io-client/node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/engine.io-parser": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
@@ -10567,27 +10513,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/engine.io/node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/enhanced-resolve": {
@@ -16769,6 +16694,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -18407,27 +18333,6 @@
         "ws": "~8.20.1"
       }
     },
-    "node_modules/socket.io-adapter/node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/socket.io-client": {
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
@@ -18504,13 +18409,6 @@
       "engines": {
         "node": ">= 10.x"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/sqlstring": {
       "version": "2.3.3",
@@ -19327,6 +19225,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/tmpl": {
@@ -20504,7 +20414,6 @@
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -726,12 +726,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -740,29 +740,29 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -788,13 +788,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -814,13 +814,13 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -839,36 +839,36 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -888,52 +888,52 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1191,31 +1191,31 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -1223,13 +1223,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2720,14 +2720,23 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -4023,9 +4032,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
-      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -4055,12 +4064,12 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.1.tgz",
-      "integrity": "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
+      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/core": "2.8.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -4068,31 +4077,16 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
-      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
-      "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+      "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.6.1",
-        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/resources": "2.8.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -4100,21 +4094,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
-      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
@@ -10560,6 +10539,27 @@
         "xmlhttprequest-ssl": "~2.1.1"
       }
     },
+    "node_modules/engine.io-client/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/engine.io-parser": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
@@ -10567,6 +10567,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/enhanced-resolve": {
@@ -12027,20 +12048,33 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/formidable": {
@@ -14324,10 +14358,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -16725,7 +16769,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -18364,6 +18407,27 @@
         "ws": "~8.20.1"
       }
     },
+    "node_modules/socket.io-adapter/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/socket.io-client": {
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
@@ -19263,18 +19327,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/tmpl": {
@@ -20449,9 +20501,10 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -49,9 +49,16 @@
     "@prisma/client": "7.5.0"
   },
   "overrides": {
+    "@babel/core": "7.29.7",
     "@hono/node-server": "2.0.4",
     "@nestjs/common": "11.1.24",
     "@nestjs/core": "11.1.24",
+    "@opentelemetry/core": "2.8.0",
+    "@opentelemetry/resources": "2.8.0",
+    "@opentelemetry/sdk-trace-base": "2.8.0",
+    "@istanbuljs/load-nyc-config": {
+      "js-yaml": "4.2.0"
+    },
     "@tootallnate/once": "3.0.1",
     "brace-expansion": "1.1.15",
     "anymatch": {
@@ -61,10 +68,18 @@
       "yaml": "1.10.3"
     },
     "effect": "3.20.0",
+    "engine.io": {
+      "ws": "8.21.0"
+    },
+    "engine.io-client": {
+      "ws": "8.21.0"
+    },
     "file-type": "21.3.4",
+    "form-data": "4.0.6",
     "jest-util": {
       "picomatch": "2.3.2"
     },
+    "js-yaml": "4.2.0",
     "hono": "4.12.23",
     "lodash": "4.18.1",
     "micromatch": {

--- a/packages/db/prisma/migrations/20260615110000_appointment_reminder_lifecycle/migration.sql
+++ b/packages/db/prisma/migrations/20260615110000_appointment_reminder_lifecycle/migration.sql
@@ -1,0 +1,20 @@
+ALTER TABLE "Reminder" ADD COLUMN "appointmentId" UUID;
+
+UPDATE "Reminder"
+SET "appointmentId" = ((regexp_match("payloadJson", '"appointmentId":"([0-9a-fA-F-]{36})"'))[1])::uuid
+WHERE "templateKey" = 'APPOINTMENT_REMINDER_V1'
+  AND "appointmentId" IS NULL
+  AND "payloadJson" ~ '"appointmentId":"[0-9a-fA-F-]{36}"'
+  AND EXISTS (
+    SELECT 1
+    FROM "Appointment"
+    WHERE "Appointment"."id" =
+      ((regexp_match("Reminder"."payloadJson", '"appointmentId":"([0-9a-fA-F-]{36})"'))[1])::uuid
+  );
+
+CREATE INDEX "Reminder_appointmentId_idx" ON "Reminder"("appointmentId");
+
+ALTER TABLE "Reminder"
+ADD CONSTRAINT "Reminder_appointmentId_fkey"
+FOREIGN KEY ("appointmentId") REFERENCES "Appointment"("id")
+ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -633,10 +633,11 @@ model Prescription {
 }
 
 model Reminder {
-  id          String  @id @default(uuid()) @db.Uuid
-  clinicId    String  @db.Uuid
-  patientId   String  @db.Uuid
-  encounterId String? @db.Uuid
+  id            String  @id @default(uuid()) @db.Uuid
+  clinicId      String  @db.Uuid
+  patientId     String  @db.Uuid
+  encounterId   String? @db.Uuid
+  appointmentId String? @db.Uuid
 
   channel     ReminderChannel
   toAddress   String          @db.VarChar(320)
@@ -652,13 +653,15 @@ model Reminder {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  clinic    Clinic     @relation(fields: [clinicId], references: [id], onDelete: Cascade)
-  patient   Patient    @relation(fields: [patientId], references: [id], onDelete: Cascade)
-  encounter Encounter? @relation(fields: [encounterId], references: [id], onDelete: SetNull)
+  clinic      Clinic       @relation(fields: [clinicId], references: [id], onDelete: Cascade)
+  patient     Patient      @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  encounter   Encounter?   @relation(fields: [encounterId], references: [id], onDelete: SetNull)
+  appointment Appointment? @relation(fields: [appointmentId], references: [id], onDelete: SetNull)
 
   @@index([clinicId, scheduledAt])
   @@index([status, scheduledAt])
   @@index([patientId])
+  @@index([appointmentId])
 }
 
 model PatientAccountLink {
@@ -776,6 +779,7 @@ model Appointment {
   changeRequests    AppointmentRequest[] @relation("AppointmentSourceChangeRequest")
   assignedDoctor    User?                @relation("AppointmentAssignedDoctor", fields: [assignedDoctorId], references: [id], onDelete: SetNull)
   assignedVolunteer User?                @relation("AppointmentAssignedVolunteer", fields: [assignedVolunteerId], references: [id], onDelete: SetNull)
+  reminders         Reminder[]
 
   @@index([clinicId, startsAt])
   @@index([patientId, startsAt])


### PR DESCRIPTION
## Summary
- Completed appointment reminder lifecycle automation for confirm, reschedule, cancel, complete, and no-show flows.
- Linked reminder records directly to appointments and added stale-send safeguards in the reminder processor.
- Surfaced reminder delivery state in staff appointment and reminder history views.
- Documented operator-facing reminder lifecycle behavior.

## Details
- Added nullable `Reminder.appointmentId` with migration/backfill from existing appointment reminder payloads.
- Refactored appointment reminder creation to consistently create linked SMS/email/no-contact records.
- Added deterministic BullMQ job IDs and best-effort queued job removal when reminders are suppressed.
- Prevented sends for cancelled, completed, no-show, missing, or rescheduled appointment reminders.
- Extended reminder list responses with `appointmentId` and `updatedAt`.
- Added staff appointment `reminderSummary` with status counts, next queued send, channels, and latest failure.
- Updated reminders UI with delivered status filtering, appointment-aware rows, and clearer failure labels.

## Tests
- Added reminder service tests for scheduling, suppression, stale sends, delivery status, and missing contact methods.
- Updated patient portal service tests for reminder summaries and no-contact appointment confirmation.
- Ran API/web typechecks, lint, security scan, unit tests, build, and e2e.

Closes #5 