### PR TITLE
Offline/expansion tenant context for background jobs and scripts

### DIFF
--- a/apps/api/src/prisma/job-tenant-context.runner.spec.ts
+++ b/apps/api/src/prisma/job-tenant-context.runner.spec.ts
@@ -1,0 +1,171 @@
+import { Logger } from '@nestjs/common';
+import { JobTenantContextRunner, UnresolvedJobTenantError } from './job-tenant-context.runner';
+
+describe('JobTenantContextRunner', () => {
+  const transactionClient = { marker: 'transaction-client' };
+  const prisma = {
+    withClinicContext: jest.fn(async (_clinicId, _context, callback) =>
+      callback(transactionClient),
+    ),
+    withSystemContext: jest.fn(async (_context, callback) => callback(transactionClient)),
+  };
+  let runner: JobTenantContextRunner;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    runner = new JobTenantContextRunner(prisma as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('runs work with the explicit clinic and user context', async () => {
+    const callback = jest.fn().mockResolvedValue('done');
+
+    const result = await runner.runClinicJob(
+      {
+        queueName: 'research-exports',
+        jobId: 'job-1',
+        resourceId: 'export-1',
+        tenant: { clinicId: ' clinic-1 ', userId: ' user-1 ' },
+        legacy: {
+          resolveTenant: jest.fn(),
+          systemReason: 'Resolve a legacy export tenant',
+        },
+        unresolvedTenant: 'fail',
+      },
+      callback,
+    );
+
+    expect(result).toBe('done');
+    expect(prisma.withSystemContext).not.toHaveBeenCalled();
+    expect(prisma.withClinicContext).toHaveBeenCalledWith(
+      'clinic-1',
+      { requestId: 'job-1', userId: 'user-1' },
+      callback,
+    );
+    expect(callback).toHaveBeenCalledWith(transactionClient);
+  });
+
+  it('resolves legacy tenant metadata under an explicit system reason', async () => {
+    const resolveTenant = jest.fn().mockResolvedValue({ clinicId: 'clinic-legacy', userId: null });
+
+    await runner.runClinicJob(
+      {
+        queueName: 'reminders',
+        jobId: 42,
+        resourceId: 'reminder-1',
+        legacy: {
+          resolveTenant,
+          systemReason: 'Resolve tenant for a legacy reminder payload',
+        },
+        unresolvedTenant: 'discard',
+      },
+      jest.fn().mockResolvedValue(undefined),
+    );
+
+    expect(prisma.withSystemContext).toHaveBeenCalledWith(
+      {
+        requestId: '42',
+        userId: null,
+        systemReason: 'Resolve tenant for a legacy reminder payload',
+      },
+      expect.any(Function),
+    );
+    expect(resolveTenant).toHaveBeenCalledTimes(1);
+    expect(prisma.withClinicContext).toHaveBeenCalledWith(
+      'clinic-legacy',
+      { requestId: '42', userId: null },
+      expect.any(Function),
+    );
+  });
+
+  it('safely discards unresolved work without invoking the callback', async () => {
+    const callback = jest.fn();
+
+    const result = await runner.runClinicJob(
+      {
+        queueName: 'reminders',
+        resourceId: 'deleted-reminder',
+        legacy: {
+          resolveTenant: jest.fn().mockResolvedValue(null),
+          systemReason: 'Resolve tenant for a legacy reminder payload',
+        },
+        unresolvedTenant: 'discard',
+      },
+      callback,
+    );
+
+    expect(result).toBeUndefined();
+    expect(prisma.withClinicContext).not.toHaveBeenCalled();
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('fails unresolved work without invoking it when fail policy is selected', async () => {
+    const callback = jest.fn();
+
+    await expect(
+      runner.runClinicJob(
+        {
+          queueName: 'research-exports',
+          resourceId: 'missing-export',
+          legacy: {
+            resolveTenant: jest.fn().mockResolvedValue(null),
+            systemReason: 'Resolve tenant for a legacy research export payload',
+          },
+          unresolvedTenant: 'fail',
+        },
+        callback,
+      ),
+    ).rejects.toBeInstanceOf(UnresolvedJobTenantError);
+
+    expect(prisma.withClinicContext).not.toHaveBeenCalled();
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('requires Prisma to validate every system-context reason', async () => {
+    await runner.runSystemJob(
+      {
+        queueName: 'maintenance',
+        resourceId: 'cleanup',
+        systemReason: '',
+      },
+      jest.fn().mockResolvedValue(undefined),
+    );
+
+    expect(prisma.withSystemContext).toHaveBeenCalledWith(
+      {
+        requestId: 'cleanup',
+        userId: null,
+        systemReason: '',
+      },
+      expect.any(Function),
+    );
+  });
+
+  it('propagates callback failures without retrying outside tenant context', async () => {
+    const error = new Error('job failed');
+    prisma.withClinicContext.mockRejectedValueOnce(error);
+
+    await expect(
+      runner.runClinicJob(
+        {
+          queueName: 'reminders',
+          resourceId: 'reminder-1',
+          tenant: { clinicId: 'clinic-1', userId: null },
+          legacy: {
+            resolveTenant: jest.fn(),
+            systemReason: 'Resolve tenant for a legacy reminder payload',
+          },
+          unresolvedTenant: 'discard',
+        },
+        jest.fn(),
+      ),
+    ).rejects.toBe(error);
+
+    expect(prisma.withSystemContext).not.toHaveBeenCalled();
+    expect(prisma.withClinicContext).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/prisma/job-tenant-context.runner.ts
+++ b/apps/api/src/prisma/job-tenant-context.runner.ts
@@ -1,0 +1,137 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from './prisma.service';
+
+export type JobTenant = {
+  clinicId: string;
+  userId: string | null;
+};
+
+export type UnresolvedTenantPolicy = 'discard' | 'fail';
+
+export type ClinicJobContext = {
+  queueName: string;
+  jobId?: string | number | null;
+  resourceId: string;
+  tenant?: JobTenant | null;
+  legacy: {
+    resolveTenant: () => Promise<JobTenant | null>;
+    systemReason: string;
+  };
+  unresolvedTenant: UnresolvedTenantPolicy;
+};
+
+export type SystemJobContext = {
+  queueName: string;
+  jobId?: string | number | null;
+  resourceId: string;
+  systemReason: string;
+  userId?: string | null;
+};
+
+export class UnresolvedJobTenantError extends Error {
+  constructor(queueName: string, resourceId: string) {
+    super(`Unable to resolve tenant for ${queueName} job resource ${resourceId}`);
+    this.name = 'UnresolvedJobTenantError';
+  }
+}
+
+@Injectable()
+export class JobTenantContextRunner {
+  private readonly logger = new Logger(JobTenantContextRunner.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async runClinicJob<T>(
+    context: ClinicJobContext,
+    callback: (client: Prisma.TransactionClient) => Promise<T>,
+  ): Promise<T | undefined> {
+    const requestId = this.getRequestId(context.jobId, context.resourceId);
+    let tenant = this.normalizeTenant(context.tenant);
+
+    if (!tenant) {
+      this.warn('legacy_job_tenant_resolution', context, {
+        systemReason: context.legacy.systemReason,
+      });
+      tenant = this.normalizeTenant(
+        await this.runSystemJob(
+          {
+            queueName: context.queueName,
+            jobId: context.jobId,
+            resourceId: context.resourceId,
+            systemReason: context.legacy.systemReason,
+          },
+          () => context.legacy.resolveTenant(),
+        ),
+      );
+    }
+
+    if (!tenant) {
+      this.warn('unresolved_job_tenant', context, {
+        policy: context.unresolvedTenant,
+      });
+      if (context.unresolvedTenant === 'fail') {
+        throw new UnresolvedJobTenantError(context.queueName, context.resourceId);
+      }
+      return undefined;
+    }
+
+    return this.prisma.withClinicContext(
+      tenant.clinicId,
+      { requestId, userId: tenant.userId },
+      callback,
+    );
+  }
+
+  async runSystemJob<T>(
+    context: SystemJobContext,
+    callback: (client: Prisma.TransactionClient) => Promise<T>,
+  ): Promise<T> {
+    this.warn('system_job_context', context, {
+      systemReason: context.systemReason,
+    });
+    return this.prisma.withSystemContext(
+      {
+        requestId: this.getRequestId(context.jobId, context.resourceId),
+        userId: context.userId ?? null,
+        systemReason: context.systemReason,
+      },
+      callback,
+    );
+  }
+
+  private normalizeTenant(tenant: JobTenant | null | undefined): JobTenant | null {
+    if (!tenant) {
+      return null;
+    }
+
+    const clinicId = tenant.clinicId.trim();
+    if (!clinicId) {
+      return null;
+    }
+    return {
+      clinicId,
+      userId: tenant.userId?.trim() || null,
+    };
+  }
+
+  private getRequestId(jobId: string | number | null | undefined, resourceId: string) {
+    return String(jobId ?? resourceId);
+  }
+
+  private warn(
+    event: string,
+    context: Pick<ClinicJobContext, 'queueName' | 'jobId' | 'resourceId'>,
+    details: Record<string, string>,
+  ) {
+    this.logger.warn(
+      JSON.stringify({
+        event,
+        queueName: context.queueName,
+        jobId: context.jobId == null ? null : String(context.jobId),
+        resourceId: context.resourceId,
+        ...details,
+      }),
+    );
+  }
+}

--- a/apps/api/src/prisma/prisma.module.ts
+++ b/apps/api/src/prisma/prisma.module.ts
@@ -2,17 +2,19 @@ import { Global, Module } from '@nestjs/common';
 import { APP_INTERCEPTOR } from '@nestjs/core';
 import { PrismaService } from './prisma.service';
 import { PrismaRlsInterceptor } from './prisma-rls.interceptor';
+import { JobTenantContextRunner } from './job-tenant-context.runner';
 
 @Global()
 @Module({
   providers: [
     PrismaService,
     PrismaRlsInterceptor,
+    JobTenantContextRunner,
     {
       provide: APP_INTERCEPTOR,
       useExisting: PrismaRlsInterceptor,
     },
   ],
-  exports: [PrismaService],
+  exports: [PrismaService, JobTenantContextRunner],
 })
 export class PrismaModule {}

--- a/apps/api/src/prisma/prisma.service.spec.ts
+++ b/apps/api/src/prisma/prisma.service.spec.ts
@@ -1,0 +1,152 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { Prisma } from '@prisma/client';
+import {
+  InvalidSystemContextError,
+  PrismaContextConflictError,
+  PrismaService,
+  UnknownClinicContextError,
+} from './prisma.service';
+
+type TransactionHarness = {
+  $executeRaw: jest.Mock;
+  clinic: {
+    findUnique: jest.Mock;
+  };
+};
+
+type TestablePrismaService = {
+  rlsStorage: AsyncLocalStorage<{
+    client: Prisma.TransactionClient;
+    rls: Record<string, unknown>;
+  }>;
+  transactionWithContext<T>(callback: (client: Prisma.TransactionClient) => Promise<T>): Promise<T>;
+};
+
+describe('PrismaService tenant context', () => {
+  let prisma: PrismaService;
+  let tx: TransactionHarness;
+
+  beforeEach(() => {
+    tx = {
+      $executeRaw: jest.fn().mockResolvedValue(1),
+      clinic: {
+        findUnique: jest.fn().mockResolvedValue({
+          organizationId: 'organization-1',
+          zoneCode: 'zone-1',
+        }),
+      },
+    };
+    prisma = Object.create(PrismaService.prototype) as PrismaService;
+    const testable = prisma as unknown as TestablePrismaService;
+    testable.rlsStorage = new AsyncLocalStorage();
+    testable.transactionWithContext = jest.fn(async (callback) => callback(tx as never));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('records a normalized system context and clears it after work completes', async () => {
+    await prisma.withSystemContext(
+      {
+        requestId: 'job-1',
+        userId: null,
+        systemReason: 'Resolve a legacy job tenant',
+      },
+      async () => {
+        expect(prisma.getCurrentRlsContext()).toEqual({
+          requestId: 'job-1',
+          userId: null,
+          organizationId: null,
+          clinicIds: [],
+          activeClinicId: null,
+          zoneCode: null,
+          isSystemAdmin: true,
+          systemReason: 'Resolve a legacy job tenant',
+        });
+      },
+    );
+
+    expect(prisma.getCurrentRlsContext()).toBeNull();
+    expect(tx.$executeRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects an empty system reason before opening a transaction', async () => {
+    await expect(
+      prisma.withSystemContext({ systemReason: '   ' }, async () => undefined),
+    ).rejects.toBeInstanceOf(InvalidSystemContextError);
+
+    expect(
+      (prisma as unknown as TestablePrismaService).transactionWithContext,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('applies clinic scope before resolving and enriching clinic metadata', async () => {
+    await prisma.withClinicContext(
+      'clinic-1',
+      { requestId: 'job-1', userId: 'user-1' },
+      async () => {
+        expect(prisma.getCurrentRlsContext()).toEqual({
+          requestId: 'job-1',
+          userId: 'user-1',
+          organizationId: 'organization-1',
+          clinicIds: ['clinic-1'],
+          activeClinicId: 'clinic-1',
+          zoneCode: 'zone-1',
+          isSystemAdmin: false,
+          systemReason: null,
+        });
+      },
+    );
+
+    expect(tx.$executeRaw).toHaveBeenCalledTimes(2);
+    expect(tx.clinic.findUnique).toHaveBeenCalledWith({
+      where: { id: 'clinic-1' },
+      select: { organizationId: true, zoneCode: true },
+    });
+    expect(prisma.getCurrentRlsContext()).toBeNull();
+  });
+
+  it('fails clearly when clinic metadata cannot be resolved', async () => {
+    tx.clinic.findUnique.mockResolvedValue(null);
+
+    await expect(
+      prisma.withClinicContext('missing-clinic', {}, async () => undefined),
+    ).rejects.toBeInstanceOf(UnknownClinicContextError);
+
+    expect(tx.$executeRaw).toHaveBeenCalledTimes(1);
+    expect(prisma.getCurrentRlsContext()).toBeNull();
+  });
+
+  it('deduplicates clinic IDs in generic RLS context', async () => {
+    await prisma.withRlsContext(
+      {
+        clinicIds: ['clinic-2', 'clinic-1', 'clinic-2'],
+        activeClinicId: 'clinic-1',
+      },
+      async () => {
+        expect(prisma.getCurrentRlsContext()?.clinicIds).toEqual(['clinic-1', 'clinic-2']);
+      },
+    );
+  });
+
+  it('rejects incompatible nested contexts instead of retaining broader access', async () => {
+    await prisma.withSystemContext({ systemReason: 'System maintenance' }, async () => {
+      await expect(
+        prisma.withClinicContext('clinic-1', {}, async () => undefined),
+      ).rejects.toBeInstanceOf(PrismaContextConflictError);
+    });
+  });
+
+  it('clears context when tenant work throws', async () => {
+    const error = new Error('tenant work failed');
+
+    await expect(
+      prisma.withRlsContext({ clinicIds: ['clinic-1'] }, async () => {
+        throw error;
+      }),
+    ).rejects.toBe(error);
+
+    expect(prisma.getCurrentRlsContext()).toBeNull();
+  });
+});

--- a/apps/api/src/prisma/prisma.service.ts
+++ b/apps/api/src/prisma/prisma.service.ts
@@ -11,7 +11,15 @@ export interface PrismaRlsContext {
   activeClinicId?: string | null;
   zoneCode?: string | null;
   isSystemAdmin?: boolean;
+  systemReason?: string | null;
 }
+
+export type PrismaSystemContext = Omit<
+  PrismaRlsContext,
+  'clinicIds' | 'isSystemAdmin' | 'systemReason'
+> & {
+  systemReason: string;
+};
 
 type PrismaLikeClient = PrismaClient | Prisma.TransactionClient;
 
@@ -26,14 +34,39 @@ type TransactionOptions = {
   isolationLevel?: Prisma.TransactionIsolationLevel;
 };
 
+export class InvalidSystemContextError extends Error {
+  constructor() {
+    super('System context requires a non-empty reason');
+    this.name = 'InvalidSystemContextError';
+  }
+}
+
+export class PrismaContextConflictError extends Error {
+  constructor() {
+    super('Cannot change Prisma tenant context inside an active context');
+    this.name = 'PrismaContextConflictError';
+  }
+}
+
+export class UnknownClinicContextError extends Error {
+  constructor(clinicId: string) {
+    super(`Cannot establish tenant context for unknown clinic: ${clinicId}`);
+    this.name = 'UnknownClinicContextError';
+  }
+}
+
 const INTERNAL_PRISMA_KEYS = new Set([
   'applyRlsContext',
+  'assertCompatibleContext',
+  'assertCompatibleClinicContext',
   'constructor',
   'getActiveClient',
   'getCurrentRlsContext',
+  'normalizeRlsContext',
   'onModuleDestroy',
   'onModuleInit',
   'rlsStorage',
+  'transactionWithContext',
   'withClinicContext',
   'withRlsContext',
   'withSystemContext',
@@ -86,20 +119,19 @@ export class PrismaService extends PrismaClient implements OnModuleInit, OnModul
     context: PrismaRlsContext,
     callback: (client: Prisma.TransactionClient) => Promise<T>,
   ): Promise<T> {
+    const normalizedContext = this.normalizeRlsContext(context);
     const active = this.rlsStorage.getStore();
     if (active) {
+      this.assertCompatibleContext(active.rls, normalizedContext);
       return callback(active.client);
     }
 
-    return super.$transaction(async (tx) => {
-      await this.applyRlsContext(tx, context);
+    return this.transactionWithContext(async (tx) => {
+      await this.applyRlsContext(tx, normalizedContext);
       return this.rlsStorage.run(
         {
           client: tx,
-          rls: {
-            ...context,
-            clinicIds: [...new Set(context.clinicIds ?? [])],
-          },
+          rls: normalizedContext,
         },
         () => callback(tx),
       );
@@ -111,19 +143,67 @@ export class PrismaService extends PrismaClient implements OnModuleInit, OnModul
     context: Omit<PrismaRlsContext, 'activeClinicId' | 'clinicIds' | 'isSystemAdmin'>,
     callback: (client: Prisma.TransactionClient) => Promise<T>,
   ): Promise<T> {
-    const rlsContext = await this.buildClinicRlsContext(clinicId, context);
-    return this.withRlsContext(rlsContext, callback);
+    const normalizedClinicId = clinicId.trim();
+    if (!normalizedClinicId) {
+      throw new UnknownClinicContextError(normalizedClinicId);
+    }
+
+    const active = this.rlsStorage.getStore();
+    if (active) {
+      this.assertCompatibleClinicContext(active.rls, normalizedClinicId, context);
+      return callback(active.client);
+    }
+
+    const initialContext = this.normalizeRlsContext({
+      ...context,
+      organizationId: context.organizationId ?? null,
+      zoneCode: context.zoneCode ?? null,
+      clinicIds: [normalizedClinicId],
+      activeClinicId: normalizedClinicId,
+      isSystemAdmin: false,
+      systemReason: null,
+    });
+
+    return this.withRlsContext(initialContext, async (tx) => {
+      const clinic = await tx.clinic.findUnique({
+        where: { id: normalizedClinicId },
+        select: { organizationId: true, zoneCode: true },
+      });
+      if (!clinic) {
+        throw new UnknownClinicContextError(normalizedClinicId);
+      }
+
+      const enrichedContext = this.normalizeRlsContext({
+        ...initialContext,
+        organizationId: context.organizationId ?? clinic.organizationId,
+        zoneCode: context.zoneCode ?? clinic.zoneCode,
+      });
+      await this.applyRlsContext(tx, enrichedContext);
+
+      const current = this.rlsStorage.getStore();
+      if (current) {
+        current.rls = enrichedContext;
+      }
+
+      return callback(tx);
+    });
   }
 
   async withSystemContext<T>(
-    context: Omit<PrismaRlsContext, 'clinicIds' | 'isSystemAdmin'>,
+    context: PrismaSystemContext,
     callback: (client: Prisma.TransactionClient) => Promise<T>,
   ): Promise<T> {
+    const systemReason = context.systemReason.trim();
+    if (!systemReason) {
+      throw new InvalidSystemContextError();
+    }
+
     return this.withRlsContext(
       {
         ...context,
         clinicIds: [],
         isSystemAdmin: true,
+        systemReason,
       },
       callback,
     );
@@ -154,23 +234,63 @@ export class PrismaService extends PrismaClient implements OnModuleInit, OnModul
     return this.rlsStorage.getStore()?.client ?? this;
   }
 
-  private async buildClinicRlsContext(
-    clinicId: string,
-    context: Omit<PrismaRlsContext, 'activeClinicId' | 'clinicIds' | 'isSystemAdmin'>,
-  ): Promise<PrismaRlsContext> {
-    const clinic = await this.clinic.findUnique({
-      where: { id: clinicId },
-      select: { organizationId: true, zoneCode: true },
-    });
+  private transactionWithContext<T>(
+    callback: (client: Prisma.TransactionClient) => Promise<T>,
+  ): Promise<T> {
+    return super.$transaction(callback);
+  }
 
+  private normalizeRlsContext(context: PrismaRlsContext): PrismaRlsContext {
     return {
       ...context,
-      organizationId: context.organizationId ?? clinic?.organizationId ?? null,
-      zoneCode: context.zoneCode ?? clinic?.zoneCode ?? null,
+      userId: context.userId ?? null,
+      organizationId: context.organizationId ?? null,
+      clinicIds: [...new Set(context.clinicIds ?? [])].sort(),
+      activeClinicId: context.activeClinicId ?? null,
+      zoneCode: context.zoneCode ?? null,
+      isSystemAdmin: context.isSystemAdmin ?? false,
+      systemReason: context.systemReason ?? null,
+    };
+  }
+
+  private assertCompatibleContext(active: PrismaRlsContext, requested: PrismaRlsContext) {
+    const normalizedActive = this.normalizeRlsContext(active);
+    const sameClinicIds =
+      normalizedActive.clinicIds?.length === requested.clinicIds?.length &&
+      normalizedActive.clinicIds?.every(
+        (clinicId, index) => clinicId === requested.clinicIds?.[index],
+      );
+    const isCompatible =
+      normalizedActive.requestId === requested.requestId &&
+      normalizedActive.userId === requested.userId &&
+      normalizedActive.organizationId === requested.organizationId &&
+      sameClinicIds &&
+      normalizedActive.activeClinicId === requested.activeClinicId &&
+      normalizedActive.zoneCode === requested.zoneCode &&
+      normalizedActive.isSystemAdmin === requested.isSystemAdmin &&
+      normalizedActive.systemReason === requested.systemReason;
+
+    if (!isCompatible) {
+      throw new PrismaContextConflictError();
+    }
+  }
+
+  private assertCompatibleClinicContext(
+    active: PrismaRlsContext,
+    clinicId: string,
+    context: Omit<PrismaRlsContext, 'activeClinicId' | 'clinicIds' | 'isSystemAdmin'>,
+  ) {
+    const requested = this.normalizeRlsContext({
+      ...active,
+      ...context,
+      organizationId: context.organizationId ?? active.organizationId,
+      zoneCode: context.zoneCode ?? active.zoneCode,
       clinicIds: [clinicId],
       activeClinicId: clinicId,
       isSystemAdmin: false,
-    };
+      systemReason: null,
+    });
+    this.assertCompatibleContext(active, requested);
   }
 
   private async applyRlsContext(client: Prisma.TransactionClient, context: PrismaRlsContext) {
@@ -183,6 +303,7 @@ export class PrismaService extends PrismaClient implements OnModuleInit, OnModul
         set_config('app.current_clinic_ids', ${clinicIds}, true),
         set_config('app.current_active_clinic_id', ${context.activeClinicId ?? ''}, true),
         set_config('app.current_zone_code', ${context.zoneCode ?? ''}, true),
+        set_config('app.system_context_reason', ${context.systemReason ?? ''}, true),
         set_config(
           'app.is_system_admin',
           ${context.isSystemAdmin ? 'true' : 'false'},

--- a/apps/api/src/reminders/reminder.processor.spec.ts
+++ b/apps/api/src/reminders/reminder.processor.spec.ts
@@ -38,7 +38,10 @@ describe('ReminderProcessor tenant context', () => {
     await processor.process({ id: 'job-1', data: { reminderId: 'reminder-1' } } as never);
 
     expect(prisma.withSystemContext).toHaveBeenCalledWith(
-      { requestId: 'job-1' },
+      {
+        requestId: 'job-1',
+        systemReason: 'Resolve tenant for a legacy reminder payload',
+      },
       expect.any(Function),
     );
     expect(reminderService.findReminderClinicId).toHaveBeenCalledWith('reminder-1');

--- a/apps/api/src/reminders/reminder.processor.spec.ts
+++ b/apps/api/src/reminders/reminder.processor.spec.ts
@@ -5,50 +5,79 @@ describe('ReminderProcessor tenant context', () => {
     processReminder: jest.fn(),
     findReminderClinicId: jest.fn(),
   };
-  const prisma = {
-    withClinicContext: jest.fn(async (_clinicId, _context, callback) => callback()),
-    withSystemContext: jest.fn(async (_context, callback) => callback()),
+  const tenantContext = {
+    runClinicJob: jest.fn(async (_context, callback) => callback()),
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('processes new reminder jobs inside the queued clinic context', async () => {
-    const processor = new ReminderProcessor(reminderService as never, prisma as never);
+  it('passes new reminder jobs through the queued clinic context', async () => {
+    const processor = new ReminderProcessor(reminderService as never, tenantContext as never);
 
     await processor.process({
       id: 'job-1',
-      data: { reminderId: 'reminder-1', clinicId: 'clinic-1' },
+      data: {
+        reminderId: 'reminder-1',
+        clinicId: 'clinic-1',
+        userId: null,
+      },
     } as never);
 
-    expect(prisma.withSystemContext).not.toHaveBeenCalled();
-    expect(prisma.withClinicContext).toHaveBeenCalledWith(
-      'clinic-1',
-      { requestId: 'job-1', userId: null },
+    expect(tenantContext.runClinicJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queueName: 'reminders',
+        jobId: 'job-1',
+        resourceId: 'reminder-1',
+        tenant: { clinicId: 'clinic-1', userId: null },
+        unresolvedTenant: 'discard',
+      }),
       expect.any(Function),
     );
+    expect(reminderService.findReminderClinicId).not.toHaveBeenCalled();
     expect(reminderService.processReminder).toHaveBeenCalledWith('reminder-1');
   });
 
-  it('uses system context only to resolve legacy jobs missing clinicId', async () => {
-    reminderService.findReminderClinicId.mockResolvedValue('clinic-1');
-    const processor = new ReminderProcessor(reminderService as never, prisma as never);
+  it('declares safe discard and resolves legacy reminder tenants as system work', async () => {
+    reminderService.findReminderClinicId.mockResolvedValue('clinic-legacy');
+    const processor = new ReminderProcessor(reminderService as never, tenantContext as never);
 
-    await processor.process({ id: 'job-1', data: { reminderId: 'reminder-1' } } as never);
+    await processor.process({
+      id: 'job-legacy',
+      data: { reminderId: 'reminder-legacy' },
+    } as never);
 
-    expect(prisma.withSystemContext).toHaveBeenCalledWith(
-      {
-        requestId: 'job-1',
+    const context = tenantContext.runClinicJob.mock.calls[0][0];
+    expect(context).toMatchObject({
+      tenant: null,
+      unresolvedTenant: 'discard',
+      legacy: {
         systemReason: 'Resolve tenant for a legacy reminder payload',
       },
-      expect.any(Function),
-    );
-    expect(reminderService.findReminderClinicId).toHaveBeenCalledWith('reminder-1');
-    expect(prisma.withClinicContext).toHaveBeenCalledWith(
-      'clinic-1',
-      { requestId: 'job-1', userId: null },
-      expect.any(Function),
-    );
+    });
+    await expect(context.legacy.resolveTenant()).resolves.toEqual({
+      clinicId: 'clinic-legacy',
+      userId: null,
+    });
+  });
+
+  it('does not replace a supplied tenant with a database lookup', async () => {
+    const processor = new ReminderProcessor(reminderService as never, tenantContext as never);
+
+    await processor.process({
+      id: 'job-1',
+      data: {
+        reminderId: 'reminder-1',
+        clinicId: 'different-clinic',
+        userId: null,
+      },
+    } as never);
+
+    expect(tenantContext.runClinicJob.mock.calls[0][0].tenant).toEqual({
+      clinicId: 'different-clinic',
+      userId: null,
+    });
+    expect(reminderService.findReminderClinicId).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/reminders/reminder.processor.ts
+++ b/apps/api/src/reminders/reminder.processor.ts
@@ -1,43 +1,45 @@
 import { Processor, WorkerHost } from '@nestjs/bullmq';
 import { Job } from 'bullmq';
-import { PrismaService } from '../prisma/prisma.service';
+import { JobTenantContextRunner } from '../prisma/job-tenant-context.runner';
 import { ReminderService } from './reminder.service';
+
+export type ReminderJobData = {
+  reminderId: string;
+  clinicId?: string;
+  userId?: string | null;
+};
 
 @Processor('reminders')
 export class ReminderProcessor extends WorkerHost {
   constructor(
     private readonly reminderService: ReminderService,
-    private readonly prisma: PrismaService,
+    private readonly tenantContext: JobTenantContextRunner,
   ) {
     super();
   }
 
-  async process(job: Job<{ reminderId: string; clinicId?: string }>): Promise<void> {
-    const { reminderId } = job.data;
-    const clinicId =
-      job.data.clinicId ??
-      (await this.prisma.withSystemContext(
-        {
-          requestId: String(job.id ?? reminderId),
+  async process(job: Job<ReminderJobData>): Promise<void> {
+    const { reminderId, clinicId, userId } = job.data;
+    await this.tenantContext.runClinicJob(
+      {
+        queueName: 'reminders',
+        jobId: job.id,
+        resourceId: reminderId,
+        tenant: clinicId ? { clinicId, userId: userId ?? null } : null,
+        legacy: {
           systemReason: 'Resolve tenant for a legacy reminder payload',
+          resolveTenant: async () => {
+            const resolvedClinicId = await this.reminderService.findReminderClinicId(reminderId);
+            return resolvedClinicId
+              ? {
+                  clinicId: resolvedClinicId,
+                  userId: null,
+                }
+              : null;
+          },
         },
-        () => this.reminderService.findReminderClinicId(reminderId),
-      ));
-
-    if (!clinicId) {
-      await this.prisma.withSystemContext(
-        {
-          requestId: String(job.id ?? reminderId),
-          systemReason: 'Process an unresolved legacy reminder payload',
-        },
-        () => this.reminderService.processReminder(reminderId),
-      );
-      return;
-    }
-
-    await this.prisma.withClinicContext(
-      clinicId,
-      { requestId: String(job.id ?? reminderId), userId: null },
+        unresolvedTenant: 'discard',
+      },
       () => this.reminderService.processReminder(reminderId),
     );
   }

--- a/apps/api/src/reminders/reminder.processor.ts
+++ b/apps/api/src/reminders/reminder.processor.ts
@@ -16,13 +16,21 @@ export class ReminderProcessor extends WorkerHost {
     const { reminderId } = job.data;
     const clinicId =
       job.data.clinicId ??
-      (await this.prisma.withSystemContext({ requestId: String(job.id ?? reminderId) }, () =>
-        this.reminderService.findReminderClinicId(reminderId),
+      (await this.prisma.withSystemContext(
+        {
+          requestId: String(job.id ?? reminderId),
+          systemReason: 'Resolve tenant for a legacy reminder payload',
+        },
+        () => this.reminderService.findReminderClinicId(reminderId),
       ));
 
     if (!clinicId) {
-      await this.prisma.withSystemContext({ requestId: String(job.id ?? reminderId) }, () =>
-        this.reminderService.processReminder(reminderId),
+      await this.prisma.withSystemContext(
+        {
+          requestId: String(job.id ?? reminderId),
+          systemReason: 'Process an unresolved legacy reminder payload',
+        },
+        () => this.reminderService.processReminder(reminderId),
       );
       return;
     }

--- a/apps/api/src/reminders/reminder.service.spec.ts
+++ b/apps/api/src/reminders/reminder.service.spec.ts
@@ -109,7 +109,7 @@ describe('ReminderService', () => {
     });
     expect(reminderQueue.add).toHaveBeenCalledWith(
       'send',
-      { reminderId: 'reminder-1', clinicId: 'clinic-1' },
+      { reminderId: 'reminder-1', clinicId: 'clinic-1', userId: null },
       expect.objectContaining({ jobId: 'reminder:reminder-1' }),
     );
   });

--- a/apps/api/src/reminders/reminder.service.ts
+++ b/apps/api/src/reminders/reminder.service.ts
@@ -648,7 +648,7 @@ export class ReminderService {
     const delayMs = Math.max(0, scheduledAt.getTime() - Date.now());
     await this.reminderQueue.add(
       'send',
-      { reminderId, clinicId },
+      { reminderId, clinicId, userId: null },
       {
         jobId: this.getReminderJobId(reminderId),
         delay: delayMs,

--- a/apps/api/src/research/research-export.processor.spec.ts
+++ b/apps/api/src/research/research-export.processor.spec.ts
@@ -3,52 +3,93 @@ import { ResearchExportProcessor } from './research-export.processor';
 describe('ResearchExportProcessor tenant context', () => {
   const researchExportService = {
     processQueuedExport: jest.fn(),
-    findExportClinicId: jest.fn(),
+    findExportJobTenant: jest.fn(),
   };
-  const prisma = {
-    withClinicContext: jest.fn(async (_clinicId, _context, callback) => callback()),
-    withSystemContext: jest.fn(async (_context, callback) => callback()),
+  const tenantContext = {
+    runClinicJob: jest.fn(async (_context, callback) => callback()),
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('processes new export jobs inside the queued clinic context', async () => {
-    const processor = new ResearchExportProcessor(researchExportService as never, prisma as never);
+  it('propagates the queued clinic and actor context', async () => {
+    const processor = new ResearchExportProcessor(
+      researchExportService as never,
+      tenantContext as never,
+    );
 
     await processor.process({
       id: 'job-1',
-      data: { exportId: 'export-1', clinicId: 'clinic-1' },
+      data: {
+        exportId: 'export-1',
+        clinicId: 'clinic-1',
+        userId: 'director-1',
+      },
     } as never);
 
-    expect(prisma.withSystemContext).not.toHaveBeenCalled();
-    expect(prisma.withClinicContext).toHaveBeenCalledWith(
-      'clinic-1',
-      { requestId: 'job-1', userId: null },
+    expect(tenantContext.runClinicJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queueName: 'research-exports',
+        jobId: 'job-1',
+        resourceId: 'export-1',
+        tenant: { clinicId: 'clinic-1', userId: 'director-1' },
+        unresolvedTenant: 'fail',
+      }),
       expect.any(Function),
     );
+    expect(researchExportService.findExportJobTenant).not.toHaveBeenCalled();
     expect(researchExportService.processQueuedExport).toHaveBeenCalledWith('export-1');
   });
 
-  it('uses system context only to resolve legacy jobs missing clinicId', async () => {
-    researchExportService.findExportClinicId.mockResolvedValue('clinic-1');
-    const processor = new ResearchExportProcessor(researchExportService as never, prisma as never);
+  it('declares failure and resolves the full legacy export tenant context', async () => {
+    researchExportService.findExportJobTenant.mockResolvedValue({
+      clinicId: 'clinic-legacy',
+      userId: 'requester-1',
+    });
+    const processor = new ResearchExportProcessor(
+      researchExportService as never,
+      tenantContext as never,
+    );
 
-    await processor.process({ id: 'job-1', data: { exportId: 'export-1' } } as never);
+    await processor.process({
+      id: 'job-legacy',
+      data: { exportId: 'export-legacy' },
+    } as never);
 
-    expect(prisma.withSystemContext).toHaveBeenCalledWith(
-      {
-        requestId: 'job-1',
+    const context = tenantContext.runClinicJob.mock.calls[0][0];
+    expect(context).toMatchObject({
+      tenant: null,
+      unresolvedTenant: 'fail',
+      legacy: {
         systemReason: 'Resolve tenant for a legacy research export payload',
       },
-      expect.any(Function),
+    });
+    await expect(context.legacy.resolveTenant()).resolves.toEqual({
+      clinicId: 'clinic-legacy',
+      userId: 'requester-1',
+    });
+  });
+
+  it('does not replace a supplied tenant with a database lookup', async () => {
+    const processor = new ResearchExportProcessor(
+      researchExportService as never,
+      tenantContext as never,
     );
-    expect(researchExportService.findExportClinicId).toHaveBeenCalledWith('export-1');
-    expect(prisma.withClinicContext).toHaveBeenCalledWith(
-      'clinic-1',
-      { requestId: 'job-1', userId: null },
-      expect.any(Function),
-    );
+
+    await processor.process({
+      id: 'job-1',
+      data: {
+        exportId: 'export-1',
+        clinicId: 'different-clinic',
+        userId: 'director-1',
+      },
+    } as never);
+
+    expect(tenantContext.runClinicJob.mock.calls[0][0].tenant).toEqual({
+      clinicId: 'different-clinic',
+      userId: 'director-1',
+    });
+    expect(researchExportService.findExportJobTenant).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/research/research-export.processor.spec.ts
+++ b/apps/api/src/research/research-export.processor.spec.ts
@@ -38,7 +38,10 @@ describe('ResearchExportProcessor tenant context', () => {
     await processor.process({ id: 'job-1', data: { exportId: 'export-1' } } as never);
 
     expect(prisma.withSystemContext).toHaveBeenCalledWith(
-      { requestId: 'job-1' },
+      {
+        requestId: 'job-1',
+        systemReason: 'Resolve tenant for a legacy research export payload',
+      },
       expect.any(Function),
     );
     expect(researchExportService.findExportClinicId).toHaveBeenCalledWith('export-1');

--- a/apps/api/src/research/research-export.processor.ts
+++ b/apps/api/src/research/research-export.processor.ts
@@ -17,13 +17,21 @@ export class ResearchExportProcessor extends WorkerHost {
     const { exportId } = job.data;
     const clinicId =
       job.data.clinicId ??
-      (await this.prisma.withSystemContext({ requestId: String(job.id ?? exportId) }, () =>
-        this.researchExportService.findExportClinicId(exportId),
+      (await this.prisma.withSystemContext(
+        {
+          requestId: String(job.id ?? exportId),
+          systemReason: 'Resolve tenant for a legacy research export payload',
+        },
+        () => this.researchExportService.findExportClinicId(exportId),
       ));
 
     if (!clinicId) {
-      await this.prisma.withSystemContext({ requestId: String(job.id ?? exportId) }, () =>
-        this.researchExportService.processQueuedExport(exportId),
+      await this.prisma.withSystemContext(
+        {
+          requestId: String(job.id ?? exportId),
+          systemReason: 'Process an unresolved legacy research export payload',
+        },
+        () => this.researchExportService.processQueuedExport(exportId),
       );
       return;
     }

--- a/apps/api/src/research/research-export.processor.ts
+++ b/apps/api/src/research/research-export.processor.ts
@@ -1,44 +1,38 @@
 import { Processor, WorkerHost } from '@nestjs/bullmq';
 import { Job } from 'bullmq';
-import { PrismaService } from '../prisma/prisma.service';
+import { JobTenantContextRunner } from '../prisma/job-tenant-context.runner';
 import { ResearchExportService } from './research-export.service';
 import { RESEARCH_EXPORT_QUEUE_NAME } from './research-policy';
+
+export type ResearchExportJobData = {
+  exportId: string;
+  clinicId?: string;
+  userId?: string | null;
+};
 
 @Processor(RESEARCH_EXPORT_QUEUE_NAME)
 export class ResearchExportProcessor extends WorkerHost {
   constructor(
     private readonly researchExportService: ResearchExportService,
-    private readonly prisma: PrismaService,
+    private readonly tenantContext: JobTenantContextRunner,
   ) {
     super();
   }
 
-  async process(job: Job<{ exportId: string; clinicId?: string }>): Promise<void> {
-    const { exportId } = job.data;
-    const clinicId =
-      job.data.clinicId ??
-      (await this.prisma.withSystemContext(
-        {
-          requestId: String(job.id ?? exportId),
+  async process(job: Job<ResearchExportJobData>): Promise<void> {
+    const { exportId, clinicId, userId } = job.data;
+    await this.tenantContext.runClinicJob(
+      {
+        queueName: RESEARCH_EXPORT_QUEUE_NAME,
+        jobId: job.id,
+        resourceId: exportId,
+        tenant: clinicId ? { clinicId, userId: userId ?? null } : null,
+        legacy: {
           systemReason: 'Resolve tenant for a legacy research export payload',
+          resolveTenant: () => this.researchExportService.findExportJobTenant(exportId),
         },
-        () => this.researchExportService.findExportClinicId(exportId),
-      ));
-
-    if (!clinicId) {
-      await this.prisma.withSystemContext(
-        {
-          requestId: String(job.id ?? exportId),
-          systemReason: 'Process an unresolved legacy research export payload',
-        },
-        () => this.researchExportService.processQueuedExport(exportId),
-      );
-      return;
-    }
-
-    await this.prisma.withClinicContext(
-      clinicId,
-      { requestId: String(job.id ?? exportId), userId: null },
+        unresolvedTenant: 'fail',
+      },
       () => this.researchExportService.processQueuedExport(exportId),
     );
   }

--- a/apps/api/src/research/research-export.service.spec.ts
+++ b/apps/api/src/research/research-export.service.spec.ts
@@ -114,7 +114,7 @@ describe('ResearchExportService', () => {
     );
     expect(exportQueue.add).toHaveBeenCalledWith(
       'process',
-      { exportId: 'exp-1', clinicId },
+      { exportId: 'exp-1', clinicId, userId },
       expect.objectContaining({ jobId: 'exp-1' }),
     );
   });
@@ -145,7 +145,15 @@ describe('ResearchExportService', () => {
         status: 'APPROVED',
       }),
     );
-    expect(exportQueue.add).toHaveBeenCalled();
+    expect(exportQueue.add).toHaveBeenCalledWith(
+      'process',
+      {
+        exportId: 'exp-1',
+        clinicId,
+        userId: 'director-1',
+      },
+      expect.objectContaining({ jobId: 'exp-1' }),
+    );
   });
 
   it('retries a failed export by re-queueing it', async () => {
@@ -171,7 +179,15 @@ describe('ResearchExportService', () => {
     });
 
     expect(result.status).toBe('APPROVED');
-    expect(exportQueue.add).toHaveBeenCalled();
+    expect(exportQueue.add).toHaveBeenCalledWith(
+      'process',
+      {
+        exportId: 'exp-1',
+        clinicId,
+        userId,
+      },
+      expect.objectContaining({ jobId: 'exp-1' }),
+    );
   });
 
   it('marks a queued export completed after transform and sync succeed', async () => {
@@ -282,5 +298,21 @@ describe('ResearchExportService', () => {
     repo.findById.mockResolvedValue(null);
 
     await expect(service.processQueuedExport('missing')).rejects.toThrow(NotFoundException);
+  });
+
+  it('resolves legacy job tenant metadata from the export record', async () => {
+    repo.findById.mockResolvedValue(
+      makeExportRecord({
+        approvedByUserId: 'director-1',
+      }),
+    );
+
+    await expect(service.findExportJobTenant('exp-1')).resolves.toEqual({
+      clinicId,
+      userId: 'director-1',
+    });
+
+    repo.findById.mockResolvedValue(null);
+    await expect(service.findExportJobTenant('missing')).resolves.toBeNull();
   });
 });

--- a/apps/api/src/research/research-export.service.ts
+++ b/apps/api/src/research/research-export.service.ts
@@ -354,9 +354,17 @@ export class ResearchExportService {
     }
   }
 
-  async findExportClinicId(exportId: string): Promise<string | null> {
+  async findExportJobTenant(
+    exportId: string,
+  ): Promise<{ clinicId: string; userId: string | null } | null> {
     const exportRecord = await this.repo.findById(exportId);
-    return exportRecord?.clinicId ?? null;
+    if (!exportRecord) {
+      return null;
+    }
+    return {
+      clinicId: exportRecord.clinicId,
+      userId: exportRecord.approvedByUserId ?? exportRecord.requestedByUserId,
+    };
   }
 
   async recordDownload(exportId: string, auditCtx?: ExportAuditContext) {
@@ -381,7 +389,11 @@ export class ResearchExportService {
     try {
       await this.exportQueue.add(
         'process',
-        { exportId: exportRecord.id, clinicId: exportRecord.clinicId },
+        {
+          exportId: exportRecord.id,
+          clinicId: exportRecord.clinicId,
+          userId: actorUserId,
+        },
         {
           jobId: exportRecord.id,
           attempts: 3,

--- a/docs/DATABASE_SETUP.md
+++ b/docs/DATABASE_SETUP.md
@@ -136,11 +136,59 @@ Treat those local drift migrations as disposable until they are validated agains
 
 ## RLS And Runtime Notes
 
-- clinic-scoped tables are protected by Postgres RLS
-- the API uses `PrismaService.withRlsContext(...)` to set transaction-local context per request
-- background jobs and standalone scripts do not automatically inherit the same context unless they opt into it explicitly
+- Clinic-scoped tables are protected by Postgres RLS.
+- HTTP traffic uses `PrismaService.withRlsContext(...)` to set transaction-local context.
+- Queue workers must use `JobTenantContextRunner`; they do not inherit HTTP context.
+- Direct database scripts are privileged operations and do not automatically receive tenant context.
 
-This means direct SQL access or ad hoc scripts can still bypass the same safety shape as normal HTTP traffic unless they use the same conventions.
+### Background job rule
+
+Every newly produced queue payload must carry `clinicId` and an explicit `userId` (`null` for
+automated work). Every processor must call one of these runner methods before touching the database:
+
+- `runClinicJob(...)` for clinic data. It applies clinic/user context before the callback runs.
+- `runSystemJob(...)` only for work that genuinely spans tenants. A non-empty
+  `systemReason` is mandatory and the runner logs the decision without job payload data.
+
+`runClinicJob(...)` also requires an explicit unresolved-tenant policy:
+
+- `discard` is appropriate only when a missing backing record makes the work safely obsolete.
+- `fail` raises `UnresolvedJobTenantError` so BullMQ retries and failure monitoring retain the
+  integrity signal.
+
+Legacy jobs without tenant metadata may use system context only to resolve their clinic and user.
+The actual job callback must then run under clinic context. It must never continue under system
+context when resolution fails.
+
+Before adding or changing a processor:
+
+1. Identify whether its data is clinic-scoped, system-scoped, or contains no database access.
+2. Put clinic/user identity in every newly produced queue payload.
+3. Use the matching runner method and declare the unresolved-tenant policy.
+4. Add tests for direct tenant metadata, any legacy resolver, and the failure/discard decision.
+5. Confirm warnings contain identifiers and static reasons only, never payload data or PHI.
+
+### Standalone script rule
+
+Do not use a direct `PrismaClient` for routine clinic maintenance. Prefer an authenticated API
+operation or a Nest application command that can use `JobTenantContextRunner`. If direct access is
+unavoidable, the script must document its tenant-safety decision at the top of the file, accept an
+explicit clinic identifier for clinic work, use a least-privilege database credential, and include
+reviewed validation and failure behavior.
+
+Current standalone utility audit:
+
+| Path                                        | Database access | Tenant-safety decision                                                                                                                         |
+| ------------------------------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `scripts/check-secrets.mjs`                 | No              | Repository scanner; no tenant decision required                                                                                                |
+| `scripts/create-keycloak-e2e-user.mjs`      | No              | Keycloak E2E setup; no clinic data                                                                                                             |
+| `scripts/validate-keycloak-realm.mjs`       | No              | Static realm validation; no tenant data                                                                                                        |
+| `packages/db/prisma/seed.ts`                | Yes             | Privileged system bootstrap; creates the organization, clinic, initial identities, roles, and seed records before normal tenant context exists |
+| `packages/db/prisma/assign-system-admin.ts` | Yes             | Privileged system maintenance; grants a global role and is intentionally not clinic-scoped                                                     |
+| `packages/db/prisma/seed-drugs.ts`          | Indirect        | Not standalone; receives an explicit clinic from the privileged bootstrap seed                                                                 |
+
+The two privileged direct-client scripts are exceptions, not templates for future clinic-scoped
+scripts. Adding another exception requires a documented system reason and security review.
 
 ---
 

--- a/docs/security-audit-2026-04-04.md
+++ b/docs/security-audit-2026-04-04.md
@@ -56,7 +56,7 @@
 ## Residual Risks / Follow-up
 
 - Exact staging and production frontend domains in the Keycloak export are currently assumed to be `https://staging.nkwapa.app` and `https://app.nkwapa.app`; update these if your real domains differ.
-- RLS protection depends on the app using the request-scoped Prisma context for HTTP traffic. Background jobs and standalone scripts still rely on owner-level access unless they explicitly opt into the same context.
+- RLS protection depends on every execution path establishing context. HTTP requests use the Prisma interceptor, queue processors use `JobTenantContextRunner`, and privileged standalone database scripts are explicitly documented exceptions.
 - Full end-to-end validation of Keycloak action token overrides should be confirmed in a running Keycloak environment after import.
 
 ## Follow-up Hardening - 2026-05-28
@@ -86,9 +86,29 @@
 
 ### Job context model
 
-- Normal job path: enqueue payload includes `clinicId`; processor wraps work in `withClinicContext(clinicId, ...)`.
-- Legacy job path: processor resolves `clinicId` from the reminder/export record, then uses tenant context.
-- Documented system fallback: only used for legacy payloads whose backing record no longer resolves to a clinic. These paths are logged as explicit system-context execution and should trend to zero as old queues drain.
+- Normal job path: queue payloads include `clinicId` and `userId`; processors delegate all
+  database work to `JobTenantContextRunner.runClinicJob(...)`.
+- Legacy job path: the runner uses a required static system reason while resolving clinic/user
+  metadata, then applies clinic context before invoking the processor callback.
+- Unresolved reminder jobs are logged and safely discarded because deleted/stale records are
+  already no-ops. Unresolved research export jobs throw `UnresolvedJobTenantError` so retries and
+  queue failure monitoring surface the integrity issue.
+- `runSystemJob(...)` requires a non-empty reason. System and legacy-resolution warnings include
+  queue/job/resource identifiers and static decisions only; payloads and PHI are not logged.
+- Prisma rejects incompatible nested contexts, enriches clinic metadata only after applying clinic
+  scope, and clears its AsyncLocalStorage context after success or failure.
+
+### Standalone script audit
+
+- Top-level repository scripts do not access clinic data.
+- `packages/db/prisma/seed.ts` is an explicit privileged bootstrap exception because it creates the
+  organization, clinic, identities, roles, and initial clinic records.
+- `packages/db/prisma/assign-system-admin.ts` is explicit privileged system maintenance because it
+  grants a global role.
+- `seed-drugs.ts` is not standalone and receives its clinic from the bootstrap seed.
+- Future clinic maintenance must use an authenticated API/application command with tenant context;
+  any new direct-client system exception requires an inline reason, least-privilege credential,
+  validation/failure tests, and security review.
 
 ### Verification results
 
@@ -140,6 +160,8 @@
   remediation proposes incompatible downgrades of core tooling. CI therefore blocks moderate-or-
   higher runtime advisories and critical advisories anywhere in the graph. Remove this exception
   when the upstream tools support a patched `brace-expansion` release.
-- Legacy background jobs without `clinicId` remain supported for queue drain compatibility. Monitor logs for system-context fallback and treat any recurring fallback as a data repair task.
+- Legacy background jobs without tenant metadata remain supported only for queue drain compatibility.
+  Monitor `legacy_job_tenant_resolution` warnings and treat recurring events as producer or data
+  repair work. No unresolved legacy job may execute clinic work under system context.
 - RLS remains app-context driven. Production database role separation and forced RLS ownership controls should be reviewed separately before relying on RLS as the only tenant isolation layer.
 - E2E coverage depends on Docker-backed Postgres, Redis, Keycloak, and the matching Playwright browser runtime being available in the execution environment.

--- a/packages/db/prisma/assign-system-admin.ts
+++ b/packages/db/prisma/assign-system-admin.ts
@@ -3,6 +3,10 @@
  * Assign SYSTEM_ADMIN role to a user by Keycloak sub.
  * Usage: SEED_SYSTEM_ADMIN_SUB=<keycloak-sub> pnpm db:assign-system-admin
  *
+ * TENANT SAFETY: privileged system maintenance. This operation intentionally has no clinic scope
+ * because it grants a global role. Run it only with an approved administrative database credential.
+ * Do not copy this direct-client pattern into clinic-scoped maintenance scripts.
+ *
  * Get your Keycloak sub from: Keycloak Admin → Users → select user → Details tab
  * Or decode your JWT at jwt.io and copy the "sub" claim.
  */

--- a/packages/db/prisma/seed-drugs.ts
+++ b/packages/db/prisma/seed-drugs.ts
@@ -59,6 +59,11 @@ const SEED_DRUGS = [
   },
 ];
 
+/**
+ * This is not a standalone script. The privileged bootstrap seed is its only caller and supplies
+ * the clinic explicitly. Any future runtime or maintenance caller must establish tenant context
+ * before invoking clinic-scoped writes.
+ */
 export async function seedDrugs(prisma: PrismaClient, clinicId: string): Promise<void> {
   for (const drug of SEED_DRUGS) {
     const existing = await prisma.drug.findFirst({

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -1,4 +1,12 @@
 // packages/db/prisma/seed.ts
+/**
+ * TENANT SAFETY: privileged system bootstrap.
+ *
+ * This script intentionally uses a direct Prisma client because it creates the organization,
+ * clinic, initial users, roles, and clinic seed data needed before an application tenant context
+ * can exist. Run it only with an approved administrative database credential. It is not a pattern
+ * for clinic maintenance or data repair scripts.
+ */
 import 'dotenv/config';
 import { PrismaClient, UserRole, Sex, NationalIdType, EncounterStatus } from '@prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';


### PR DESCRIPTION
## Summary

Establishes explicit tenant-context conventions for background jobs and privileged database scripts.

This completes the tenant-safety work in #19 without weakening PostgreSQL RLS policies.

## What changed

- Added a globally injectable `JobTenantContextRunner` with:
  - Clinic-scoped job execution
  - Explicit system-scoped execution requiring a reason
  - Legacy tenant resolution
  - Required `fail` or `discard` behavior when a tenant cannot be resolved
  - Privacy-safe structured warnings
- Hardened `PrismaService` to:
  - Record system-context reasons
  - Reject incompatible nested tenant contexts
  - Apply clinic scope before resolving organization and zone metadata
  - Fail clearly for unknown clinics
  - Clear AsyncLocalStorage context after success or failure
- Updated reminder jobs to:
  - Enqueue explicit clinic context and `userId: null`
  - Safely discard stale legacy jobs whose reminder no longer exists
  - Never process clinic data under system context
- Updated research export jobs to:
  - Enqueue explicit clinic and initiating-user context
  - Recover actor metadata for legacy payloads
  - Fail visibly when a legacy export tenant cannot be resolved
- Audited standalone utilities and documented:
  - Which scripts have no database access
  - Why seed and system-admin utilities require privileged system access
  - Required conventions for future processors and maintenance scripts

## Security decisions

- Queue payloads are treated as untrusted input and tenant identifiers are normalized before use.
- System context requires a non-empty, static reason.
- Legacy system access is limited to tenant discovery.
- Actual reminder and research work always executes under clinic context.
- Incompatible nested contexts throw instead of silently inheriting broader access.
- Logs include static reasons and identifiers only, never queue payloads or PHI.
- No RLS policies were weakened.

## Validation

- [x] Formatting
- [x] Keycloak realm validation
- [x] Workspace lint
- [x] Workspace typechecks
- [x] 46 unit-test suites / 260 tests
- [x] API production build
- [x] Web production build
- [x] Database package build
- [x] Secret scan
- [x] Runtime dependency audit: zero vulnerabilities
- [x] Full dependency audit policy: no critical vulnerabilities
- [x] Prisma migration validation: 19 migrations current
- [x] Docker-backed Playwright E2E: 10/10 tests

## Rollout notes

Legacy jobs without tenant metadata remain compatible while old queues drain. Monitor:

- `legacy_job_tenant_resolution`
- `system_job_context`
- `unresolved_job_tenant`

Recurring legacy-resolution warnings should be treated as an outdated producer or data-repair issue.

No database migration or UI rollout is required.

Closes #19
Refs #69