### PR TITLE
feat(clinical records): expand encounter vitals and tobacco screening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,12 @@ jobs:
       - name: Build @nkwapa/db
         run: npm run build --workspace=@nkwapa/db
 
+      - name: Verify expanded vitals legacy migration
+        run: npm run test --workspace=@nkwapa/db -- --runInBand src/vitals-migration.integration.spec.ts
+        env:
+          RUN_MIGRATION_TESTS: '1'
+          DATABASE_URL: ${{ env.DATABASE_URL }}
+
       - name: Run tests with coverage
         run: npm run test --workspaces --if-present -- --coverage --ci
         env:

--- a/IMPLEMENTATION_STATUS.md
+++ b/IMPLEMENTATION_STATUS.md
@@ -117,20 +117,20 @@ nkwapa/
 
 ### Clinical Workflows
 
-| Feature                                           | Status | %    | Notes                                                |
-| ------------------------------------------------- | ------ | ---- | ---------------------------------------------------- |
-| Patient registry (create, update, search, detail) | ✅     | 100% | Code generation, encrypted national ID               |
-| Patient merge & code alias                        | ✅     | 100% | SYSTEM_ADMIN-only merge with alias preservation      |
-| Portal link/invite                                | ✅     | 95%  | Link, invite, claim flows; invite automation lighter |
-| Duplicate review queue                            | ❌     | 0%   | Hashed ID collision detected, no dedicated queue UI  |
-| Cross-clinic chart consolidation                  | ❌     | 0%   | Merge is clinic-local only                           |
-| Encounter workflow (draft -> review -> finalize)  | ✅     | 100% | Full state machine with role-based transitions       |
-| Vitals recording                                  | ✅     | 100% | BP, HR, weight, height, BMI computation              |
-| Diabetes screening                                | ✅     | 100% | Glucose, HbA1c, symptoms, DM suspicion               |
-| Hypertension assessment                           | ✅     | 100% | BP classification per thresholds                     |
-| Care plan creation                                | ✅     | 100% | Counseling, medication, follow-up date               |
-| Prescription & drug catalog                       | ✅     | 100% | Clinic-scoped drug catalog, encounter prescriptions  |
-| Consent grant/revoke                              | ✅     | 100% | Witness fields, snapshot text, offline supported     |
+| Feature                                           | Status | %    | Notes                                                                                    |
+| ------------------------------------------------- | ------ | ---- | ---------------------------------------------------------------------------------------- |
+| Patient registry (create, update, search, detail) | ✅     | 100% | Code generation, encrypted national ID                                                   |
+| Patient merge & code alias                        | ✅     | 100% | SYSTEM_ADMIN-only merge with alias preservation                                          |
+| Portal link/invite                                | ✅     | 95%  | Link, invite, claim flows; invite automation lighter                                     |
+| Duplicate review queue                            | ❌     | 0%   | Hashed ID collision detected, no dedicated queue UI                                      |
+| Cross-clinic chart consolidation                  | ❌     | 0%   | Merge is clinic-local only                                                               |
+| Encounter workflow (draft -> review -> finalize)  | ✅     | 100% | Full state machine with role-based transitions                                           |
+| Vitals recording                                  | ✅     | 100% | Contextual BP, pulse, temperature, respiration, SpO2, anthropometrics, tobacco screening |
+| Diabetes screening                                | ✅     | 100% | Glucose, HbA1c, symptoms, DM suspicion                                                   |
+| Hypertension assessment                           | ✅     | 100% | BP classification per thresholds                                                         |
+| Care plan creation                                | ✅     | 100% | Counseling, medication, follow-up date                                                   |
+| Prescription & drug catalog                       | ✅     | 100% | Clinic-scoped drug catalog, encounter prescriptions                                      |
+| Consent grant/revoke                              | ✅     | 100% | Witness fields, snapshot text, offline supported                                         |
 
 ### Clinic Operations
 

--- a/apps/api/src/dashboard/dashboard.service.spec.ts
+++ b/apps/api/src/dashboard/dashboard.service.spec.ts
@@ -1,0 +1,67 @@
+import { DashboardService } from './dashboard.service';
+
+describe('DashboardService clinical measurement metrics', () => {
+  it('computes clinic-scoped 30-day coverage and descriptive averages', async () => {
+    const prisma = {
+      encounter: { count: jest.fn().mockResolvedValue(10) },
+      vitals: {
+        findMany: jest.fn().mockResolvedValue([
+          { temperatureCelsius: 37, respiratoryRate: 16, spo2Percent: 98, bmi: 24 },
+          { temperatureCelsius: 38, respiratoryRate: 18, spo2Percent: null, bmi: 26 },
+        ]),
+      },
+      tobaccoScreening: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            smokingStatus: 'CURRENT',
+            smokelessTobaccoStatus: 'NEVER',
+            passiveExposure: 'NO',
+            counselingGiven: 'YES',
+            reviewedAt: new Date(),
+          },
+          {
+            smokingStatus: 'NEVER',
+            smokelessTobaccoStatus: 'NEVER',
+            passiveExposure: 'NOT_ASSESSED',
+            counselingGiven: 'NOT_ASSESSED',
+            reviewedAt: null,
+          },
+          {
+            smokingStatus: 'NOT_ASSESSED',
+            smokelessTobaccoStatus: 'NOT_ASSESSED',
+            passiveExposure: 'NOT_ASSESSED',
+            counselingGiven: 'NOT_ASSESSED',
+            reviewedAt: null,
+          },
+        ]),
+        groupBy: jest.fn().mockResolvedValue([
+          { smokingStatus: 'CURRENT', _count: 1 },
+          { smokingStatus: 'NEVER', _count: 1 },
+          { smokingStatus: 'NOT_ASSESSED', _count: 1 },
+        ]),
+      },
+    };
+    const service = new DashboardService(prisma as never);
+    const metrics = await (
+      service as unknown as {
+        getClinicalMeasurementMetrics: (clinicId: string) => Promise<Record<string, unknown>>;
+      }
+    ).getClinicalMeasurementMetrics('clinic-1');
+
+    expect(prisma.encounter.count).toHaveBeenCalledWith({
+      where: { clinicId: 'clinic-1', createdAt: { gte: expect.any(Date) } },
+    });
+    expect(metrics).toMatchObject({
+      windowDays: 30,
+      sampleSize: 10,
+      vitalsCaptureRate: 20,
+      tobaccoAssessmentRate: 20,
+      counselingDocumentationRate: 100,
+      pendingTobaccoReviews: 2,
+      measurements: {
+        temperatureCelsius: { count: 2, average: 37.5 },
+        spo2Percent: { count: 1, average: 98 },
+      },
+    });
+  });
+});

--- a/apps/api/src/dashboard/dashboard.service.ts
+++ b/apps/api/src/dashboard/dashboard.service.ts
@@ -12,6 +12,7 @@ import type {
   TrendPoint,
   StaffActivityRow,
   ClinicComparisonRow,
+  ClinicalMeasurementMetrics,
 } from './dto/dashboard-response.dto';
 
 @Injectable()
@@ -31,19 +32,35 @@ export class DashboardService {
     const isDoctor = roles.includes('DOCTOR');
     const isDirector = roles.includes('DIRECTOR') || roles.includes('MANAGER');
     const isVolunteer = roles.includes('VOLUNTEER');
+    const clinicalMeasurements =
+      isDoctor || isDirector || isVolunteer
+        ? await this.getClinicalMeasurementMetrics(clinicId)
+        : null;
 
     if (isAdmin) {
       response.systemAdmin = await this.getSystemAdminMetrics();
     }
     if (isDoctor) {
-      response.doctor = await this.getDoctorMetrics(clinicId, userId);
-      response.review = await this.getReviewMetrics(clinicId, userId);
+      response.doctor = {
+        ...(await this.getDoctorMetrics(clinicId, userId)),
+        clinicalMeasurements: clinicalMeasurements!,
+      };
+      response.review = {
+        ...(await this.getReviewMetrics(clinicId, userId)),
+        clinicalMeasurements: clinicalMeasurements!,
+      };
     }
     if (isDirector) {
-      response.director = await this.getDirectorMetrics(clinicId);
+      response.director = {
+        ...(await this.getDirectorMetrics(clinicId)),
+        clinicalMeasurements: clinicalMeasurements!,
+      };
     }
     if (isVolunteer) {
-      response.volunteer = await this.getVolunteerMetrics(clinicId, userId);
+      response.volunteer = {
+        ...(await this.getVolunteerMetrics(clinicId, userId)),
+        clinicalMeasurements: clinicalMeasurements!,
+      };
     }
 
     return response;
@@ -81,7 +98,10 @@ export class DashboardService {
     return { totalPatients, encountersToday, pendingDrafts, pendingReview, readyToFinalize };
   }
 
-  private async getDoctorMetrics(clinicId: string, userId: string): Promise<DoctorMetrics> {
+  private async getDoctorMetrics(
+    clinicId: string,
+    userId: string,
+  ): Promise<Omit<DoctorMetrics, 'clinicalMeasurements'>> {
     const now = new Date();
     const todayStart = startOfDay(now);
     const weekStart = startOfWeek(now);
@@ -187,7 +207,10 @@ export class DashboardService {
     };
   }
 
-  private async getReviewMetrics(clinicId: string, userId: string): Promise<ReviewMetrics> {
+  private async getReviewMetrics(
+    clinicId: string,
+    userId: string,
+  ): Promise<Omit<ReviewMetrics, 'clinicalMeasurements'>> {
     const now = new Date();
     const todayStart = startOfDay(now);
     const weekStart = startOfWeek(now);
@@ -256,7 +279,9 @@ export class DashboardService {
     };
   }
 
-  private async getDirectorMetrics(clinicId: string): Promise<DirectorMetrics> {
+  private async getDirectorMetrics(
+    clinicId: string,
+  ): Promise<Omit<DirectorMetrics, 'clinicalMeasurements'>> {
     const now = new Date();
     const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
 
@@ -365,7 +390,10 @@ export class DashboardService {
     };
   }
 
-  private async getVolunteerMetrics(clinicId: string, userId: string): Promise<VolunteerMetrics> {
+  private async getVolunteerMetrics(
+    clinicId: string,
+    userId: string,
+  ): Promise<Omit<VolunteerMetrics, 'clinicalMeasurements'>> {
     const now = new Date();
     const todayStart = startOfDay(now);
     const fourteenDaysAgo = new Date(now.getTime() - 14 * 24 * 60 * 60 * 1000);
@@ -524,6 +552,84 @@ export class DashboardService {
       systemWideEncounters,
       clinicComparison,
       systemEncountersTrend,
+    };
+  }
+
+  private async getClinicalMeasurementMetrics(
+    clinicId: string,
+  ): Promise<ClinicalMeasurementMetrics> {
+    const windowStart = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    const [totalEncounters, vitals, tobaccoScreens, tobaccoGroups] = await Promise.all([
+      this.prisma.encounter.count({ where: { clinicId, createdAt: { gte: windowStart } } }),
+      this.prisma.vitals.findMany({
+        where: { clinicId, encounter: { createdAt: { gte: windowStart } } },
+        select: {
+          temperatureCelsius: true,
+          respiratoryRate: true,
+          spo2Percent: true,
+          bmi: true,
+        },
+      }),
+      this.prisma.tobaccoScreening.findMany({
+        where: { clinicId, encounter: { createdAt: { gte: windowStart } } },
+        select: {
+          smokingStatus: true,
+          smokelessTobaccoStatus: true,
+          passiveExposure: true,
+          counselingGiven: true,
+          reviewedAt: true,
+        },
+      }),
+      this.prisma.tobaccoScreening.groupBy({
+        by: ['smokingStatus'],
+        where: { clinicId, encounter: { createdAt: { gte: windowStart } } },
+        _count: true,
+      }),
+    ]);
+
+    const assessed = tobaccoScreens.filter(
+      (screen) =>
+        screen.smokingStatus !== 'NOT_ASSESSED' ||
+        screen.smokelessTobaccoStatus !== 'NOT_ASSESSED' ||
+        screen.passiveExposure !== 'NOT_ASSESSED',
+    ).length;
+    const currentUsers = tobaccoScreens.filter(
+      (screen) => screen.smokingStatus === 'CURRENT' || screen.smokelessTobaccoStatus === 'CURRENT',
+    );
+    const counselingDocumented = currentUsers.filter(
+      (screen) => screen.counselingGiven !== 'NOT_ASSESSED',
+    ).length;
+    const rate = (numerator: number, denominator: number) =>
+      denominator > 0 ? Math.round((numerator / denominator) * 100) : 0;
+    const aggregate = (values: Array<number | null>) => {
+      const recorded = values.filter((value): value is number => value != null);
+      return {
+        count: recorded.length,
+        average:
+          recorded.length > 0
+            ? Math.round((recorded.reduce((sum, value) => sum + value, 0) / recorded.length) * 10) /
+              10
+            : null,
+      };
+    };
+    const tobaccoStatusDistribution: Record<string, number> = {};
+    for (const group of tobaccoGroups)
+      tobaccoStatusDistribution[group.smokingStatus] = group._count;
+
+    return {
+      windowDays: 30,
+      sampleSize: totalEncounters,
+      vitalsCaptureRate: rate(vitals.length, totalEncounters),
+      tobaccoAssessmentRate: rate(assessed, totalEncounters),
+      counselingDocumentationRate: rate(counselingDocumented, currentUsers.length),
+      pendingTobaccoReviews: tobaccoScreens.filter((screen) => screen.reviewedAt == null).length,
+      measurements: {
+        temperatureCelsius: aggregate(vitals.map((record) => record.temperatureCelsius)),
+        respiratoryRate: aggregate(vitals.map((record) => record.respiratoryRate)),
+        spo2Percent: aggregate(vitals.map((record) => record.spo2Percent)),
+        bmi: aggregate(vitals.map((record) => record.bmi)),
+      },
+      tobaccoStatusDistribution,
     };
   }
 }

--- a/apps/api/src/dashboard/dto/dashboard-response.dto.ts
+++ b/apps/api/src/dashboard/dto/dashboard-response.dto.ts
@@ -35,7 +35,29 @@ export interface DashboardSummary {
   readyToFinalize: number;
 }
 
+export interface MeasurementAggregate {
+  count: number;
+  average: number | null;
+}
+
+export interface ClinicalMeasurementMetrics {
+  windowDays: 30;
+  sampleSize: number;
+  vitalsCaptureRate: number;
+  tobaccoAssessmentRate: number;
+  counselingDocumentationRate: number;
+  pendingTobaccoReviews: number;
+  measurements: {
+    temperatureCelsius: MeasurementAggregate;
+    respiratoryRate: MeasurementAggregate;
+    spo2Percent: MeasurementAggregate;
+    bmi: MeasurementAggregate;
+  };
+  tobaccoStatusDistribution: Record<string, number>;
+}
+
 export interface DoctorMetrics {
+  clinicalMeasurements: ClinicalMeasurementMetrics;
   awaitingFinalization: number;
   patientsSeen: { today: number; week: number; month: number };
   followUpComplianceRate: number;
@@ -46,6 +68,7 @@ export interface DoctorMetrics {
 }
 
 export interface ReviewMetrics {
+  clinicalMeasurements: ClinicalMeasurementMetrics;
   awaitingReview: number;
   reviewsCompleted: { today: number; week: number };
   recentReviews: EncounterSummary[];
@@ -54,6 +77,7 @@ export interface ReviewMetrics {
 }
 
 export interface DirectorMetrics {
+  clinicalMeasurements: ClinicalMeasurementMetrics;
   patientRegistrationTrend: TrendPoint[];
   encounterVolumeTrend: TrendPoint[];
   screeningRates: { hypertension: number; diabetes: number };
@@ -64,6 +88,7 @@ export interface DirectorMetrics {
 }
 
 export interface VolunteerMetrics {
+  clinicalMeasurements: ClinicalMeasurementMetrics;
   patientsRegisteredToday: number;
   encountersCreatedToday: number;
   pendingSubmissions: number;

--- a/apps/api/src/encounters/encounter.service.ts
+++ b/apps/api/src/encounters/encounter.service.ts
@@ -58,6 +58,9 @@ export class EncounterService {
       ? {
           patient: true,
           vitals: true,
+          tobaccoScreening: {
+            include: { reviewedBy: { select: { id: true, displayName: true } } },
+          },
           diabetesScreening: true,
           hypertensionAssessment: true,
           carePlan: true,

--- a/apps/api/src/patient-portal/patient-portal.service.spec.ts
+++ b/apps/api/src/patient-portal/patient-portal.service.spec.ts
@@ -514,7 +514,15 @@ describe('PatientPortalService', () => {
         return [
           {
             createdAt: new Date('2026-03-18T08:00:00.000Z'),
-            vitals: { systolicBp: 141, diastolicBp: 92 },
+            vitals: {
+              systolicBp: 141,
+              diastolicBp: 92,
+              temperatureCelsius: 37,
+              respiratoryRate: 18,
+              spo2Percent: 97,
+              weightKg: 72,
+              bmi: 24.9,
+            },
             diabetesScreening: null,
           },
         ];
@@ -527,11 +535,23 @@ describe('PatientPortalService', () => {
     const staffResult = await service.listTrendsForStaff('patient-1', 'clinic-1', {});
 
     expect(patientResult.bp).toEqual([]);
+    expect(patientResult.measurements).toBeUndefined();
     expect(staffResult.bp).toEqual([
       {
         t: '2026-03-18T08:00:00.000Z',
         sys: 141,
         dia: 92,
+        source: 'ENCOUNTER',
+      },
+    ]);
+    expect(staffResult.measurements).toEqual([
+      {
+        t: '2026-03-18T08:00:00.000Z',
+        temperatureCelsius: 37,
+        respiratoryRate: 18,
+        spo2Percent: 97,
+        weightKg: 72,
+        bmi: 24.9,
         source: 'ENCOUNTER',
       },
     ]);

--- a/apps/api/src/patient-portal/patient-portal.service.ts
+++ b/apps/api/src/patient-portal/patient-portal.service.ts
@@ -139,6 +139,16 @@ interface GlucoseTrendPoint {
   source: 'ENCOUNTER' | 'PATIENT';
 }
 
+interface ExpandedVitalsTrendPoint {
+  t: string;
+  temperatureCelsius: number | null;
+  respiratoryRate: number | null;
+  spo2Percent: number | null;
+  weightKg: number | null;
+  bmi: number | null;
+  source: 'ENCOUNTER';
+}
+
 interface FollowUpSummary {
   requested: number;
   confirmed: number;
@@ -168,6 +178,7 @@ interface AppointmentRange {
 export interface PatientTrendsResponse {
   bp: BloodPressureTrendPoint[];
   glucose: GlucoseTrendPoint[];
+  measurements?: ExpandedVitalsTrendPoint[];
   followUp: FollowUpSummary;
 }
 
@@ -260,12 +271,12 @@ export class PatientPortalService {
     query: ListPatientTrendsQueryDto,
   ) {
     const patient = await this.resolvePortalPatient(clinicId, userId);
-    return this.listTrends(patient.id, clinicId, query, ['FINALIZED']);
+    return this.listTrends(patient.id, clinicId, query, ['FINALIZED'], false);
   }
 
   async listTrendsForStaff(patientId: string, clinicId: string, query: ListPatientTrendsQueryDto) {
     await this.assertPatientInClinic(patientId, clinicId);
-    return this.listTrends(patientId, clinicId, query, ['DRAFT', 'IN_REVIEW', 'FINALIZED']);
+    return this.listTrends(patientId, clinicId, query, ['DRAFT', 'IN_REVIEW', 'FINALIZED'], true);
   }
 
   async createMeasurementForAuthenticatedPatient(
@@ -1708,6 +1719,7 @@ export class PatientPortalService {
     clinicId: string,
     query: ListPatientTrendsQueryDto,
     encounterStatuses: EncounterStatus[],
+    includeExpandedVitals: boolean,
   ): Promise<PatientTrendsResponse> {
     const dateFilter = this.buildRecordedAtFilter(query.from, query.to);
 
@@ -1743,6 +1755,11 @@ export class PatientPortalService {
             select: {
               systolicBp: true,
               diastolicBp: true,
+              temperatureCelsius: true,
+              respiratoryRate: true,
+              spo2Percent: true,
+              weightKg: true,
+              bmi: true,
             },
           },
           diabetesScreening: {
@@ -1878,9 +1895,39 @@ export class PatientPortalService {
       }),
     ].sort((left, right) => new Date(left.t).getTime() - new Date(right.t).getTime());
 
+    const expandedMeasurements: ExpandedVitalsTrendPoint[] = includeExpandedVitals
+      ? encounters.flatMap((encounter) => {
+          const vitals = encounter.vitals;
+          if (
+            !vitals ||
+            [
+              vitals.temperatureCelsius,
+              vitals.respiratoryRate,
+              vitals.spo2Percent,
+              vitals.weightKg,
+              vitals.bmi,
+            ].every((value) => value == null)
+          ) {
+            return [];
+          }
+          return [
+            {
+              t: encounter.createdAt.toISOString(),
+              temperatureCelsius: vitals.temperatureCelsius,
+              respiratoryRate: vitals.respiratoryRate,
+              spo2Percent: vitals.spo2Percent,
+              weightKg: vitals.weightKg,
+              bmi: vitals.bmi,
+              source: 'ENCOUNTER' as const,
+            },
+          ];
+        })
+      : [];
+
     return {
       bp,
       glucose,
+      ...(includeExpandedVitals ? { measurements: expandedMeasurements } : {}),
       followUp: {
         requested,
         confirmed,

--- a/apps/api/src/research/research-policy.ts
+++ b/apps/api/src/research/research-policy.ts
@@ -2,7 +2,7 @@ import { createHash } from 'crypto';
 
 export const RESEARCH_EXPORT_QUEUE_NAME = 'research-exports';
 export const RESEARCH_POLICY_VERSION = 'research-export-v1';
-export const RESEARCH_DATASET_VERSION = 2;
+export const RESEARCH_DATASET_VERSION = 3;
 export const RESEARCH_TIMESTAMP_ROUNDING_MINUTES = 15;
 export const RESEARCH_FILE_FORMAT = 'zip';
 
@@ -11,6 +11,7 @@ export const RESEARCH_TABLE_NAMES = [
   'research_ops_checkins.csv',
   'research_ops_assignments.csv',
   'research_clinical_vitals.csv',
+  'research_clinical_tobacco.csv',
   'research_clinical_screenings.csv',
   'research_measurements.csv',
   'research_appointments.csv',

--- a/apps/api/src/research/research-transform.service.spec.ts
+++ b/apps/api/src/research/research-transform.service.spec.ts
@@ -65,7 +65,7 @@ describe('ResearchTransformService', () => {
         'research_revocations.csv',
       ]),
     );
-    expect(result.manifest.datasetVersion).toBe(2);
+    expect(result.manifest.datasetVersion).toBe(3);
     expect(fs.existsSync(result.artifactPath)).toBe(true);
   });
 
@@ -158,10 +158,27 @@ describe('ResearchTransformService', () => {
           createdAt: new Date('2026-03-18T08:35:00.000Z'),
           systolicBp: 128,
           diastolicBp: 83,
-          heartRate: 70,
+          bpSite: 'LEFT_ARM',
+          patientPosition: 'SITTING',
+          cuffSize: 'ADULT',
+          pulseBpm: 70,
+          temperatureCelsius: 37,
+          temperatureSource: 'ORAL',
+          respiratoryRate: 16,
+          spo2Percent: 98,
           weightKg: 72,
           heightCm: 174,
           bmi: 23.8,
+        },
+        tobaccoScreening: {
+          createdAt: new Date('2026-03-18T08:40:00.000Z'),
+          smokingStatus: 'NEVER',
+          smokelessTobaccoStatus: 'NOT_ASSESSED',
+          passiveExposure: 'NO',
+          readinessToQuit: 'NOT_APPLICABLE',
+          counselingGiven: 'NO',
+          reviewedByUserId: 'doctor-private-id',
+          reviewedAt: new Date('2026-03-18T08:45:00.000Z'),
         },
         diabetesScreening: {
           createdAt: new Date('2026-03-18T08:38:00.000Z'),
@@ -300,15 +317,21 @@ describe('ResearchTransformService', () => {
     const medicalHistoryCsv = result.repoFiles.find(
       (file) => file.name === 'research_medical_history.csv',
     );
+    const tobaccoCsv = result.repoFiles.find(
+      (file) => file.name === 'research_clinical_tobacco.csv',
+    );
 
     expect(result.recordCount).toBeGreaterThan(0);
-    expect(result.manifest.datasetVersion).toBe(2);
+    expect(result.manifest.datasetVersion).toBe(3);
     expect(subjectsCsv?.content).toContain('research_patient_key');
     expect(subjectsCsv?.content).toContain('1990');
     expect(subjectsCsv?.content).not.toContain('Witness');
     expect(measurementsCsv?.content).toContain('126');
     expect(measurementsCsv?.content).toContain('102');
     expect(measurementsCsv?.content).not.toContain('Do not leak');
+    expect(tobaccoCsv?.content).toContain('smoking_status');
+    expect(tobaccoCsv?.content).toContain('NEVER');
+    expect(tobaccoCsv?.content).not.toContain('doctor-private-id');
     expect(appointmentsCsv?.content).toContain('2026-03-25');
     expect(appointmentsCsv?.content).not.toContain('Should not leak');
     expect(revocationsCsv?.content).toContain('REVOKED');

--- a/apps/api/src/research/research-transform.service.ts
+++ b/apps/api/src/research/research-transform.service.ts
@@ -53,10 +53,33 @@ const VITALS_HEADERS = [
   'recorded_at',
   'systolic_bp',
   'diastolic_bp',
-  'heart_rate',
+  'bp_site',
+  'patient_position',
+  'cuff_size',
+  'pulse_bpm',
+  'temperature_celsius',
+  'temperature_source',
+  'respiratory_rate',
+  'spo2_percent',
   'weight_kg',
   'height_cm',
   'bmi',
+];
+
+const TOBACCO_HEADERS = [
+  'research_encounter_key',
+  'research_patient_key',
+  'research_clinic_key',
+  'encounter_status',
+  'encounter_created_at',
+  'recorded_at',
+  'smoking_status',
+  'smokeless_tobacco_status',
+  'passive_exposure',
+  'readiness_to_quit',
+  'counseling_given',
+  'reviewed',
+  'reviewed_at',
 ];
 
 const SCREENING_HEADERS = [
@@ -242,6 +265,7 @@ export class ResearchTransformService {
             },
             include: {
               vitals: true,
+              tobaccoScreening: true,
               diabetesScreening: true,
               hypertensionAssessment: true,
             },
@@ -432,10 +456,37 @@ export class ResearchTransformService {
         recorded_at: this.deIdService.roundTimestamp(encounter.vitals?.createdAt ?? null),
         systolic_bp: encounter.vitals?.systolicBp ?? null,
         diastolic_bp: encounter.vitals?.diastolicBp ?? null,
-        heart_rate: encounter.vitals?.pulseBpm ?? null,
+        bp_site: encounter.vitals?.bpSite ?? null,
+        patient_position: encounter.vitals?.patientPosition ?? null,
+        cuff_size: encounter.vitals?.cuffSize ?? null,
+        pulse_bpm: encounter.vitals?.pulseBpm ?? null,
+        temperature_celsius: encounter.vitals?.temperatureCelsius ?? null,
+        temperature_source: encounter.vitals?.temperatureSource ?? null,
+        respiratory_rate: encounter.vitals?.respiratoryRate ?? null,
+        spo2_percent: encounter.vitals?.spo2Percent ?? null,
         weight_kg: encounter.vitals?.weightKg ?? null,
         height_cm: encounter.vitals?.heightCm ?? null,
         bmi: encounter.vitals?.bmi ?? null,
+      }));
+
+    const tobaccoRows = encounters
+      .filter((encounter) => encounter.tobaccoScreening != null)
+      .map((encounter) => ({
+        research_encounter_key: this.deIdService.entityKey(clinicId, 'encounter', encounter.id),
+        research_patient_key: this.deIdService.patientKey(clinicId, encounter.patientId),
+        research_clinic_key: clinicKey,
+        encounter_status: encounter.status,
+        encounter_created_at: this.deIdService.roundTimestamp(encounter.createdAt),
+        recorded_at: this.deIdService.roundTimestamp(encounter.tobaccoScreening?.createdAt ?? null),
+        smoking_status: encounter.tobaccoScreening?.smokingStatus ?? null,
+        smokeless_tobacco_status: encounter.tobaccoScreening?.smokelessTobaccoStatus ?? null,
+        passive_exposure: encounter.tobaccoScreening?.passiveExposure ?? null,
+        readiness_to_quit: encounter.tobaccoScreening?.readinessToQuit ?? null,
+        counseling_given: encounter.tobaccoScreening?.counselingGiven ?? null,
+        reviewed: encounter.tobaccoScreening?.reviewedAt != null,
+        reviewed_at: this.deIdService.roundTimestamp(
+          encounter.tobaccoScreening?.reviewedAt ?? null,
+        ),
       }));
 
     const screeningRows = encounters
@@ -559,6 +610,7 @@ export class ResearchTransformService {
       this.createCsvFile('research_ops_checkins.csv', CHECKIN_HEADERS, checkInRows),
       this.createCsvFile('research_ops_assignments.csv', ASSIGNMENT_HEADERS, assignmentRows),
       this.createCsvFile('research_clinical_vitals.csv', VITALS_HEADERS, vitalsRows),
+      this.createCsvFile('research_clinical_tobacco.csv', TOBACCO_HEADERS, tobaccoRows),
       this.createCsvFile('research_clinical_screenings.csv', SCREENING_HEADERS, screeningRows),
       this.createCsvFile('research_measurements.csv', MEASUREMENT_HEADERS, measurementRows),
       this.createCsvFile('research_appointments.csv', APPOINTMENT_HEADERS, appointmentRows),

--- a/apps/api/src/research/research-transform.service.ts
+++ b/apps/api/src/research/research-transform.service.ts
@@ -432,7 +432,7 @@ export class ResearchTransformService {
         recorded_at: this.deIdService.roundTimestamp(encounter.vitals?.createdAt ?? null),
         systolic_bp: encounter.vitals?.systolicBp ?? null,
         diastolic_bp: encounter.vitals?.diastolicBp ?? null,
-        heart_rate: encounter.vitals?.heartRate ?? null,
+        heart_rate: encounter.vitals?.pulseBpm ?? null,
         weight_kg: encounter.vitals?.weightKg ?? null,
         height_cm: encounter.vitals?.heightCm ?? null,
         bmi: encounter.vitals?.bmi ?? null,

--- a/apps/api/src/sync/clinical-measurements.service.spec.ts
+++ b/apps/api/src/sync/clinical-measurements.service.spec.ts
@@ -1,0 +1,257 @@
+import { BadRequestException, ConflictException, ForbiddenException } from '@nestjs/common';
+import {
+  BloodPressureSite,
+  EncounterStatus,
+  ReadinessToQuit,
+  ScreeningAnswer,
+  TemperatureSource,
+  TobaccoUseStatus,
+  UserRole,
+} from '@prisma/client';
+import { ClinicalMeasurementsService } from './clinical-measurements.service';
+
+const IDS = {
+  clinic: '00000000-0000-4000-8000-000000000001',
+  encounter: '00000000-0000-4000-8000-000000000002',
+  vitals: '00000000-0000-4000-8000-000000000003',
+  tobacco: '00000000-0000-4000-8000-000000000004',
+  user: '00000000-0000-4000-8000-000000000005',
+};
+
+function payload(overrides: Record<string, unknown> = {}) {
+  return {
+    schemaVersion: 1,
+    encounterId: IDS.encounter,
+    vitalsId: IDS.vitals,
+    tobaccoScreeningId: IDS.tobacco,
+    vitals: {
+      systolicBp: 120,
+      diastolicBp: 80,
+      bpSite: BloodPressureSite.LEFT_ARM,
+      pulseBpm: 72,
+      temperatureValue: 98.6,
+      temperatureUnit: 'FAHRENHEIT',
+      temperatureSource: TemperatureSource.ORAL,
+      respiratoryRate: 16,
+      spo2Percent: 98,
+      weightKg: 70,
+      heightCm: 170,
+      bmi: 999,
+    },
+    tobacco: {
+      smokingStatus: TobaccoUseStatus.NEVER,
+      smokelessTobaccoStatus: TobaccoUseStatus.NOT_ASSESSED,
+      passiveExposure: ScreeningAnswer.NO,
+      readinessToQuit: ReadinessToQuit.NOT_APPLICABLE,
+      counselingGiven: ScreeningAnswer.NO,
+    },
+    ...overrides,
+  };
+}
+
+function createHarness(options?: {
+  encounter?: { clinicId: string; status: EncounterStatus } | null;
+  existingTobacco?: Record<string, unknown> | null;
+}) {
+  const tx = {
+    encounter: {
+      findUnique: jest
+        .fn()
+        .mockResolvedValue(
+          options?.encounter === undefined
+            ? { clinicId: IDS.clinic, status: EncounterStatus.DRAFT }
+            : options.encounter,
+        ),
+    },
+    vitals: {
+      findUnique: jest.fn().mockResolvedValue(null),
+      upsert: jest.fn().mockImplementation(({ create }) => Promise.resolve(create)),
+    },
+    tobaccoScreening: {
+      findUnique: jest.fn().mockResolvedValue(options?.existingTobacco ?? null),
+      upsert: jest
+        .fn()
+        .mockImplementation(({ create, update }) =>
+          Promise.resolve({ id: IDS.tobacco, ...(options?.existingTobacco ? update : create) }),
+        ),
+    },
+    auditEvent: { create: jest.fn().mockResolvedValue({}) },
+    syncMutation: { create: jest.fn().mockResolvedValue({}) },
+  };
+  const prisma = {
+    $transaction: jest.fn(async (callback: (client: typeof tx) => Promise<unknown>) =>
+      callback(tx),
+    ),
+  };
+  return { tx, prisma, service: new ClinicalMeasurementsService(prisma as never) };
+}
+
+describe('ClinicalMeasurementsService', () => {
+  it('converts temperature and derives authoritative BMI', async () => {
+    const { service } = createHarness();
+    const normalized = await service.validateAndNormalize(payload());
+
+    expect(normalized.vitals.temperatureCelsius).toBe(37);
+    expect(normalized.vitals.bmi).toBe(24.2);
+    expect(normalized.vitals.pulseBpm).toBe(72);
+  });
+
+  it.each([
+    ['partial blood pressure', { vitals: { systolicBp: 120, bpSite: BloodPressureSite.LEFT_ARM } }],
+    [
+      'impossible blood pressure ordering',
+      {
+        vitals: {
+          systolicBp: 80,
+          diastolicBp: 120,
+          bpSite: BloodPressureSite.LEFT_ARM,
+        },
+      },
+    ],
+    [
+      'missing temperature source',
+      { vitals: { temperatureValue: 37, temperatureUnit: 'CELSIUS' } },
+    ],
+    [
+      'invalid enum',
+      {
+        vitals: {
+          systolicBp: 120,
+          diastolicBp: 80,
+          bpSite: 'MIDDLE_ARM',
+        },
+      },
+    ],
+  ])('rejects %s with field errors', async (_label, overrides) => {
+    const { service } = createHarness();
+    await expect(service.validateAndNormalize(payload(overrides))).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+  });
+
+  it('requires screening write permission', async () => {
+    const { service } = createHarness();
+    await expect(
+      service.applyBundle({
+        clinicId: IDS.clinic,
+        actorUserId: IDS.user,
+        user: { user: { id: IDS.user }, roles: [{ role: UserRole.DIRECTOR }] },
+        mutation: {
+          id: 'mutation-1',
+          entityType: 'encounter_vitals_bundle',
+          entityId: IDS.vitals,
+          clinicId: IDS.clinic,
+          operation: 'UPSERT',
+          idempotencyKey: 'idempotency-1',
+          payloadJson: payload(),
+        },
+        payload: payload(),
+      }),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('rejects cross-clinic and finalized encounters', async () => {
+    const user = { user: { id: IDS.user }, roles: [{ role: UserRole.VOLUNTEER }] };
+    const mutation = {
+      id: 'mutation-1',
+      entityType: 'encounter_vitals_bundle',
+      entityId: IDS.vitals,
+      clinicId: IDS.clinic,
+      operation: 'UPSERT' as const,
+      idempotencyKey: 'idempotency-1',
+      payloadJson: payload(),
+    };
+    const crossClinic = createHarness({
+      encounter: {
+        clinicId: '00000000-0000-4000-8000-000000000099',
+        status: EncounterStatus.DRAFT,
+      },
+    });
+    await expect(
+      crossClinic.service.applyBundle({
+        clinicId: IDS.clinic,
+        actorUserId: IDS.user,
+        user,
+        mutation,
+        payload: payload(),
+      }),
+    ).rejects.toThrow('active clinic');
+
+    const finalized = createHarness({
+      encounter: { clinicId: IDS.clinic, status: EncounterStatus.FINALIZED },
+    });
+    await expect(
+      finalized.service.applyBundle({
+        clinicId: IDS.clinic,
+        actorUserId: IDS.user,
+        user,
+        mutation,
+        payload: payload(),
+      }),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('writes both records, audits, and idempotency state in one transaction', async () => {
+    const { service, prisma, tx } = createHarness();
+    await service.applyBundle({
+      clinicId: IDS.clinic,
+      actorUserId: IDS.user,
+      user: { user: { id: IDS.user }, roles: [{ role: UserRole.VOLUNTEER }] },
+      mutation: {
+        id: 'mutation-1',
+        entityType: 'encounter_vitals_bundle',
+        entityId: IDS.vitals,
+        clinicId: IDS.clinic,
+        operation: 'UPSERT',
+        idempotencyKey: 'idempotency-1',
+        payloadJson: payload(),
+      },
+      payload: payload({ markTobaccoReviewed: true }),
+    });
+
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(tx.vitals.upsert).toHaveBeenCalledTimes(1);
+    expect(tx.tobaccoScreening.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({ reviewedByUserId: IDS.user }),
+      }),
+    );
+    expect(tx.auditEvent.create).toHaveBeenCalledTimes(2);
+    expect(tx.syncMutation.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears stale review metadata when tobacco answers change', async () => {
+    const { service, tx } = createHarness({
+      existingTobacco: {
+        smokingStatus: TobaccoUseStatus.CURRENT,
+        smokelessTobaccoStatus: TobaccoUseStatus.NOT_ASSESSED,
+        passiveExposure: ScreeningAnswer.NO,
+        readinessToQuit: ReadinessToQuit.NOT_READY,
+        counselingGiven: ScreeningAnswer.NO,
+        reviewedByUserId: IDS.user,
+        reviewedAt: new Date(),
+      },
+    });
+    await service.applyBundle({
+      clinicId: IDS.clinic,
+      actorUserId: IDS.user,
+      user: { user: { id: IDS.user }, roles: [{ role: UserRole.DOCTOR }] },
+      mutation: {
+        id: 'mutation-1',
+        entityType: 'encounter_vitals_bundle',
+        entityId: IDS.vitals,
+        clinicId: IDS.clinic,
+        operation: 'UPSERT',
+        idempotencyKey: 'idempotency-1',
+        payloadJson: payload(),
+      },
+      payload: payload(),
+    });
+
+    expect(tx.tobaccoScreening.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({ reviewedByUserId: null, reviewedAt: null }),
+      }),
+    );
+  });
+});

--- a/apps/api/src/sync/clinical-measurements.service.ts
+++ b/apps/api/src/sync/clinical-measurements.service.ts
@@ -1,0 +1,396 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { plainToInstance } from 'class-transformer';
+import { validate, type ValidationError } from 'class-validator';
+import {
+  BloodPressureCuffSize,
+  BloodPressureSite,
+  EncounterStatus,
+  PatientPosition,
+  ReadinessToQuit,
+  ScreeningAnswer,
+  SyncMutationStatus,
+  SyncOperation,
+  TemperatureSource,
+  TobaccoUseStatus,
+  type UserRole,
+} from '@prisma/client';
+import { computeBmi, toCelsius } from '@nkwapa/db';
+import { hasPermission, PERMISSIONS } from '../auth/constants/permissions';
+import { PrismaService } from '../prisma/prisma.service';
+import {
+  EncounterVitalsBundleDto,
+  type TemperatureInputUnit,
+  type TobaccoScreeningInputDto,
+  type VitalsInputDto,
+} from './dto/encounter-vitals-bundle.dto';
+import type { SyncMutationDto } from './dto/sync-mutation.dto';
+import type { RequestMetadata, UserWithId } from './sync.service';
+
+type NormalizedVitals = {
+  systolicBp: number | null;
+  diastolicBp: number | null;
+  bpSite: BloodPressureSite | null;
+  bpSiteOther: string | null;
+  patientPosition: PatientPosition | null;
+  patientPositionOther: string | null;
+  cuffSize: BloodPressureCuffSize | null;
+  cuffSizeOther: string | null;
+  pulseBpm: number | null;
+  temperatureCelsius: number | null;
+  temperatureSource: TemperatureSource | null;
+  temperatureSourceOther: string | null;
+  respiratoryRate: number | null;
+  spo2Percent: number | null;
+  weightKg: number | null;
+  heightCm: number | null;
+  bmi: number | null;
+  notes: string | null;
+};
+
+type NormalizedTobacco = {
+  smokingStatus: TobaccoUseStatus;
+  smokelessTobaccoStatus: TobaccoUseStatus;
+  passiveExposure: ScreeningAnswer;
+  readinessToQuit: ReadinessToQuit;
+  counselingGiven: ScreeningAnswer;
+};
+
+export type NormalizedEncounterVitalsBundle = {
+  schemaVersion: 1;
+  encounterId: string;
+  vitalsId: string;
+  tobaccoScreeningId?: string;
+  vitals: NormalizedVitals;
+  tobacco?: NormalizedTobacco;
+  markTobaccoReviewed: boolean;
+};
+
+@Injectable()
+export class ClinicalMeasurementsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async applyBundle(params: {
+    clinicId: string;
+    actorUserId: string;
+    user: UserWithId;
+    mutation: SyncMutationDto;
+    payload: Record<string, unknown>;
+    metadata?: RequestMetadata;
+    legacy?: boolean;
+  }): Promise<void> {
+    if (
+      !hasPermission(params.user.roles as Array<{ role: UserRole }>, PERMISSIONS.SCREENING_WRITE)
+    ) {
+      throw new ForbiddenException(
+        'SCREENING.WRITE permission is required for clinical measurements',
+      );
+    }
+
+    const bundlePayload = params.legacy
+      ? this.fromLegacyVitals(params.mutation, params.payload)
+      : params.payload;
+    const bundle = await this.validateAndNormalize(bundlePayload, !params.legacy);
+
+    await this.prisma.$transaction(async (tx) => {
+      const encounter = await tx.encounter.findUnique({
+        where: { id: bundle.encounterId },
+        select: { clinicId: true, status: true },
+      });
+      if (!encounter || encounter.clinicId !== params.clinicId) {
+        throw new NotFoundException('Encounter not found in the active clinic');
+      }
+      if (encounter.status === EncounterStatus.FINALIZED) {
+        throw new ConflictException({
+          code: 'CONFLICT_FINALIZED',
+          message: 'Cannot modify measurements for a finalized encounter',
+          existingStatus: EncounterStatus.FINALIZED,
+        });
+      }
+
+      const [existingVitals, existingTobacco] = await Promise.all([
+        tx.vitals.findUnique({ where: { encounterId: bundle.encounterId } }),
+        bundle.tobacco
+          ? tx.tobaccoScreening.findUnique({ where: { encounterId: bundle.encounterId } })
+          : Promise.resolve(null),
+      ]);
+
+      const vitals = await tx.vitals.upsert({
+        where: { encounterId: bundle.encounterId },
+        create: {
+          id: bundle.vitalsId,
+          clinicId: params.clinicId,
+          encounterId: bundle.encounterId,
+          ...bundle.vitals,
+        },
+        update: bundle.vitals,
+      });
+
+      let tobacco = null;
+      if (bundle.tobacco && bundle.tobaccoScreeningId) {
+        const answersChanged =
+          !existingTobacco ||
+          existingTobacco.smokingStatus !== bundle.tobacco.smokingStatus ||
+          existingTobacco.smokelessTobaccoStatus !== bundle.tobacco.smokelessTobaccoStatus ||
+          existingTobacco.passiveExposure !== bundle.tobacco.passiveExposure ||
+          existingTobacco.readinessToQuit !== bundle.tobacco.readinessToQuit ||
+          existingTobacco.counselingGiven !== bundle.tobacco.counselingGiven;
+        const reviewData = bundle.markTobaccoReviewed
+          ? { reviewedByUserId: params.actorUserId, reviewedAt: new Date() }
+          : answersChanged
+            ? { reviewedByUserId: null, reviewedAt: null }
+            : {};
+
+        tobacco = await tx.tobaccoScreening.upsert({
+          where: { encounterId: bundle.encounterId },
+          create: {
+            id: bundle.tobaccoScreeningId,
+            clinicId: params.clinicId,
+            encounterId: bundle.encounterId,
+            ...bundle.tobacco,
+            ...reviewData,
+          },
+          update: { ...bundle.tobacco, ...reviewData },
+        });
+      }
+
+      await tx.auditEvent.create({
+        data: {
+          clinicId: params.clinicId,
+          actorUserId: params.actorUserId,
+          action: existingVitals ? 'VITALS.UPSERT' : 'VITALS.CREATE',
+          entityType: 'Vitals',
+          entityId: vitals.id,
+          beforeJson: existingVitals ? JSON.stringify(existingVitals) : undefined,
+          afterJson: JSON.stringify(vitals),
+          requestId: params.mutation.idempotencyKey,
+          ipAddress: params.metadata?.ipAddress,
+          userAgent: params.metadata?.userAgent,
+        },
+      });
+
+      if (tobacco) {
+        await tx.auditEvent.create({
+          data: {
+            clinicId: params.clinicId,
+            actorUserId: params.actorUserId,
+            action: bundle.markTobaccoReviewed
+              ? 'TOBACCO_SCREENING.REVIEW'
+              : existingTobacco
+                ? 'TOBACCO_SCREENING.UPSERT'
+                : 'TOBACCO_SCREENING.CREATE',
+            entityType: 'TobaccoScreening',
+            entityId: tobacco.id,
+            beforeJson: existingTobacco ? JSON.stringify(existingTobacco) : undefined,
+            afterJson: JSON.stringify(tobacco),
+            requestId: params.mutation.idempotencyKey,
+            ipAddress: params.metadata?.ipAddress,
+            userAgent: params.metadata?.userAgent,
+          },
+        });
+      }
+
+      await tx.syncMutation.create({
+        data: {
+          clinicId: params.clinicId,
+          entityType: params.mutation.entityType,
+          entityId: params.mutation.entityId,
+          operation: SyncOperation.UPSERT,
+          idempotencyKey: params.mutation.idempotencyKey,
+          status: SyncMutationStatus.APPLIED,
+        },
+      });
+    });
+  }
+
+  async validateAndNormalize(
+    payload: Record<string, unknown>,
+    requireBloodPressureContext = true,
+  ): Promise<NormalizedEncounterVitalsBundle> {
+    const dto = plainToInstance(EncounterVitalsBundleDto, payload);
+    const errors = await validate(dto, {
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      forbidUnknownValues: true,
+    });
+    if (errors.length) this.throwValidationErrors(errors);
+
+    const vitals = this.normalizeVitals(dto.vitals, requireBloodPressureContext);
+    if (dto.markTobaccoReviewed && (!dto.tobacco || !dto.tobaccoScreeningId)) {
+      this.throwFieldError('markTobaccoReviewed', 'Tobacco answers are required before review');
+    }
+    if (dto.tobacco && !dto.tobaccoScreeningId) {
+      this.throwFieldError('tobaccoScreeningId', 'A tobacco screening ID is required');
+    }
+
+    return {
+      schemaVersion: 1,
+      encounterId: dto.encounterId,
+      vitalsId: dto.vitalsId,
+      tobaccoScreeningId: dto.tobaccoScreeningId,
+      vitals,
+      tobacco: dto.tobacco ? this.normalizeTobacco(dto.tobacco) : undefined,
+      markTobaccoReviewed: dto.markTobaccoReviewed === true,
+    };
+  }
+
+  private normalizeVitals(
+    input: VitalsInputDto,
+    requireBloodPressureContext: boolean,
+  ): NormalizedVitals {
+    const systolicBp = input.systolicBp ?? null;
+    const diastolicBp = input.diastolicBp ?? null;
+    const hasSystolic = systolicBp != null;
+    const hasDiastolic = diastolicBp != null;
+    if (hasSystolic !== hasDiastolic) {
+      this.throwFieldError(
+        'vitals.systolicBp',
+        'Systolic and diastolic blood pressure are required together',
+      );
+    }
+    if (systolicBp != null && diastolicBp != null && systolicBp <= diastolicBp) {
+      this.throwFieldError(
+        'vitals.systolicBp',
+        'Systolic blood pressure must be greater than diastolic',
+      );
+    }
+
+    const bpSite = input.bpSite ?? null;
+    const patientPosition = input.patientPosition ?? null;
+    const cuffSize = input.cuffSize ?? null;
+    if (requireBloodPressureContext && hasSystolic && !bpSite) {
+      this.throwFieldError(
+        'vitals.bpSite',
+        'Blood pressure site is required with a blood pressure reading',
+      );
+    }
+    if (!hasSystolic && (bpSite || patientPosition || cuffSize)) {
+      this.throwFieldError(
+        'vitals.bpSite',
+        'Blood pressure context requires a blood pressure reading',
+      );
+    }
+
+    const pulseBpm = input.pulseBpm ?? input.heartRate ?? null;
+    if (input.pulseBpm != null && input.heartRate != null && input.pulseBpm !== input.heartRate) {
+      this.throwFieldError('vitals.pulseBpm', 'pulseBpm and legacy heartRate cannot conflict');
+    }
+
+    const hasTemperature = input.temperatureValue != null;
+    if (
+      hasTemperature !== (input.temperatureUnit != null) ||
+      hasTemperature !== (input.temperatureSource != null)
+    ) {
+      this.throwFieldError(
+        'vitals.temperatureValue',
+        'Temperature value, unit, and source are required together',
+      );
+    }
+    const temperatureCelsius = hasTemperature
+      ? toCelsius(input.temperatureValue as number, input.temperatureUnit as TemperatureInputUnit)
+      : null;
+    if (temperatureCelsius != null && (temperatureCelsius < 25 || temperatureCelsius > 45)) {
+      this.throwFieldError('vitals.temperatureValue', 'Temperature must convert to 25–45 °C');
+    }
+
+    return {
+      systolicBp,
+      diastolicBp,
+      bpSite,
+      bpSiteOther: this.normalizeOther('vitals.bpSiteOther', bpSite, input.bpSiteOther),
+      patientPosition,
+      patientPositionOther: this.normalizeOther(
+        'vitals.patientPositionOther',
+        patientPosition,
+        input.patientPositionOther,
+      ),
+      cuffSize,
+      cuffSizeOther: this.normalizeOther('vitals.cuffSizeOther', cuffSize, input.cuffSizeOther),
+      pulseBpm,
+      temperatureCelsius,
+      temperatureSource: input.temperatureSource ?? null,
+      temperatureSourceOther: this.normalizeOther(
+        'vitals.temperatureSourceOther',
+        input.temperatureSource,
+        input.temperatureSourceOther,
+      ),
+      respiratoryRate: input.respiratoryRate ?? null,
+      spo2Percent: input.spo2Percent ?? null,
+      weightKg: input.weightKg ?? null,
+      heightCm: input.heightCm ?? null,
+      bmi: computeBmi(input.weightKg, input.heightCm),
+      notes: input.notes?.trim() || null,
+    };
+  }
+
+  private normalizeTobacco(input: TobaccoScreeningInputDto): NormalizedTobacco {
+    return {
+      smokingStatus: input.smokingStatus,
+      smokelessTobaccoStatus: input.smokelessTobaccoStatus,
+      passiveExposure: input.passiveExposure,
+      readinessToQuit: input.readinessToQuit,
+      counselingGiven: input.counselingGiven,
+    };
+  }
+
+  private normalizeOther(
+    field: string,
+    selected: string | null | undefined,
+    detail: string | null | undefined,
+  ): string | null {
+    const normalized = detail?.trim() || null;
+    if (selected === 'OTHER' && !normalized) {
+      this.throwFieldError(field, 'Detail is required when OTHER is selected');
+    }
+    if (selected !== 'OTHER' && normalized) {
+      this.throwFieldError(field, 'Detail is only allowed when OTHER is selected');
+    }
+    return selected === 'OTHER' ? normalized : null;
+  }
+
+  private fromLegacyVitals(
+    mutation: SyncMutationDto,
+    payload: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const vitals = { ...payload };
+    const encounterId = vitals.encounterId;
+    delete vitals.encounterId;
+    delete vitals.clinicId;
+    return {
+      schemaVersion: 1,
+      encounterId,
+      vitalsId: mutation.entityId,
+      vitals,
+    };
+  }
+
+  private throwValidationErrors(errors: ValidationError[]): never {
+    const flatten = (
+      items: ValidationError[],
+      parent = '',
+    ): Array<{ field: string; message: string }> =>
+      items.flatMap((error) => {
+        const field = parent ? `${parent}.${error.property}` : error.property;
+        const own = Object.values(error.constraints ?? {}).map((message) => ({ field, message }));
+        return [...own, ...flatten(error.children ?? [], field)];
+      });
+    throw new BadRequestException({
+      code: 'VALIDATION_ERROR',
+      message: 'Clinical measurement validation failed',
+      fieldErrors: flatten(errors),
+    });
+  }
+
+  private throwFieldError(field: string, message: string): never {
+    throw new BadRequestException({
+      code: 'VALIDATION_ERROR',
+      message: 'Clinical measurement validation failed',
+      fieldErrors: [{ field, message }],
+    });
+  }
+}

--- a/apps/api/src/sync/dto/encounter-vitals-bundle.dto.ts
+++ b/apps/api/src/sync/dto/encounter-vitals-bundle.dto.ts
@@ -1,0 +1,193 @@
+import { Type } from 'class-transformer';
+import {
+  IsBoolean,
+  IsEnum,
+  IsIn,
+  IsInt,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Max,
+  MaxLength,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import {
+  BloodPressureCuffSize,
+  BloodPressureSite,
+  PatientPosition,
+  ReadinessToQuit,
+  ScreeningAnswer,
+  TemperatureSource,
+  TobaccoUseStatus,
+} from '@prisma/client';
+import { ToOptionalNumber, ToSanitizedString } from '../../common/validation';
+
+export const TEMPERATURE_UNITS = ['CELSIUS', 'FAHRENHEIT'] as const;
+export type TemperatureInputUnit = (typeof TEMPERATURE_UNITS)[number];
+
+export class VitalsInputDto {
+  @IsOptional()
+  @ToOptionalNumber()
+  @IsInt()
+  @Min(40)
+  @Max(300)
+  systolicBp?: number | null;
+
+  @IsOptional()
+  @ToOptionalNumber()
+  @IsInt()
+  @Min(20)
+  @Max(200)
+  diastolicBp?: number | null;
+
+  @IsOptional()
+  @IsEnum(BloodPressureSite)
+  bpSite?: BloodPressureSite | null;
+
+  @IsOptional()
+  @ToSanitizedString({ maxLength: 120 })
+  @IsString()
+  @MaxLength(120)
+  bpSiteOther?: string | null;
+
+  @IsOptional()
+  @IsEnum(PatientPosition)
+  patientPosition?: PatientPosition | null;
+
+  @IsOptional()
+  @ToSanitizedString({ maxLength: 120 })
+  @IsString()
+  @MaxLength(120)
+  patientPositionOther?: string | null;
+
+  @IsOptional()
+  @IsEnum(BloodPressureCuffSize)
+  cuffSize?: BloodPressureCuffSize | null;
+
+  @IsOptional()
+  @ToSanitizedString({ maxLength: 120 })
+  @IsString()
+  @MaxLength(120)
+  cuffSizeOther?: string | null;
+
+  @IsOptional()
+  @ToOptionalNumber()
+  @IsInt()
+  @Min(20)
+  @Max(300)
+  pulseBpm?: number | null;
+
+  /** @deprecated Compatibility alias for pulseBpm. */
+  @IsOptional()
+  @ToOptionalNumber()
+  @IsInt()
+  @Min(20)
+  @Max(300)
+  heartRate?: number | null;
+
+  @IsOptional()
+  @ToOptionalNumber()
+  @IsNumber({ allowInfinity: false, allowNaN: false, maxDecimalPlaces: 2 })
+  temperatureValue?: number | null;
+
+  @IsOptional()
+  @IsIn(TEMPERATURE_UNITS)
+  temperatureUnit?: TemperatureInputUnit | null;
+
+  @IsOptional()
+  @IsEnum(TemperatureSource)
+  temperatureSource?: TemperatureSource | null;
+
+  @IsOptional()
+  @ToSanitizedString({ maxLength: 120 })
+  @IsString()
+  @MaxLength(120)
+  temperatureSourceOther?: string | null;
+
+  @IsOptional()
+  @ToOptionalNumber()
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  respiratoryRate?: number | null;
+
+  @IsOptional()
+  @ToOptionalNumber()
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  spo2Percent?: number | null;
+
+  @IsOptional()
+  @ToOptionalNumber()
+  @IsNumber({ allowInfinity: false, allowNaN: false, maxDecimalPlaces: 2 })
+  @Min(0.1)
+  @Max(700)
+  weightKg?: number | null;
+
+  @IsOptional()
+  @ToOptionalNumber()
+  @IsNumber({ allowInfinity: false, allowNaN: false, maxDecimalPlaces: 2 })
+  @Min(20)
+  @Max(300)
+  heightCm?: number | null;
+
+  /** @deprecated Accepted but ignored; BMI is always derived by the server. */
+  @IsOptional()
+  @ToOptionalNumber()
+  @IsNumber({ allowInfinity: false, allowNaN: false })
+  bmi?: number | null;
+
+  @IsOptional()
+  @ToSanitizedString({ maxLength: 2000, preserveNewlines: true })
+  @IsString()
+  @MaxLength(2000)
+  notes?: string | null;
+}
+
+export class TobaccoScreeningInputDto {
+  @IsEnum(TobaccoUseStatus)
+  smokingStatus: TobaccoUseStatus = TobaccoUseStatus.NOT_ASSESSED;
+
+  @IsEnum(TobaccoUseStatus)
+  smokelessTobaccoStatus: TobaccoUseStatus = TobaccoUseStatus.NOT_ASSESSED;
+
+  @IsEnum(ScreeningAnswer)
+  passiveExposure: ScreeningAnswer = ScreeningAnswer.NOT_ASSESSED;
+
+  @IsEnum(ReadinessToQuit)
+  readinessToQuit: ReadinessToQuit = ReadinessToQuit.NOT_ASSESSED;
+
+  @IsEnum(ScreeningAnswer)
+  counselingGiven: ScreeningAnswer = ScreeningAnswer.NOT_ASSESSED;
+}
+
+export class EncounterVitalsBundleDto {
+  @IsIn([1])
+  schemaVersion!: 1;
+
+  @IsUUID()
+  encounterId!: string;
+
+  @IsUUID()
+  vitalsId!: string;
+
+  @IsOptional()
+  @IsUUID()
+  tobaccoScreeningId?: string;
+
+  @ValidateNested()
+  @Type(() => VitalsInputDto)
+  vitals!: VitalsInputDto;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => TobaccoScreeningInputDto)
+  tobacco?: TobaccoScreeningInputDto;
+
+  @IsOptional()
+  @IsBoolean()
+  markTobaccoReviewed?: boolean;
+}

--- a/apps/api/src/sync/dto/sync-pull-response.dto.ts
+++ b/apps/api/src/sync/dto/sync-pull-response.dto.ts
@@ -9,13 +9,20 @@ import {
   Prescription,
   MedicalHistoryRecord,
   MedicalHistoryRevision,
+  TobaccoScreening,
 } from '@prisma/client';
+
+export type SyncVitalsRecord = Vitals & {
+  /** @deprecated Compatibility alias for pulseBpm. */
+  heartRate: number | null;
+};
 
 export interface SyncPullResponseDto {
   cursor: string;
   patients: Patient[];
   encounters: Encounter[];
-  vitals: Vitals[];
+  vitals: SyncVitalsRecord[];
+  tobaccoScreenings: TobaccoScreening[];
   diabetesScreenings: DiabetesScreening[];
   hypertensionAssessments: HypertensionAssessment[];
   carePlans: CarePlan[];

--- a/apps/api/src/sync/sync.controller.spec.ts
+++ b/apps/api/src/sync/sync.controller.spec.ts
@@ -219,6 +219,7 @@ describe('SyncController', () => {
       patients: [],
       encounters: [],
       vitals: [],
+      tobaccoScreenings: [],
       diabetesScreenings: [],
       hypertensionAssessments: [],
       carePlans: [],

--- a/apps/api/src/sync/sync.module.ts
+++ b/apps/api/src/sync/sync.module.ts
@@ -5,10 +5,11 @@ import { AuthModule } from '../auth/auth.module';
 import { PatientModule } from '../patients/patient.module';
 import { EncounterModule } from '../encounters/encounter.module';
 import { MedicalHistoryModule } from '../medical-history/medical-history.module';
+import { ClinicalMeasurementsService } from './clinical-measurements.service';
 
 @Module({
   imports: [AuthModule, PatientModule, EncounterModule, MedicalHistoryModule],
   controllers: [SyncController],
-  providers: [SyncService],
+  providers: [SyncService, ClinicalMeasurementsService],
 })
 export class SyncModule {}

--- a/apps/api/src/sync/sync.service.spec.ts
+++ b/apps/api/src/sync/sync.service.spec.ts
@@ -40,6 +40,14 @@ describe('SyncService', () => {
         findUnique: jest.fn().mockResolvedValue(null),
         upsert: jest.fn().mockResolvedValue({ id: 'enc-1', status: 'DRAFT' }),
       },
+      vitals: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'vitals-1',
+          clinicId: 'clinic-1',
+          encounter: { status: EncounterStatus.DRAFT },
+        }),
+        deleteMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -102,6 +110,57 @@ describe('SyncService', () => {
 
     expect(result).toEqual([{ id: 'mut-vitals-1', status: 'APPLIED' }]);
     expect(clinicalMeasurementsService.applyBundle).not.toHaveBeenCalled();
+  });
+
+  it('rejects a vitals delete without screening write permission', async () => {
+    const results = await service.applyMutations(
+      'clinic-1',
+      {
+        user: { id: 'director-1' },
+        roles: [{ clinicId: 'clinic-1', role: 'DIRECTOR' }],
+      } as never,
+      [
+        {
+          id: 'mut-delete-vitals',
+          entityType: 'vitals',
+          entityId: 'vitals-1',
+          operation: 'DELETE',
+          clinicId: 'clinic-1',
+          idempotencyKey: 'delete-vitals-1',
+        },
+      ],
+    );
+
+    expect(results[0]).toMatchObject({
+      status: SYNC_MUTATION_RESULT_STATUS.ERROR,
+      conflictType: 'APPLICATION_REJECTED',
+    });
+    expect(prisma.vitals.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it('rejects deleting vitals from a finalized encounter', async () => {
+    (prisma.vitals.findFirst as jest.Mock).mockResolvedValue({
+      id: 'vitals-1',
+      clinicId: 'clinic-1',
+      encounter: { status: EncounterStatus.FINALIZED },
+    });
+
+    const results = await service.applyMutations('clinic-1', mockUser as never, [
+      {
+        id: 'mut-delete-finalized-vitals',
+        entityType: 'vitals',
+        entityId: 'vitals-1',
+        operation: 'DELETE',
+        clinicId: 'clinic-1',
+        idempotencyKey: 'delete-finalized-vitals-1',
+      },
+    ]);
+
+    expect(results[0]).toMatchObject({
+      status: SYNC_MUTATION_RESULT_STATUS.CONFLICT,
+      conflictType: 'CONFLICT_FINALIZED',
+    });
+    expect(prisma.vitals.deleteMany).not.toHaveBeenCalled();
   });
 
   describe('patient UPSERT - DUPLICATE_NATIONAL_ID', () => {

--- a/apps/api/src/sync/sync.service.spec.ts
+++ b/apps/api/src/sync/sync.service.spec.ts
@@ -9,6 +9,7 @@ import { SYNC_MUTATION_RESULT_STATUS } from './dto/sync-push-response.dto';
 import type { SyncMutationDto } from './dto/sync-mutation.dto';
 import { MedicalHistoryService } from '../medical-history/medical-history.service';
 import { ConflictException } from '@nestjs/common';
+import { ClinicalMeasurementsService } from './clinical-measurements.service';
 
 const mockUser = {
   user: { id: 'user-1' },
@@ -21,6 +22,7 @@ describe('SyncService', () => {
   let encounterRepo: jest.Mocked<EncounterRepository>;
   let prisma: jest.Mocked<PrismaService>;
   let medicalHistoryService: jest.Mocked<MedicalHistoryService>;
+  let clinicalMeasurementsService: jest.Mocked<ClinicalMeasurementsService>;
   beforeEach(async () => {
     const mockPrisma = {
       syncMutation: {
@@ -65,6 +67,10 @@ describe('SyncService', () => {
             revise: jest.fn().mockResolvedValue({}),
           },
         },
+        {
+          provide: ClinicalMeasurementsService,
+          useValue: { applyBundle: jest.fn().mockResolvedValue(undefined) },
+        },
       ],
     }).compile();
 
@@ -73,6 +79,29 @@ describe('SyncService', () => {
     prisma = module.get(PrismaService);
     encounterRepo = module.get(EncounterRepository);
     medicalHistoryService = module.get(MedicalHistoryService);
+    clinicalMeasurementsService = module.get(ClinicalMeasurementsService);
+  });
+
+  it('replays an applied vitals bundle idempotently without writing again', async () => {
+    (prisma.syncMutation.findUnique as jest.Mock).mockResolvedValue({
+      status: 'APPLIED',
+      conflictType: null,
+      conflictDetailsJson: null,
+    });
+    const result = await service.applyMutations('clinic-1', mockUser as never, [
+      {
+        id: 'mut-vitals-1',
+        entityType: 'encounter_vitals_bundle',
+        entityId: 'vitals-1',
+        operation: 'UPSERT',
+        clinicId: 'clinic-1',
+        payloadJson: {},
+        idempotencyKey: 'vitals-idem-1',
+      },
+    ]);
+
+    expect(result).toEqual([{ id: 'mut-vitals-1', status: 'APPLIED' }]);
+    expect(clinicalMeasurementsService.applyBundle).not.toHaveBeenCalled();
   });
 
   describe('patient UPSERT - DUPLICATE_NATIONAL_ID', () => {

--- a/apps/api/src/sync/sync.service.ts
+++ b/apps/api/src/sync/sync.service.ts
@@ -1,4 +1,4 @@
-import { ConflictException, Injectable } from '@nestjs/common';
+import { ConflictException, HttpException, Injectable } from '@nestjs/common';
 import {
   SyncOperation,
   SyncMutationStatus,
@@ -27,11 +27,13 @@ import { SyncPullResponseDto } from './dto/sync-pull-response.dto';
 import { MedicalHistoryService } from '../medical-history/medical-history.service';
 import { hasPermission, PERMISSIONS } from '../auth/constants/permissions';
 import { isApiFeatureEnabled } from '../common/feature-flags';
+import { ClinicalMeasurementsService } from './clinical-measurements.service';
 
 export type EntityType =
   | 'patient'
   | 'encounter'
   | 'vitals'
+  | 'encounter_vitals_bundle'
   | 'diabetes_screening'
   | 'hypertension_assessment'
   | 'care_plan'
@@ -57,6 +59,7 @@ export class SyncService {
     private readonly patientRepository: PatientRepository,
     private readonly encounterRepository: EncounterRepository,
     private readonly medicalHistoryService: MedicalHistoryService,
+    private readonly clinicalMeasurementsService: ClinicalMeasurementsService,
   ) {}
 
   async applyMutations(
@@ -105,19 +108,25 @@ export class SyncService {
         results.push(result);
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
-        const conflictResponse =
-          err instanceof ConflictException && typeof err.getResponse() === 'object'
+        const httpResponse =
+          err instanceof HttpException && typeof err.getResponse() === 'object'
             ? (err.getResponse() as Record<string, unknown>)
             : null;
+        const conflictResponse = err instanceof ConflictException ? httpResponse : null;
         const isRevisionConflict =
           mut.entityType === 'medical_history_revision' && conflictResponse !== null;
-        const status = isRevisionConflict
+        const isConflict = conflictResponse !== null;
+        const status = isConflict
           ? SYNC_MUTATION_RESULT_STATUS.CONFLICT
           : SYNC_MUTATION_RESULT_STATUS.ERROR;
-        const conflictType = isRevisionConflict
-          ? String(conflictResponse.code ?? 'MEDICAL_HISTORY_CONFLICT')
-          : 'APPLICATION_ERROR';
-        const conflictDetails = conflictResponse ?? { message: msg };
+        const conflictType = httpResponse?.code
+          ? String(httpResponse.code)
+          : isRevisionConflict
+            ? 'MEDICAL_HISTORY_CONFLICT'
+            : err instanceof HttpException
+              ? 'APPLICATION_REJECTED'
+              : 'APPLICATION_ERROR';
+        const conflictDetails = httpResponse ?? { message: msg };
         results.push({
           id: mut.id,
           status,
@@ -131,7 +140,7 @@ export class SyncService {
             entityId: mut.entityId,
             operation: mut.operation === 'UPSERT' ? SyncOperation.UPSERT : SyncOperation.DELETE,
             idempotencyKey: mut.idempotencyKey,
-            status: isRevisionConflict ? SyncMutationStatus.CONFLICT : SyncMutationStatus.ERROR,
+            status: isConflict ? SyncMutationStatus.CONFLICT : SyncMutationStatus.ERROR,
             conflictType,
             conflictDetailsJson: JSON.stringify(conflictDetails),
           },
@@ -179,6 +188,17 @@ export class SyncService {
         return this.applyVitalsUpsert(
           clinicId,
           actorUserId,
+          user,
+          mut,
+          payload,
+          idempotencyKey,
+          metadata,
+        );
+      case 'encounter_vitals_bundle':
+        return this.applyVitalsBundle(
+          clinicId,
+          actorUserId,
+          user,
           mut,
           payload,
           idempotencyKey,
@@ -449,69 +469,41 @@ export class SyncService {
   private async applyVitalsUpsert(
     clinicId: string,
     actorUserId: string,
+    user: UserWithId,
     mut: SyncMutationDto,
     payload: Record<string, unknown>,
     idempotencyKey: string,
     metadata?: RequestMetadata,
   ): Promise<SyncMutationResultDto> {
-    const encounterId = payload.encounterId as string;
-    if (!encounterId) throw new Error('Vitals payload must include encounterId');
-    await this.ensureEncounterNotFinalized(encounterId);
-
-    const existing = await this.prisma.vitals.findUnique({
-      where: { encounterId },
-    });
-    const before = existing ? JSON.stringify(existing) : null;
-
-    const vitals = await this.prisma.vitals.upsert({
-      where: { encounterId },
-      create: {
-        id: mut.entityId,
-        clinicId,
-        encounterId,
-        systolicBp: (payload.systolicBp as number) ?? null,
-        diastolicBp: (payload.diastolicBp as number) ?? null,
-        heartRate: (payload.heartRate as number) ?? null,
-        weightKg: (payload.weightKg as number) ?? null,
-        heightCm: (payload.heightCm as number) ?? null,
-        bmi: (payload.bmi as number) ?? null,
-        notes: (payload.notes as string) ?? null,
-      },
-      update: {
-        systolicBp: (payload.systolicBp as number) ?? existing?.systolicBp ?? null,
-        diastolicBp: (payload.diastolicBp as number) ?? existing?.diastolicBp ?? null,
-        heartRate: (payload.heartRate as number) ?? existing?.heartRate ?? null,
-        weightKg: (payload.weightKg as number) ?? existing?.weightKg ?? null,
-        heightCm: (payload.heightCm as number) ?? existing?.heightCm ?? null,
-        bmi: (payload.bmi as number) ?? existing?.bmi ?? null,
-        notes: (payload.notes as string) ?? existing?.notes ?? null,
-      },
-    });
-
-    await this.auditService.logWrite({
+    await this.clinicalMeasurementsService.applyBundle({
       clinicId,
       actorUserId,
-      action: existing ? 'VITALS.UPSERT' : 'VITALS.CREATE',
-      entityType: 'Vitals',
-      entityId: vitals.id,
-      beforeJson: before,
-      afterJson: JSON.stringify(vitals),
-      requestId: idempotencyKey,
-      ipAddress: metadata?.ipAddress,
-      userAgent: metadata?.userAgent,
+      user,
+      mutation: mut,
+      payload,
+      metadata,
+      legacy: true,
     });
+    return { id: mut.id, status: SYNC_MUTATION_RESULT_STATUS.APPLIED };
+  }
 
-    await this.prisma.syncMutation.create({
-      data: {
-        clinicId,
-        entityType: 'vitals',
-        entityId: mut.entityId,
-        operation: SyncOperation.UPSERT,
-        idempotencyKey,
-        status: SyncMutationStatus.APPLIED,
-      },
+  private async applyVitalsBundle(
+    clinicId: string,
+    actorUserId: string,
+    user: UserWithId,
+    mut: SyncMutationDto,
+    payload: Record<string, unknown>,
+    _idempotencyKey: string,
+    metadata?: RequestMetadata,
+  ): Promise<SyncMutationResultDto> {
+    await this.clinicalMeasurementsService.applyBundle({
+      clinicId,
+      actorUserId,
+      user,
+      mutation: mut,
+      payload,
+      metadata,
     });
-
     return { id: mut.id, status: SYNC_MUTATION_RESULT_STATUS.APPLIED };
   }
 
@@ -1107,7 +1099,8 @@ export class SyncService {
     const [
       patients,
       encounters,
-      vitals,
+      vitalsRows,
+      tobaccoScreenings,
       diabetesScreenings,
       hypertensionAssessments,
       carePlans,
@@ -1127,6 +1120,9 @@ export class SyncService {
         where: { ...where, ...updatedAtFilter },
       }),
       this.prisma.vitals.findMany({
+        where: { ...where, ...updatedAtFilter },
+      }),
+      this.prisma.tobaccoScreening.findMany({
         where: { ...where, ...updatedAtFilter },
       }),
       this.prisma.diabetesScreening.findMany({
@@ -1154,11 +1150,16 @@ export class SyncService {
         },
       }),
     ]);
+    const vitals = vitalsRows.map((record) => ({
+      ...record,
+      heartRate: record.pulseBpm,
+    }));
 
     const allRows = [
       ...patients.map((p) => ({ updatedAt: p.updatedAt, id: p.id })),
       ...encounters.map((e) => ({ updatedAt: e.updatedAt, id: e.id })),
       ...vitals.map((v) => ({ updatedAt: v.updatedAt, id: v.id })),
+      ...tobaccoScreenings.map((t) => ({ updatedAt: t.updatedAt, id: t.id })),
       ...diabetesScreenings.map((d) => ({ updatedAt: d.updatedAt, id: d.id })),
       ...hypertensionAssessments.map((h) => ({ updatedAt: h.updatedAt, id: h.id })),
       ...carePlans.map((c) => ({ updatedAt: c.updatedAt, id: c.id })),
@@ -1189,6 +1190,7 @@ export class SyncService {
       patients,
       encounters,
       vitals,
+      tobaccoScreenings,
       diabetesScreenings,
       hypertensionAssessments,
       carePlans,

--- a/apps/api/src/sync/sync.service.ts
+++ b/apps/api/src/sync/sync.service.ts
@@ -1,4 +1,10 @@
-import { ConflictException, HttpException, Injectable } from '@nestjs/common';
+import {
+  ConflictException,
+  ForbiddenException,
+  HttpException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import {
   SyncOperation,
   SyncMutationStatus,
@@ -162,7 +168,7 @@ export class SyncService {
     const idempotencyKey = mut.idempotencyKey;
 
     if (mut.operation === SYNC_OPERATION.DELETE) {
-      return this.applyDelete(clinicId, actorUserId, mut, metadata);
+      return this.applyDelete(clinicId, actorUserId, user, mut, metadata);
     }
 
     switch (mut.entityType as EntityType) {
@@ -988,6 +994,7 @@ export class SyncService {
   private async applyDelete(
     clinicId: string,
     actorUserId: string,
+    user: UserWithId,
     mut: SyncMutationDto,
     metadata?: RequestMetadata,
   ): Promise<SyncMutationResultDto> {
@@ -1024,28 +1031,49 @@ export class SyncService {
       };
     }
 
+    if (entityType === 'vitals') {
+      if (!hasPermission(user.roles, PERMISSIONS.SCREENING_WRITE)) {
+        throw new ForbiddenException('SCREENING.WRITE permission is required to delete vitals');
+      }
+      const vitals = await this.prisma.vitals.findFirst({
+        where: { id: mut.entityId, clinicId },
+        select: { encounter: { select: { status: true } } },
+      });
+      if (!vitals) throw new NotFoundException('Vitals not found in the active clinic');
+      if (vitals.encounter.status === EncounterStatus.FINALIZED) {
+        throw new ConflictException({
+          code: 'CONFLICT_FINALIZED',
+          message: 'Cannot delete measurements for a finalized encounter',
+          existingStatus: EncounterStatus.FINALIZED,
+        });
+      }
+    }
+
     const beforeMap: Record<string, (id: string) => Promise<unknown>> = {
-      vitals: (id) => this.prisma.vitals.findUnique({ where: { id } }),
-      diabetes_screening: (id) => this.prisma.diabetesScreening.findUnique({ where: { id } }),
+      vitals: (id) => this.prisma.vitals.findFirst({ where: { id, clinicId } }),
+      diabetes_screening: (id) =>
+        this.prisma.diabetesScreening.findFirst({ where: { id, clinicId } }),
       hypertension_assessment: (id) =>
-        this.prisma.hypertensionAssessment.findUnique({ where: { id } }),
-      care_plan: (id) => this.prisma.carePlan.findUnique({ where: { id } }),
-      patient_consent: (id) => this.prisma.patientConsent.findUnique({ where: { id } }),
-      prescription: (id) => this.prisma.prescription.findUnique({ where: { id } }),
+        this.prisma.hypertensionAssessment.findFirst({ where: { id, clinicId } }),
+      care_plan: (id) => this.prisma.carePlan.findFirst({ where: { id, clinicId } }),
+      patient_consent: (id) => this.prisma.patientConsent.findFirst({ where: { id, clinicId } }),
+      prescription: (id) => this.prisma.prescription.findFirst({ where: { id, clinicId } }),
     };
     const finder = beforeMap[entityType];
     const beforeRecord = finder ? await finder(mut.entityId) : null;
     const before = beforeRecord ? JSON.stringify(beforeRecord) : null;
 
     const deleteMap: Record<string, () => Promise<unknown>> = {
-      vitals: () => this.prisma.vitals.deleteMany({ where: { id: mut.entityId } }),
+      vitals: () => this.prisma.vitals.deleteMany({ where: { id: mut.entityId, clinicId } }),
       diabetes_screening: () =>
-        this.prisma.diabetesScreening.deleteMany({ where: { id: mut.entityId } }),
+        this.prisma.diabetesScreening.deleteMany({ where: { id: mut.entityId, clinicId } }),
       hypertension_assessment: () =>
-        this.prisma.hypertensionAssessment.deleteMany({ where: { id: mut.entityId } }),
-      care_plan: () => this.prisma.carePlan.deleteMany({ where: { id: mut.entityId } }),
-      patient_consent: () => this.prisma.patientConsent.deleteMany({ where: { id: mut.entityId } }),
-      prescription: () => this.prisma.prescription.deleteMany({ where: { id: mut.entityId } }),
+        this.prisma.hypertensionAssessment.deleteMany({ where: { id: mut.entityId, clinicId } }),
+      care_plan: () => this.prisma.carePlan.deleteMany({ where: { id: mut.entityId, clinicId } }),
+      patient_consent: () =>
+        this.prisma.patientConsent.deleteMany({ where: { id: mut.entityId, clinicId } }),
+      prescription: () =>
+        this.prisma.prescription.deleteMany({ where: { id: mut.entityId, clinicId } }),
     };
     await deleteMap[entityType]!();
 

--- a/apps/web/app/(workspace)/clinics/[clinicId]/encounters/[encounterId]/page.tsx
+++ b/apps/web/app/(workspace)/clinics/[clinicId]/encounters/[encounterId]/page.tsx
@@ -17,7 +17,7 @@ import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { VitalsForm } from '@/components/VitalsForm';
 import { DiabetesScreeningForm } from '@/components/DiabetesScreeningForm';
 import { HypertensionForm } from '@/components/HypertensionForm';
-import { db } from '@/lib/db';
+import { db, type TobaccoScreeningRecord, type VitalsRecord } from '@/lib/db';
 import { enqueueOutboxMutation } from '@/lib/outbox';
 import { SYNC_OPERATION } from '@/lib/outbox';
 import { ArrowLeft, ClipboardPlus, HeartPulse, ShieldCheck } from 'lucide-react';
@@ -31,6 +31,8 @@ interface EncounterDetail {
   clinicId: string;
   patientId: string;
   createdAt: string;
+  vitals?: VitalsRecord | null;
+  tobaccoScreening?: TobaccoScreeningRecord | null;
 }
 
 export default function EncounterDetailPage() {
@@ -53,15 +55,8 @@ export default function EncounterDetailPage() {
   const vitalsSaveRef = useRef<(() => Promise<void>) | null>(null);
   const screeningSaveRef = useRef<(() => Promise<void>) | null>(null);
   const hypertensionSaveRef = useRef<(() => Promise<void>) | null>(null);
-  const [vitals, setVitals] = useState<{
-    systolicBp?: number | null;
-    diastolicBp?: number | null;
-    heartRate?: number | null;
-    weightKg?: number | null;
-    heightCm?: number | null;
-    bmi?: number | null;
-    notes?: string | null;
-  } | null>(null);
+  const [vitals, setVitals] = useState<VitalsRecord | null>(null);
+  const [tobacco, setTobacco] = useState<TobaccoScreeningRecord | null>(null);
   const [diabetesScreening, setDiabetesScreening] = useState<{
     glucoseMgDl?: number | null;
     glucoseType?: string | null;
@@ -89,6 +84,8 @@ export default function EncounterDetailPage() {
       if (!res.ok) throw new Error(await res.text());
       enc = (await res.json()) as EncounterDetail;
       setEncounter(enc);
+      setVitals(enc.vitals ?? null);
+      setTobacco(enc.tobaccoScreening ?? null);
     } catch {
       try {
         const dbEnc = await db.encounters.get(encounterId);
@@ -114,12 +111,14 @@ export default function EncounterDetailPage() {
     }
 
     try {
-      const [v, d, h] = await Promise.all([
+      const [v, tobaccoRecord, d, h] = await Promise.all([
         db.vitals.where('encounterId').equals(encounterId).first(),
+        db.tobacco_screenings.where('encounterId').equals(encounterId).first(),
         db.diabetes_screenings.where('encounterId').equals(encounterId).first(),
         db.hypertension_assessments.where('encounterId').equals(encounterId).first(),
       ]);
       if (v) setVitals(v);
+      if (tobaccoRecord) setTobacco(tobaccoRecord);
       if (d) setDiabetesScreening(d);
       if (h) setHypertension(h);
     } catch {
@@ -268,6 +267,7 @@ export default function EncounterDetailPage() {
   const canTransitionToReview = encounter.status === 'DRAFT';
   const canTransitionToFinalized = encounter.status === 'IN_REVIEW';
   const isFinalized = encounter.status === 'FINALIZED';
+  const canEditMeasurements = !isFinalized && hasPermission(perms, 'SCREENING.WRITE');
 
   return (
     <div className="space-y-6">
@@ -379,6 +379,8 @@ export default function EncounterDetailPage() {
               encounterId={encounterId}
               recordedByUserId={userId}
               initialData={vitals ?? undefined}
+              initialTobaccoData={tobacco}
+              canEdit={canEditMeasurements}
               onSaved={fetchData}
               saveRef={vitalsSaveRef}
             />
@@ -405,14 +407,24 @@ export default function EncounterDetailPage() {
       )}
 
       {isFinalized && (
-        <Card className="rounded-[28px] border-border/80 bg-card/90 shadow-lg shadow-black/5">
-          <CardContent className="pt-6">
-            <EmptyStateCard
-              title="Encounter finalized"
-              description="This encounter is complete and no further edits are allowed on the clinic chart."
-            />
-          </CardContent>
-        </Card>
+        <div className="space-y-4">
+          <Card className="rounded-[28px] border-border/80 bg-card/90 shadow-lg shadow-black/5">
+            <CardContent className="pt-6">
+              <EmptyStateCard
+                title="Encounter finalized"
+                description="This encounter is complete and all measurements are read-only."
+              />
+            </CardContent>
+          </Card>
+          <VitalsForm
+            clinicId={clinicId}
+            encounterId={encounterId}
+            recordedByUserId={userId}
+            initialData={vitals}
+            initialTobaccoData={tobacco}
+            canEdit={false}
+          />
+        </div>
       )}
     </div>
   );

--- a/apps/web/app/(workspace)/dashboard/page.tsx
+++ b/apps/web/app/(workspace)/dashboard/page.tsx
@@ -15,6 +15,10 @@ import { ReviewDashboard } from '@/components/dashboard/ReviewDashboard';
 import { DirectorDashboard } from '@/components/dashboard/DirectorDashboard';
 import { VolunteerDashboard } from '@/components/dashboard/VolunteerDashboard';
 import { SystemAdminDashboard } from '@/components/dashboard/SystemAdminDashboard';
+import {
+  ClinicalMeasurementsDashboard,
+  type ClinicalMeasurementMetrics,
+} from '@/components/dashboard/ClinicalMeasurementsDashboard';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/components/ui/toast';
@@ -30,6 +34,7 @@ interface DashboardData {
     readyToFinalize: number;
   };
   doctor?: {
+    clinicalMeasurements: ClinicalMeasurementMetrics;
     awaitingFinalization: number;
     patientsSeen: { today: number; week: number; month: number };
     followUpComplianceRate: number;
@@ -45,6 +50,7 @@ interface DashboardData {
     finalizationsTrend: { date: string; count: number }[];
   };
   review?: {
+    clinicalMeasurements: ClinicalMeasurementMetrics;
     awaitingReview: number;
     reviewsCompleted: { today: number; week: number };
     reviewsTrend: { date: string; count: number }[];
@@ -58,6 +64,7 @@ interface DashboardData {
     }[];
   };
   director?: {
+    clinicalMeasurements: ClinicalMeasurementMetrics;
     patientRegistrationTrend: { date: string; count: number }[];
     encounterVolumeTrend: { date: string; count: number }[];
     screeningRates: { hypertension: number; diabetes: number };
@@ -73,6 +80,7 @@ interface DashboardData {
     encounterStatusDistribution: Record<string, number>;
   };
   volunteer?: {
+    clinicalMeasurements: ClinicalMeasurementMetrics;
     patientsRegisteredToday: number;
     encountersCreatedToday: number;
     pendingSubmissions: number;
@@ -234,6 +242,18 @@ export default function DashboardPage() {
             />
 
             <div className="space-y-8 border-t border-border/70 pt-6">
+              {(data.director?.clinicalMeasurements ??
+                data.doctor?.clinicalMeasurements ??
+                data.volunteer?.clinicalMeasurements) && (
+                <ClinicalMeasurementsDashboard
+                  metrics={
+                    data.director?.clinicalMeasurements ??
+                    data.doctor?.clinicalMeasurements ??
+                    data.volunteer!.clinicalMeasurements
+                  }
+                />
+              )}
+
               {data.doctor && <DoctorDashboard {...data.doctor} />}
 
               {data.review && <ReviewDashboard {...data.review} />}

--- a/apps/web/app/(workspace)/encounters/[encounterId]/page.tsx
+++ b/apps/web/app/(workspace)/encounters/[encounterId]/page.tsx
@@ -20,7 +20,7 @@ import { VitalsForm } from '@/components/VitalsForm';
 import { DiabetesScreeningForm } from '@/components/DiabetesScreeningForm';
 import { HypertensionForm } from '@/components/HypertensionForm';
 import { CarePlanForm } from '@/components/CarePlanForm';
-import { db } from '@/lib/db';
+import { db, type TobaccoScreeningRecord, type VitalsRecord } from '@/lib/db';
 import { ArrowLeft, ClipboardPlus, HeartPulse, ShieldCheck } from 'lucide-react';
 import { PrescriptionPanel } from '@/components/patients/PrescriptionPanel';
 import { isWebFeatureEnabled } from '@/lib/feature-flags';
@@ -39,6 +39,7 @@ interface EncounterDetail {
   createdAt: string;
   patient?: { firstName: string; lastName: string; patientCode: string };
   vitals?: Record<string, unknown>;
+  tobaccoScreening?: Record<string, unknown>;
   diabetesScreening?: Record<string, unknown>;
   hypertensionAssessment?: Record<string, unknown>;
   carePlan?: Record<string, unknown>;
@@ -58,7 +59,8 @@ export default function EncounterDetailPage() {
   const medicalHistoryEnabled = isWebFeatureEnabled('medicalHistory');
 
   const [encounter, setEncounter] = useState<EncounterDetail | null>(null);
-  const [vitals, setVitals] = useState<Record<string, unknown> | null>(null);
+  const [vitals, setVitals] = useState<VitalsRecord | null>(null);
+  const [tobacco, setTobacco] = useState<TobaccoScreeningRecord | null>(null);
   const [diabetes, setDiabetes] = useState<Record<string, unknown> | null>(null);
   const [hypertension, setHypertension] = useState<Record<string, unknown> | null>(null);
   const [carePlan, setCarePlan] = useState<Record<string, unknown> | null>(null);
@@ -82,7 +84,8 @@ export default function EncounterDetailPage() {
       if (!res.ok) throw new Error(await res.text());
       const enc = (await res.json()) as EncounterDetail;
       setEncounter(enc);
-      setVitals(enc.vitals ?? null);
+      setVitals((enc.vitals as VitalsRecord | undefined) ?? null);
+      setTobacco((enc.tobaccoScreening as TobaccoScreeningRecord | undefined) ?? null);
       setDiabetes(enc.diabetesScreening ?? null);
       setHypertension(enc.hypertensionAssessment ?? null);
       setCarePlan(enc.carePlan ?? null);
@@ -98,13 +101,15 @@ export default function EncounterDetailPage() {
             createdAt: dbEnc.createdAt ?? new Date().toISOString(),
           });
         }
-        const [v, d, h, c] = await Promise.all([
+        const [v, tobaccoRecord, d, h, c] = await Promise.all([
           db.vitals.where('encounterId').equals(encounterId).first(),
+          db.tobacco_screenings.where('encounterId').equals(encounterId).first(),
           db.diabetes_screenings.where('encounterId').equals(encounterId).first(),
           db.hypertension_assessments.where('encounterId').equals(encounterId).first(),
           db.care_plans.where('encounterId').equals(encounterId).first(),
         ]);
-        if (v) setVitals(v as unknown as Record<string, unknown>);
+        if (v) setVitals(v);
+        if (tobaccoRecord) setTobacco(tobaccoRecord);
         if (d) setDiabetes(d as unknown as Record<string, unknown>);
         if (h) setHypertension(h as unknown as Record<string, unknown>);
         if (c) setCarePlan(c as unknown as Record<string, unknown>);
@@ -217,6 +222,7 @@ export default function EncounterDetailPage() {
     );
 
   const isFinalized = encounter.status === 'FINALIZED';
+  const canEditMeasurements = !isFinalized && hasPermission(perms, 'SCREENING.WRITE');
   const canSubmit =
     encounter.status === 'DRAFT' && hasPermission(perms, 'ENCOUNTER.SUBMIT_FOR_REVIEW');
   const canReview =
@@ -372,6 +378,8 @@ export default function EncounterDetailPage() {
                 encounterId={encounterId}
                 recordedByUserId={userId}
                 initialData={vitals as Parameters<typeof VitalsForm>[0]['initialData']}
+                initialTobaccoData={tobacco}
+                canEdit={canEditMeasurements}
                 onSaved={fetchData}
                 saveRef={vitalsSaveRef}
               />
@@ -409,36 +417,50 @@ export default function EncounterDetailPage() {
         )}
 
         {isFinalized && (
-          <Card className="rounded-[28px] border-border/80 bg-card/90 shadow-lg shadow-black/5">
-            <CardContent className="pt-6">
-              <EmptyStateCard
-                title="Encounter finalized"
-                description="This encounter is complete and no further edits are allowed."
-              />
-              {carePlan && (
-                <div className="mt-4 space-y-2">
-                  <p>
-                    <span className="font-medium">Counseling given:</span>{' '}
-                    {(carePlan as { counselingGiven?: boolean }).counselingGiven ? 'Yes' : 'No'}
-                  </p>
-                  <p>
-                    <span className="font-medium">Medication prescribed:</span>{' '}
-                    {(carePlan as { medicationPrescribed?: boolean }).medicationPrescribed
-                      ? 'Yes'
-                      : 'No'}
-                  </p>
-                  {(carePlan as { followUpDate?: string }).followUpDate && (
+          <div className="space-y-4">
+            <Card className="rounded-[28px] border-border/80 bg-card/90 shadow-lg shadow-black/5">
+              <CardContent className="pt-6">
+                <EmptyStateCard
+                  title="Encounter finalized"
+                  description="This encounter is complete and all measurements are read-only."
+                />
+              </CardContent>
+            </Card>
+            <VitalsForm
+              clinicId={encounter.clinicId}
+              encounterId={encounterId}
+              recordedByUserId={userId}
+              initialData={vitals}
+              initialTobaccoData={tobacco}
+              canEdit={false}
+            />
+            <Card className="rounded-[28px] border-border/80 bg-card/90 shadow-lg shadow-black/5">
+              <CardContent className="pt-6">
+                {carePlan && (
+                  <div className="mt-4 space-y-2">
                     <p>
-                      <span className="font-medium">Follow-up:</span>{' '}
-                      {new Date(
-                        (carePlan as { followUpDate: string }).followUpDate,
-                      ).toLocaleDateString()}
+                      <span className="font-medium">Counseling given:</span>{' '}
+                      {(carePlan as { counselingGiven?: boolean }).counselingGiven ? 'Yes' : 'No'}
                     </p>
-                  )}
-                </div>
-              )}
-            </CardContent>
-          </Card>
+                    <p>
+                      <span className="font-medium">Medication prescribed:</span>{' '}
+                      {(carePlan as { medicationPrescribed?: boolean }).medicationPrescribed
+                        ? 'Yes'
+                        : 'No'}
+                    </p>
+                    {(carePlan as { followUpDate?: string }).followUpDate && (
+                      <p>
+                        <span className="font-medium">Follow-up:</span>{' '}
+                        {new Date(
+                          (carePlan as { followUpDate: string }).followUpDate,
+                        ).toLocaleDateString()}
+                      </p>
+                    )}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </div>
         )}
       </div>
     </RouteGuard>

--- a/apps/web/app/ServiceWorkerAndSyncProvider.tsx
+++ b/apps/web/app/ServiceWorkerAndSyncProvider.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import { createContext, useCallback, useContext, useEffect, useState } from 'react';
-import { syncNow, onSyncStatusChange, type SyncStatus } from '@/lib/sync';
+import { syncNow, onSyncStatusChange, type SyncResult, type SyncStatus } from '@/lib/sync';
 
 interface SyncContextValue {
   isOnline: boolean;
   syncStatus: SyncStatus;
   syncError?: string;
-  syncNow: (clinicId: string) => Promise<void>;
+  syncNow: (clinicId: string) => Promise<SyncResult>;
 }
 
 const SyncContext = createContext<SyncContextValue | null>(null);
@@ -23,9 +23,11 @@ export function useSync() {
 export function ServiceWorkerAndSyncProvider({
   children,
   getAccessToken,
+  activeClinicId,
 }: {
   children: React.ReactNode;
   getAccessToken?: () => Promise<string | null>;
+  activeClinicId?: string | null;
 }) {
   const [isOnline, setIsOnline] = useState(
     typeof navigator !== 'undefined' ? navigator.onLine : true,
@@ -64,13 +66,18 @@ export function ServiceWorkerAndSyncProvider({
 
   const doSyncNow = useCallback(
     async (clinicId: string) => {
-      await syncNow({
+      return syncNow({
         clinicId,
         getAccessToken,
       });
     },
     [getAccessToken],
   );
+
+  useEffect(() => {
+    if (!isOnline || !activeClinicId) return;
+    void doSyncNow(activeClinicId);
+  }, [activeClinicId, doSyncNow, isOnline]);
 
   return (
     <SyncContext.Provider

--- a/apps/web/app/SyncWithAuth.tsx
+++ b/apps/web/app/SyncWithAuth.tsx
@@ -80,7 +80,10 @@ export function SyncWithAuth({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <ServiceWorkerAndSyncProvider getAccessToken={getToken}>
+    <ServiceWorkerAndSyncProvider
+      getAccessToken={getToken}
+      activeClinicId={bootstrapCtx?.activeClinicId}
+    >
       {isDisabledAccount ? (
         <FullscreenStatus
           eyebrow="Account status"

--- a/apps/web/components/VitalsForm.tsx
+++ b/apps/web/components/VitalsForm.tsx
@@ -31,6 +31,7 @@ import {
   type VitalsFormValues,
 } from '@/lib/clinical-measurements';
 import { cn } from '@/lib/utils';
+import { useSync } from '@/app/ServiceWorkerAndSyncProvider';
 
 const NONE_VALUE = '__NONE__';
 
@@ -324,7 +325,20 @@ export function VitalsForm({
   const [saving, setSaving] = useState(false);
   const [status, setStatus] = useState<string | null>(null);
   const [statusIsError, setStatusIsError] = useState(false);
+  const { isOnline, syncNow } = useSync();
   const bmi = useMemo(() => derivedBmi(vitals), [vitals]);
+
+  useEffect(() => {
+    if (!initialData || initialData.updatedAt === localVitals?.updatedAt) return;
+    setLocalVitals(initialData);
+    setVitals(initialVitals(initialData));
+  }, [initialData, localVitals?.updatedAt]);
+
+  useEffect(() => {
+    if (!initialTobaccoData || initialTobaccoData.updatedAt === localTobacco?.updatedAt) return;
+    setLocalTobacco(initialTobaccoData);
+    setTobacco(initialTobacco(initialTobaccoData));
+  }, [initialTobaccoData, localTobacco?.updatedAt]);
 
   const updateVital = (field: keyof VitalsFormValues, value: string) => {
     setVitals((current) => ({ ...current, [field]: value }));
@@ -367,17 +381,41 @@ export function VitalsForm({
         setErrors({});
         setLocalVitals(result.vitalsRecord ?? null);
         setLocalTobacco(result.tobaccoRecord ?? null);
-        setStatus(
-          markTobaccoReviewed
-            ? 'Review saved on this device and pending sync.'
-            : 'Measurements saved on this device and pending sync.',
-        );
+        if (isOnline) {
+          const syncResult = await syncNow(clinicId);
+          setStatus(
+            syncResult.success
+              ? markTobaccoReviewed
+                ? 'Tobacco screening reviewed and synced.'
+                : 'Measurements saved and synced.'
+              : markTobaccoReviewed
+                ? 'Review saved on this device and pending sync.'
+                : 'Measurements saved on this device and pending sync.',
+          );
+        } else {
+          setStatus(
+            markTobaccoReviewed
+              ? 'Review saved on this device and pending sync.'
+              : 'Measurements saved on this device and pending sync.',
+          );
+        }
         onSaved?.();
       } finally {
         setSaving(false);
       }
     },
-    [canEdit, clinicId, encounterId, localTobacco, localVitals, onSaved, tobacco, vitals],
+    [
+      canEdit,
+      clinicId,
+      encounterId,
+      isOnline,
+      localTobacco,
+      localVitals,
+      onSaved,
+      syncNow,
+      tobacco,
+      vitals,
+    ],
   );
 
   const handleButtonSave = async (markTobaccoReviewed: boolean) => {

--- a/apps/web/components/VitalsForm.tsx
+++ b/apps/web/components/VitalsForm.tsx
@@ -1,49 +1,305 @@
 'use client';
 
-import { useState, useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Activity, Cigarette, HeartPulse, Ruler, Thermometer } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
-import { db } from '@/lib/db';
-import { enqueueOutboxMutation } from '@/lib/outbox';
-import { SYNC_OPERATION } from '@/lib/outbox';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import type { TobaccoScreeningRecord, VitalsRecord } from '@/lib/db';
+import {
+  BP_SITES,
+  CUFF_SIZES,
+  derivedBmi,
+  generateClinicalId,
+  PATIENT_POSITIONS,
+  READINESS_OPTIONS,
+  saveClinicalMeasurementsOffline,
+  SCREENING_ANSWERS,
+  TEMPERATURE_SOURCES,
+  TOBACCO_USE_STATUSES,
+  type ClinicalFieldErrors,
+  type TobaccoFormValues,
+  type VitalsFormValues,
+} from '@/lib/clinical-measurements';
+import { cn } from '@/lib/utils';
 
-function generateId(): string {
-  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
-    return crypto.randomUUID();
-  }
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-    const r = (Math.random() * 16) | 0;
-    const v = c === 'x' ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
-  });
+const NONE_VALUE = '__NONE__';
+
+const LABELS: Record<string, string> = {
+  LEFT_ARM: 'Left arm',
+  RIGHT_ARM: 'Right arm',
+  LEFT_LEG: 'Left leg',
+  RIGHT_LEG: 'Right leg',
+  OTHER: 'Other',
+  SITTING: 'Sitting',
+  STANDING: 'Standing',
+  SUPINE: 'Supine',
+  INFANT: 'Infant',
+  CHILD: 'Child',
+  SMALL_ADULT: 'Small adult',
+  ADULT: 'Adult',
+  LARGE_ADULT: 'Large adult',
+  THIGH: 'Thigh',
+  ORAL: 'Oral',
+  AXILLARY: 'Axillary',
+  TYMPANIC: 'Tympanic',
+  TEMPORAL: 'Temporal',
+  RECTAL: 'Rectal',
+  NOT_ASSESSED: 'Not assessed',
+  NEVER: 'Never',
+  FORMER: 'Former',
+  CURRENT: 'Current',
+  NO: 'No',
+  YES: 'Yes',
+  NOT_READY: 'Not ready',
+  CONSIDERING: 'Considering quitting',
+  READY: 'Ready to quit',
+  NOT_APPLICABLE: 'Not applicable',
+};
+
+function displayValue(value?: string | number | null, suffix = '') {
+  return value == null || value === ''
+    ? 'Not recorded'
+    : `${LABELS[String(value)] ?? value}${suffix}`;
 }
 
-function computeBmi(weightKg?: number, heightCm?: number): number | null {
-  if (weightKg != null && weightKg > 0 && heightCm != null && heightCm > 0) {
-    const heightM = heightCm / 100;
-    return Math.round((weightKg / (heightM * heightM)) * 10) / 10;
-  }
-  return null;
+function initialVitals(data?: VitalsRecord | null): VitalsFormValues {
+  return {
+    systolicBp: String(data?.systolicBp ?? ''),
+    diastolicBp: String(data?.diastolicBp ?? ''),
+    bpSite: data?.bpSite ?? '',
+    bpSiteOther: data?.bpSiteOther ?? '',
+    patientPosition: data?.patientPosition ?? '',
+    patientPositionOther: data?.patientPositionOther ?? '',
+    cuffSize: data?.cuffSize ?? '',
+    cuffSizeOther: data?.cuffSizeOther ?? '',
+    pulseBpm: String(data?.pulseBpm ?? data?.heartRate ?? ''),
+    temperatureValue: String(data?.temperatureCelsius ?? ''),
+    temperatureUnit: 'CELSIUS',
+    temperatureSource: data?.temperatureSource ?? '',
+    temperatureSourceOther: data?.temperatureSourceOther ?? '',
+    respiratoryRate: String(data?.respiratoryRate ?? ''),
+    spo2Percent: String(data?.spo2Percent ?? ''),
+    weightKg: String(data?.weightKg ?? ''),
+    heightCm: String(data?.heightCm ?? ''),
+    notes: data?.notes ?? '',
+  };
+}
+
+function initialTobacco(data?: TobaccoScreeningRecord | null): TobaccoFormValues {
+  return {
+    smokingStatus: data?.smokingStatus ?? 'NOT_ASSESSED',
+    smokelessTobaccoStatus: data?.smokelessTobaccoStatus ?? 'NOT_ASSESSED',
+    passiveExposure: data?.passiveExposure ?? 'NOT_ASSESSED',
+    readinessToQuit: data?.readinessToQuit ?? 'NOT_ASSESSED',
+    counselingGiven: data?.counselingGiven ?? 'NOT_ASSESSED',
+  };
 }
 
 interface VitalsFormProps {
   clinicId: string;
   encounterId: string;
   recordedByUserId: string;
-  initialData?: {
-    systolicBp?: number | null;
-    diastolicBp?: number | null;
-    heartRate?: number | null;
-    weightKg?: number | null;
-    heightCm?: number | null;
-    bmi?: number | null;
-    notes?: string | null;
-  };
+  initialData?: VitalsRecord | null;
+  initialTobaccoData?: TobaccoScreeningRecord | null;
+  canEdit?: boolean;
   onSaved?: () => void;
-  /** Optional ref to expose save for parent-driven save (e.g. on tab change) */
   saveRef?: React.MutableRefObject<(() => Promise<void>) | null>;
+}
+
+function FieldError({ id, message }: { id: string; message?: string }) {
+  return message ? (
+    <p id={id} role="alert" className="text-sm text-destructive">
+      {message}
+    </p>
+  ) : null;
+}
+
+function SectionHeading({
+  icon: Icon,
+  title,
+  description,
+}: {
+  icon: typeof HeartPulse;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="flex items-start gap-3">
+      <div className="rounded-2xl bg-primary/10 p-2.5 text-primary">
+        <Icon className="h-5 w-5" aria-hidden="true" />
+      </div>
+      <div>
+        <h3 className="font-heading text-base font-semibold">{title}</h3>
+        <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+      </div>
+    </div>
+  );
+}
+
+function SelectField({
+  id,
+  label,
+  value,
+  options,
+  onChange,
+  error,
+  optional = false,
+  disabled = false,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  options: readonly string[];
+  onChange: (value: string) => void;
+  error?: string;
+  optional?: boolean;
+  disabled?: boolean;
+}) {
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={id}>{label}</Label>
+      <Select
+        value={value || NONE_VALUE}
+        onValueChange={(next) => onChange(next === NONE_VALUE ? '' : next)}
+        disabled={disabled}
+      >
+        <SelectTrigger
+          id={id}
+          className="h-11"
+          aria-invalid={Boolean(error)}
+          aria-describedby={error ? `${id}-error` : undefined}
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {optional ? <SelectItem value={NONE_VALUE}>Not recorded</SelectItem> : null}
+          {options.map((option) => (
+            <SelectItem key={option} value={option}>
+              {LABELS[option] ?? option}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <FieldError id={`${id}-error`} message={error} />
+    </div>
+  );
+}
+
+function ReadOnlyMeasurements({
+  vitals,
+  tobacco,
+}: {
+  vitals?: VitalsRecord | null;
+  tobacco?: TobaccoScreeningRecord | null;
+}) {
+  const groups = [
+    {
+      title: 'Blood Pressure',
+      icon: HeartPulse,
+      rows: [
+        [
+          'Reading',
+          vitals?.systolicBp != null && vitals.diastolicBp != null
+            ? `${vitals.systolicBp}/${vitals.diastolicBp} mmHg`
+            : 'Not recorded',
+        ],
+        ['Site', displayValue(vitals?.bpSiteOther || vitals?.bpSite)],
+        ['Position', displayValue(vitals?.patientPositionOther || vitals?.patientPosition)],
+        ['Cuff size', displayValue(vitals?.cuffSizeOther || vitals?.cuffSize)],
+      ],
+    },
+    {
+      title: 'Other Measurements',
+      icon: Thermometer,
+      rows: [
+        ['Pulse', displayValue(vitals?.pulseBpm ?? vitals?.heartRate, ' bpm')],
+        ['Temperature', displayValue(vitals?.temperatureCelsius, ' °C')],
+        [
+          'Temperature source',
+          displayValue(vitals?.temperatureSourceOther || vitals?.temperatureSource),
+        ],
+        ['Respiratory rate', displayValue(vitals?.respiratoryRate, '/min')],
+        ['SpO₂', displayValue(vitals?.spo2Percent, '%')],
+      ],
+    },
+    {
+      title: 'Anthropometrics',
+      icon: Ruler,
+      rows: [
+        ['Weight', displayValue(vitals?.weightKg, ' kg')],
+        ['Height', displayValue(vitals?.heightCm, ' cm')],
+        ['BMI', displayValue(vitals?.bmi)],
+      ],
+    },
+    {
+      title: 'Tobacco Use',
+      icon: Cigarette,
+      rows: [
+        ['Smoking', displayValue(tobacco?.smokingStatus)],
+        ['Smokeless tobacco', displayValue(tobacco?.smokelessTobaccoStatus)],
+        ['Passive exposure', displayValue(tobacco?.passiveExposure)],
+        ['Readiness to quit', displayValue(tobacco?.readinessToQuit)],
+        ['Counseling given', displayValue(tobacco?.counselingGiven)],
+        [
+          'Reviewed',
+          tobacco?.reviewedAt
+            ? `${new Date(tobacco.reviewedAt).toLocaleString()}`
+            : tobacco?.reviewPending
+              ? 'Pending sync'
+              : 'Not reviewed',
+        ],
+      ],
+    },
+  ];
+
+  return (
+    <Card className="rounded-[28px] border-border/80 bg-card/90 shadow-lg shadow-black/5">
+      <CardHeader>
+        <h2 className="font-heading text-xl font-semibold">Clinical measurements</h2>
+        <p className="text-sm text-muted-foreground">Recorded values are preserved as read-only.</p>
+      </CardHeader>
+      <CardContent className="grid gap-4 lg:grid-cols-2">
+        {groups.map(({ title, icon: Icon, rows }) => (
+          <section
+            key={title}
+            className="rounded-3xl border border-border/70 bg-background/60 p-4 sm:p-5"
+          >
+            <div className="mb-4 flex items-center gap-2">
+              <Icon className="h-5 w-5 text-primary" aria-hidden="true" />
+              <h3 className="font-semibold">{title}</h3>
+            </div>
+            <dl className="space-y-3">
+              {rows.map(([label, value]) => (
+                <div
+                  key={label}
+                  className="flex flex-wrap justify-between gap-2 border-b border-border/50 pb-2 last:border-0"
+                >
+                  <dt className="text-sm text-muted-foreground">{label}</dt>
+                  <dd className="text-right text-sm font-medium">{value}</dd>
+                </div>
+              ))}
+            </dl>
+          </section>
+        ))}
+        {vitals?.notes ? (
+          <section className="rounded-3xl border border-border/70 bg-background/60 p-4 sm:p-5 lg:col-span-2">
+            <h3 className="font-semibold">Notes</h3>
+            <p className="mt-2 whitespace-pre-wrap text-sm text-muted-foreground">{vitals.notes}</p>
+          </section>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
 }
 
 export function VitalsForm({
@@ -51,169 +307,415 @@ export function VitalsForm({
   encounterId,
   recordedByUserId: _recordedByUserId,
   initialData,
+  initialTobaccoData,
+  canEdit = true,
   onSaved,
   saveRef,
 }: VitalsFormProps) {
-  const [systolicBp, setSystolicBp] = useState<string>(String(initialData?.systolicBp ?? ''));
-  const [diastolicBp, setDiastolicBp] = useState<string>(String(initialData?.diastolicBp ?? ''));
-  const [heartRate, setHeartRate] = useState<string>(String(initialData?.heartRate ?? ''));
-  const [weightKg, setWeightKg] = useState<string>(String(initialData?.weightKg ?? ''));
-  const [heightCm, setHeightCm] = useState<string>(String(initialData?.heightCm ?? ''));
-  const [notes, setNotes] = useState<string>(initialData?.notes ?? '');
+  const vitalsId = useRef(initialData?.id ?? generateClinicalId());
+  const tobaccoScreeningId = useRef(initialTobaccoData?.id ?? generateClinicalId());
+  const [vitals, setVitals] = useState(() => initialVitals(initialData));
+  const [tobacco, setTobacco] = useState(() => initialTobacco(initialTobaccoData));
+  const [localVitals, setLocalVitals] = useState<VitalsRecord | null>(initialData ?? null);
+  const [localTobacco, setLocalTobacco] = useState<TobaccoScreeningRecord | null>(
+    initialTobaccoData ?? null,
+  );
+  const [errors, setErrors] = useState<ClinicalFieldErrors>({});
   const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  const [statusIsError, setStatusIsError] = useState(false);
+  const bmi = useMemo(() => derivedBmi(vitals), [vitals]);
 
-  const weightNum = weightKg ? parseFloat(weightKg) : undefined;
-  const heightNum = heightCm ? parseFloat(heightCm) : undefined;
-  const bmi = computeBmi(weightNum, heightNum);
+  const updateVital = (field: keyof VitalsFormValues, value: string) => {
+    setVitals((current) => ({ ...current, [field]: value }));
+    setErrors((current) => {
+      const next = { ...current };
+      delete next[field];
+      return next;
+    });
+    setStatus(null);
+    setStatusIsError(false);
+  };
+  const updateTobacco = (field: keyof TobaccoFormValues, value: string) => {
+    setTobacco((current) => ({ ...current, [field]: value }));
+    setStatus(null);
+    setStatusIsError(false);
+  };
 
-  const handleSave = useCallback(async () => {
-    setSaving(true);
-    setError(null);
-    const vitalsId = generateId();
-    const now = new Date().toISOString();
+  const handleSave = useCallback(
+    async (markTobaccoReviewed = false) => {
+      if (!canEdit) return;
+      setSaving(true);
+      setStatus(null);
+      setStatusIsError(false);
+      try {
+        const result = await saveClinicalMeasurementsOffline({
+          clinicId,
+          encounterId,
+          vitalsId: vitalsId.current,
+          tobaccoScreeningId: tobaccoScreeningId.current,
+          vitals,
+          tobacco,
+          markTobaccoReviewed,
+          existingVitals: localVitals,
+          existingTobacco: localTobacco,
+        });
+        if (Object.keys(result.errors).length) {
+          setErrors(result.errors);
+          throw new Error('Review the highlighted clinical measurement fields.');
+        }
+        setErrors({});
+        setLocalVitals(result.vitalsRecord ?? null);
+        setLocalTobacco(result.tobaccoRecord ?? null);
+        setStatus(
+          markTobaccoReviewed
+            ? 'Review saved on this device and pending sync.'
+            : 'Measurements saved on this device and pending sync.',
+        );
+        onSaved?.();
+      } finally {
+        setSaving(false);
+      }
+    },
+    [canEdit, clinicId, encounterId, localTobacco, localVitals, onSaved, tobacco, vitals],
+  );
 
-    const payload = {
-      encounterId,
-      clinicId,
-      systolicBp: systolicBp ? parseInt(systolicBp, 10) : null,
-      diastolicBp: diastolicBp ? parseInt(diastolicBp, 10) : null,
-      heartRate: heartRate ? parseInt(heartRate, 10) : null,
-      weightKg: weightNum ?? null,
-      heightCm: heightNum ?? null,
-      bmi: bmi ?? null,
-      notes: notes.trim() || null,
-    };
-
-    const record = {
-      id: vitalsId,
-      clinicId,
-      encounterId,
-      systolicBp: payload.systolicBp ?? undefined,
-      diastolicBp: payload.diastolicBp ?? undefined,
-      heartRate: payload.heartRate ?? undefined,
-      weightKg: payload.weightKg ?? undefined,
-      heightCm: payload.heightCm ?? undefined,
-      bmi: payload.bmi ?? undefined,
-      notes: payload.notes ?? undefined,
-      createdAt: now,
-      updatedAt: now,
-    };
-
+  const handleButtonSave = async (markTobaccoReviewed: boolean) => {
     try {
-      await db.vitals.put(record);
-      await enqueueOutboxMutation(db, {
-        clinicId,
-        entityType: 'vitals',
-        entityId: vitalsId,
-        operation: SYNC_OPERATION.UPSERT,
-        payloadJson: payload,
-      });
-      onSaved?.();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to save vitals');
-    } finally {
-      setSaving(false);
+      await handleSave(markTobaccoReviewed);
+    } catch (error) {
+      setStatusIsError(true);
+      setStatus(error instanceof Error ? error.message : 'Unable to save measurements.');
     }
-  }, [
-    clinicId,
-    encounterId,
-    systolicBp,
-    diastolicBp,
-    heartRate,
-    heightNum,
-    notes,
-    weightNum,
-    bmi,
-    onSaved,
-  ]);
+  };
 
   useEffect(() => {
-    if (saveRef) saveRef.current = handleSave;
+    if (!saveRef) return;
+    saveRef.current = canEdit ? () => handleSave(false) : null;
     return () => {
-      if (saveRef) saveRef.current = null;
+      saveRef.current = null;
     };
-  }, [saveRef, handleSave]);
+  }, [canEdit, handleSave, saveRef]);
+
+  if (!canEdit) return <ReadOnlyMeasurements vitals={initialData} tobacco={initialTobaccoData} />;
+
+  const numberField = (
+    id: keyof VitalsFormValues,
+    label: string,
+    options?: { step?: string; placeholder?: string },
+  ) => (
+    <div className="space-y-2">
+      <Label htmlFor={id}>{label}</Label>
+      <Input
+        id={id}
+        type="number"
+        inputMode="decimal"
+        step={options?.step}
+        placeholder={options?.placeholder}
+        value={vitals[id]}
+        onChange={(event) => updateVital(id, event.target.value)}
+        className="h-11"
+        aria-invalid={Boolean(errors[id])}
+        aria-describedby={errors[id] ? `${id}-error` : undefined}
+      />
+      <FieldError id={`${id}-error`} message={errors[id]} />
+    </div>
+  );
 
   return (
-    <Card>
-      <CardHeader>
-        <h2 className="text-lg font-semibold">Vitals</h2>
+    <Card className="rounded-[28px] border-border/80 bg-card/90 shadow-lg shadow-black/5">
+      <CardHeader className="space-y-2">
+        <h2 className="font-heading text-xl font-semibold">Vitals and tobacco screening</h2>
+        <p className="max-w-3xl text-sm text-muted-foreground">
+          Units are explicit, BMI is calculated from kilograms and centimeters, and every save is
+          available offline.
+        </p>
       </CardHeader>
-      <CardContent className="space-y-4">
-        <div className="grid gap-4 sm:grid-cols-2">
-          <div className="space-y-2">
-            <Label htmlFor="systolicBp">Systolic BP (mmHg)</Label>
-            <Input
-              id="systolicBp"
-              type="number"
-              value={systolicBp}
-              onChange={(e) => setSystolicBp(e.target.value)}
-              placeholder="120"
+      <CardContent className="space-y-5">
+        <section className="space-y-5 rounded-3xl border border-border/70 bg-background/60 p-4 sm:p-6">
+          <SectionHeading
+            icon={HeartPulse}
+            title="Blood Pressure"
+            description="Record the reading and measurement context together."
+          />
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            {numberField('systolicBp', 'Systolic BP (mmHg)', { placeholder: '120' })}
+            {numberField('diastolicBp', 'Diastolic BP (mmHg)', { placeholder: '80' })}
+            <SelectField
+              id="bpSite"
+              label="Measurement site"
+              value={vitals.bpSite}
+              options={BP_SITES}
+              onChange={(value) => updateVital('bpSite', value)}
+              error={errors.bpSite}
+              optional
             />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="diastolicBp">Diastolic BP (mmHg)</Label>
-            <Input
-              id="diastolicBp"
-              type="number"
-              value={diastolicBp}
-              onChange={(e) => setDiastolicBp(e.target.value)}
-              placeholder="80"
+            {vitals.bpSite === 'OTHER' ? (
+              <div className="space-y-2">
+                <Label htmlFor="bpSiteOther">Other site</Label>
+                <Input
+                  id="bpSiteOther"
+                  value={vitals.bpSiteOther}
+                  onChange={(event) => updateVital('bpSiteOther', event.target.value)}
+                  className="h-11"
+                  aria-invalid={Boolean(errors.bpSiteOther)}
+                />
+                <FieldError id="bpSiteOther-error" message={errors.bpSiteOther} />
+              </div>
+            ) : null}
+            <SelectField
+              id="patientPosition"
+              label="Patient position"
+              value={vitals.patientPosition}
+              options={PATIENT_POSITIONS}
+              onChange={(value) => updateVital('patientPosition', value)}
+              error={errors.patientPosition}
+              optional
             />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="heartRate">Heart Rate (bpm)</Label>
-            <Input
-              id="heartRate"
-              type="number"
-              value={heartRate}
-              onChange={(e) => setHeartRate(e.target.value)}
-              placeholder="72"
+            {vitals.patientPosition === 'OTHER' ? (
+              <div className="space-y-2">
+                <Label htmlFor="patientPositionOther">Other position</Label>
+                <Input
+                  id="patientPositionOther"
+                  value={vitals.patientPositionOther}
+                  onChange={(event) => updateVital('patientPositionOther', event.target.value)}
+                  className="h-11"
+                  aria-invalid={Boolean(errors.patientPositionOther)}
+                />
+                <FieldError id="patientPositionOther-error" message={errors.patientPositionOther} />
+              </div>
+            ) : null}
+            <SelectField
+              id="cuffSize"
+              label="Cuff size"
+              value={vitals.cuffSize}
+              options={CUFF_SIZES}
+              onChange={(value) => updateVital('cuffSize', value)}
+              error={errors.cuffSize}
+              optional
             />
+            {vitals.cuffSize === 'OTHER' ? (
+              <div className="space-y-2">
+                <Label htmlFor="cuffSizeOther">Other cuff size</Label>
+                <Input
+                  id="cuffSizeOther"
+                  value={vitals.cuffSizeOther}
+                  onChange={(event) => updateVital('cuffSizeOther', event.target.value)}
+                  className="h-11"
+                  aria-invalid={Boolean(errors.cuffSizeOther)}
+                />
+                <FieldError id="cuffSizeOther-error" message={errors.cuffSizeOther} />
+              </div>
+            ) : null}
           </div>
-          <div className="space-y-2">
-            <Label htmlFor="weightKg">Weight (kg)</Label>
-            <Input
-              id="weightKg"
-              type="number"
-              step="0.1"
-              value={weightKg}
-              onChange={(e) => setWeightKg(e.target.value)}
-              placeholder="70"
+        </section>
+
+        <section className="space-y-5 rounded-3xl border border-border/70 bg-background/60 p-4 sm:p-6">
+          <SectionHeading
+            icon={Thermometer}
+            title="Other Measurements"
+            description="Capture pulse, breathing, oxygen saturation, and temperature."
+          />
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            {numberField('pulseBpm', 'Pulse (bpm)', { placeholder: '72' })}
+            {numberField('respiratoryRate', 'Respiratory rate (/min)', { placeholder: '16' })}
+            {numberField('spo2Percent', 'SpO₂ (%)', { placeholder: '98' })}
+            <div className="space-y-2">
+              <Label htmlFor="temperatureValue">
+                Temperature ({vitals.temperatureUnit === 'CELSIUS' ? '°C' : '°F'})
+              </Label>
+              <div className="flex gap-2">
+                <Input
+                  id="temperatureValue"
+                  type="number"
+                  inputMode="decimal"
+                  step="0.1"
+                  value={vitals.temperatureValue}
+                  onChange={(event) => updateVital('temperatureValue', event.target.value)}
+                  className="h-11 min-w-0"
+                  aria-invalid={Boolean(errors.temperatureValue)}
+                  aria-describedby={errors.temperatureValue ? 'temperatureValue-error' : undefined}
+                />
+                <Select
+                  value={vitals.temperatureUnit}
+                  onValueChange={(value: 'CELSIUS' | 'FAHRENHEIT') =>
+                    setVitals((current) => ({ ...current, temperatureUnit: value }))
+                  }
+                >
+                  <SelectTrigger aria-label="Temperature unit" className="h-11 w-24">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="CELSIUS">°C</SelectItem>
+                    <SelectItem value="FAHRENHEIT">°F</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <FieldError id="temperatureValue-error" message={errors.temperatureValue} />
+            </div>
+            <SelectField
+              id="temperatureSource"
+              label="Temperature source"
+              value={vitals.temperatureSource}
+              options={TEMPERATURE_SOURCES}
+              onChange={(value) => updateVital('temperatureSource', value)}
+              error={errors.temperatureSource}
+              optional
             />
+            {vitals.temperatureSource === 'OTHER' ? (
+              <div className="space-y-2">
+                <Label htmlFor="temperatureSourceOther">Other temperature source</Label>
+                <Input
+                  id="temperatureSourceOther"
+                  value={vitals.temperatureSourceOther}
+                  onChange={(event) => updateVital('temperatureSourceOther', event.target.value)}
+                  className="h-11"
+                  aria-invalid={Boolean(errors.temperatureSourceOther)}
+                />
+                <FieldError
+                  id="temperatureSourceOther-error"
+                  message={errors.temperatureSourceOther}
+                />
+              </div>
+            ) : null}
           </div>
-          <div className="space-y-2">
-            <Label htmlFor="heightCm">Height (cm)</Label>
-            <Input
-              id="heightCm"
-              type="number"
-              step="0.1"
-              value={heightCm}
-              onChange={(e) => setHeightCm(e.target.value)}
-              placeholder="170"
-            />
-          </div>
-          <div className="space-y-2">
-            <Label>BMI</Label>
-            <div className="flex h-9 items-center rounded-md border px-3 py-2 text-sm">
-              {bmi != null ? bmi : '—'}
+        </section>
+
+        <section className="space-y-5 rounded-3xl border border-border/70 bg-background/60 p-4 sm:p-6">
+          <SectionHeading
+            icon={Ruler}
+            title="Anthropometrics"
+            description="BMI is derived from canonical weight and height."
+          />
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            {numberField('weightKg', 'Weight (kg)', { step: '0.1', placeholder: '70' })}
+            {numberField('heightCm', 'Height (cm)', { step: '0.1', placeholder: '170' })}
+            <div className="space-y-2">
+              <Label>BMI (kg/m²)</Label>
+              <div
+                className="flex h-11 items-center rounded-md border bg-muted/40 px-3 text-sm font-medium"
+                aria-live="polite"
+              >
+                {bmi ?? 'Calculated after weight and height'}
+              </div>
             </div>
           </div>
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="notes">Notes</Label>
-          <Input
-            id="notes"
-            value={notes}
-            onChange={(e) => setNotes(e.target.value)}
-            placeholder="Optional notes"
+        </section>
+
+        <section className="space-y-5 rounded-3xl border border-border/70 bg-background/60 p-4 sm:p-6">
+          <SectionHeading
+            icon={Cigarette}
+            title="Tobacco Use"
+            description="Not assessed remains distinct from a negative response."
           />
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            <SelectField
+              id="smokingStatus"
+              label="Smoking status"
+              value={tobacco.smokingStatus}
+              options={TOBACCO_USE_STATUSES}
+              onChange={(value) => updateTobacco('smokingStatus', value)}
+            />
+            <SelectField
+              id="smokelessTobaccoStatus"
+              label="Smokeless tobacco"
+              value={tobacco.smokelessTobaccoStatus}
+              options={TOBACCO_USE_STATUSES}
+              onChange={(value) => updateTobacco('smokelessTobaccoStatus', value)}
+            />
+            <SelectField
+              id="passiveExposure"
+              label="Passive exposure"
+              value={tobacco.passiveExposure}
+              options={SCREENING_ANSWERS}
+              onChange={(value) => updateTobacco('passiveExposure', value)}
+            />
+            <SelectField
+              id="readinessToQuit"
+              label="Readiness to quit"
+              value={tobacco.readinessToQuit}
+              options={READINESS_OPTIONS}
+              onChange={(value) => updateTobacco('readinessToQuit', value)}
+            />
+            <SelectField
+              id="counselingGiven"
+              label="Counseling given"
+              value={tobacco.counselingGiven}
+              options={SCREENING_ANSWERS}
+              onChange={(value) => updateTobacco('counselingGiven', value)}
+            />
+          </div>
+          <div
+            className={cn(
+              'rounded-2xl border p-4 text-sm',
+              localTobacco?.reviewedAt
+                ? 'border-primary/30 bg-primary/5'
+                : 'border-border/70 bg-muted/30',
+            )}
+          >
+            {localTobacco?.reviewPending
+              ? 'Tobacco review is pending sync.'
+              : localTobacco?.reviewedAt
+                ? `Reviewed ${new Date(localTobacco.reviewedAt).toLocaleString()}.`
+                : 'This tobacco screening has not been explicitly reviewed.'}
+          </div>
+        </section>
+
+        <section className="space-y-2 rounded-3xl border border-border/70 bg-background/60 p-4 sm:p-6">
+          <div className="flex items-center gap-2">
+            <Activity className="h-5 w-5 text-primary" aria-hidden="true" />
+            <Label htmlFor="notes" className="text-base font-semibold">
+              Notes
+            </Label>
+          </div>
+          <Textarea
+            id="notes"
+            value={vitals.notes}
+            onChange={(event) => updateVital('notes', event.target.value)}
+            maxLength={2000}
+            rows={4}
+            aria-invalid={Boolean(errors.notes)}
+            aria-describedby={errors.notes ? 'notes-error' : 'notes-help'}
+          />
+          <div id="notes-help" className="flex justify-between text-xs text-muted-foreground">
+            <span>Optional clinical context. No automated diagnosis is generated.</span>
+            <span>{vitals.notes.length}/2000</span>
+          </div>
+          <FieldError id="notes-error" message={errors.notes} />
+        </section>
+
+        {status ? (
+          <p
+            role={statusIsError ? 'alert' : 'status'}
+            className={cn(
+              'rounded-2xl border p-3 text-sm',
+              statusIsError
+                ? 'border-destructive/30 bg-destructive/5 text-destructive'
+                : 'border-primary/25 bg-primary/5 text-foreground',
+            )}
+          >
+            {status}
+          </p>
+        ) : null}
+        <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+          <Button
+            type="button"
+            variant="outline"
+            className="h-11 rounded-2xl"
+            onClick={() => void handleButtonSave(true)}
+            disabled={saving}
+          >
+            Mark tobacco reviewed
+          </Button>
+          <Button
+            type="button"
+            className="h-11 rounded-2xl"
+            onClick={() => void handleButtonSave(false)}
+            disabled={saving}
+          >
+            {saving ? 'Saving…' : 'Save measurements'}
+          </Button>
         </div>
-        {error && <p className="text-sm text-destructive">{error}</p>}
-        <Button onClick={handleSave} disabled={saving}>
-          {saving ? 'Saving…' : 'Save Vitals'}
-        </Button>
       </CardContent>
     </Card>
   );

--- a/apps/web/components/dashboard/ClinicalMeasurementsDashboard.tsx
+++ b/apps/web/components/dashboard/ClinicalMeasurementsDashboard.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { Activity, Cigarette, ClipboardCheck, Ruler, Thermometer, Wind } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { DistributionChart } from './DistributionChart';
+import { DashboardSectionHeader } from './DashboardSectionHeader';
+
+export interface MeasurementAggregate {
+  count: number;
+  average: number | null;
+}
+
+export interface ClinicalMeasurementMetrics {
+  windowDays: 30;
+  sampleSize: number;
+  vitalsCaptureRate: number;
+  tobaccoAssessmentRate: number;
+  counselingDocumentationRate: number;
+  pendingTobaccoReviews: number;
+  measurements: {
+    temperatureCelsius: MeasurementAggregate;
+    respiratoryRate: MeasurementAggregate;
+    spo2Percent: MeasurementAggregate;
+    bmi: MeasurementAggregate;
+  };
+  tobaccoStatusDistribution: Record<string, number>;
+}
+
+const LABELS: Record<string, string> = {
+  NOT_ASSESSED: 'Not assessed',
+  NEVER: 'Never',
+  FORMER: 'Former',
+  CURRENT: 'Current',
+};
+
+export function ClinicalMeasurementsDashboard({
+  metrics,
+}: {
+  metrics: ClinicalMeasurementMetrics;
+}) {
+  const workflowCards = [
+    { label: 'Vitals captured', value: `${metrics.vitalsCaptureRate}%`, icon: ClipboardCheck },
+    { label: 'Tobacco assessed', value: `${metrics.tobaccoAssessmentRate}%`, icon: Cigarette },
+    {
+      label: 'Counseling documented',
+      value: `${metrics.counselingDocumentationRate}%`,
+      icon: Activity,
+    },
+    {
+      label: 'Pending tobacco reviews',
+      value: metrics.pendingTobaccoReviews,
+      icon: ClipboardCheck,
+    },
+  ];
+  const measurementCards = [
+    {
+      label: 'Temperature',
+      aggregate: metrics.measurements.temperatureCelsius,
+      suffix: ' °C',
+      icon: Thermometer,
+    },
+    {
+      label: 'Respiratory rate',
+      aggregate: metrics.measurements.respiratoryRate,
+      suffix: '/min',
+      icon: Wind,
+    },
+    {
+      label: 'SpO₂',
+      aggregate: metrics.measurements.spo2Percent,
+      suffix: '%',
+      icon: Activity,
+    },
+    { label: 'BMI', aggregate: metrics.measurements.bmi, suffix: '', icon: Ruler },
+  ];
+  const tobaccoDistribution = Object.fromEntries(
+    Object.entries(metrics.tobaccoStatusDistribution).map(([key, value]) => [
+      LABELS[key] ?? key,
+      value,
+    ]),
+  );
+
+  return (
+    <section className="space-y-5">
+      <DashboardSectionHeader
+        title="Clinical measurement coverage"
+        hint={`Descriptive clinic metrics from ${metrics.sampleSize} encounters in the last ${metrics.windowDays} days. These summaries do not provide diagnosis.`}
+      />
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        {workflowCards.map(({ label, value, icon: Icon }) => (
+          <Card key={label} className="border-border/70 bg-card/95">
+            <CardHeader className="flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">{label}</CardTitle>
+              <Icon className="h-4 w-4 text-primary" aria-hidden="true" />
+            </CardHeader>
+            <CardContent>
+              <p className="text-2xl font-semibold">{value}</p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        {measurementCards.map(({ label, aggregate, suffix, icon: Icon }) => (
+          <Card key={label} className="border-border/70 bg-card/95">
+            <CardHeader className="flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Average {label.toLowerCase()}</CardTitle>
+              <Icon className="h-4 w-4 text-primary" aria-hidden="true" />
+            </CardHeader>
+            <CardContent>
+              <p className="text-2xl font-semibold">
+                {aggregate.average == null ? 'No data' : `${aggregate.average}${suffix}`}
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">{aggregate.count} readings</p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+      <DistributionChart
+        title="Smoking status documentation"
+        data={tobaccoDistribution}
+        type="bar"
+        hint="Recorded smoking status counts for the same 30-day clinic window."
+        emptyMessage="No tobacco screening statuses were recorded in this timeframe."
+      />
+    </section>
+  );
+}

--- a/apps/web/components/patients/PatientTrendsPanel.tsx
+++ b/apps/web/components/patients/PatientTrendsPanel.tsx
@@ -1,14 +1,25 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Activity, CalendarClock, HeartPulse, Syringe } from 'lucide-react';
+import {
+  Activity,
+  CalendarClock,
+  HeartPulse,
+  Scale,
+  Syringe,
+  Thermometer,
+  Wind,
+} from 'lucide-react';
 import { useAuth } from '@/lib/auth-context';
 import { fetchStaffPatientTrends, type PatientTrendsResponse } from '@/lib/patient-portal';
 import {
   TREND_RANGE_OPTIONS,
   buildBloodPressureTrendData,
+  buildExpandedVitalsTrendData,
   buildGlucoseTrendData,
   formatTrendRangeFrom,
+  getLatestExpandedVital,
+  type ExpandedMeasurementKey,
   type TrendRangeDays,
 } from '@/lib/patient-trends';
 import { MeasurementTrendChart } from '@/components/portal/MeasurementTrendChart';
@@ -27,6 +38,19 @@ const FOLLOW_UP_LABELS: Array<{
   { key: 'closed', label: 'Closed' },
 ];
 
+const EXPANDED_MEASUREMENTS: Array<{
+  key: ExpandedMeasurementKey;
+  label: string;
+  suffix: string;
+  icon: typeof Thermometer;
+}> = [
+  { key: 'temperatureCelsius', label: 'Temperature', suffix: ' °C', icon: Thermometer },
+  { key: 'respiratoryRate', label: 'Respiratory rate', suffix: '/min', icon: Wind },
+  { key: 'spo2Percent', label: 'SpO₂', suffix: '%', icon: Activity },
+  { key: 'weightKg', label: 'Weight', suffix: ' kg', icon: Scale },
+  { key: 'bmi', label: 'BMI', suffix: '', icon: HeartPulse },
+];
+
 interface PatientTrendsPanelProps {
   patientId: string;
   clinicId: string;
@@ -38,6 +62,8 @@ export function PatientTrendsPanel({ patientId, clinicId }: PatientTrendsPanelPr
   const [trends, setTrends] = useState<PatientTrendsResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [selectedMeasurement, setSelectedMeasurement] =
+    useState<ExpandedMeasurementKey>('spo2Percent');
 
   useEffect(() => {
     let cancelled = false;
@@ -75,6 +101,11 @@ export function PatientTrendsPanel({ patientId, clinicId }: PatientTrendsPanelPr
 
   const bpTrend = buildBloodPressureTrendData(trends?.bp ?? []);
   const glucoseTrend = buildGlucoseTrendData(trends?.glucose ?? []);
+  const expandedMeasurements = trends?.measurements ?? [];
+  const selectedConfig =
+    EXPANDED_MEASUREMENTS.find((item) => item.key === selectedMeasurement) ??
+    EXPANDED_MEASUREMENTS[0];
+  const selectedTrend = buildExpandedVitalsTrendData(expandedMeasurements, selectedMeasurement);
   const followUp = trends?.followUp ?? {
     requested: 0,
     confirmed: 0,
@@ -181,6 +212,45 @@ export function PatientTrendsPanel({ patientId, clinicId }: PatientTrendsPanelPr
               </CardHeader>
             </Card>
           </div>
+
+          <section className="space-y-4">
+            <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+              {EXPANDED_MEASUREMENTS.map(({ key, label, suffix, icon: Icon }) => {
+                const latest = getLatestExpandedVital(expandedMeasurements, key);
+                return (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => setSelectedMeasurement(key)}
+                    className={`min-h-24 cursor-pointer rounded-2xl border p-4 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+                      selectedMeasurement === key
+                        ? 'border-primary/40 bg-primary/10'
+                        : 'border-border/70 bg-card/95 hover:bg-muted/40'
+                    }`}
+                    aria-pressed={selectedMeasurement === key}
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                        {label}
+                      </span>
+                      <Icon className="h-4 w-4 text-primary" aria-hidden="true" />
+                    </div>
+                    <p className="mt-3 text-xl font-semibold">
+                      {latest == null ? 'No data' : `${latest}${suffix}`}
+                    </p>
+                  </button>
+                );
+              })}
+            </div>
+            <MeasurementTrendChart
+              title={`${selectedConfig.label} trend`}
+              description="Encounter measurements recorded by clinic staff across the selected range."
+              emptyMessage={`No ${selectedConfig.label.toLowerCase()} readings were recorded in this timeframe.`}
+              valueSuffix={selectedConfig.suffix}
+              lines={[{ key: 'value', label: selectedConfig.label, color: 'hsl(var(--chart-3))' }]}
+              data={selectedTrend}
+            />
+          </section>
 
           <section className="grid gap-4 lg:grid-cols-2">
             <div className="lg:col-span-2">

--- a/apps/web/e2e/vitals.spec.js
+++ b/apps/web/e2e/vitals.spec.js
@@ -1,0 +1,146 @@
+const path = require('path');
+const { randomUUID } = require('crypto');
+const { test, expect } = require('@playwright/test');
+
+const authFile = path.join(__dirname, '..', 'playwright', '.auth', 'staff.json');
+
+test.use({ storageState: authFile });
+
+async function createPatient(page) {
+  const suffix = randomUUID().replaceAll('-', '').slice(0, 12);
+  await page.goto('/patients/new');
+  await page.getByLabel('First name *').fill('Vitals');
+  await page.getByLabel('Last name *').fill(`E2E-${suffix}`);
+  await page.getByLabel('National ID *').fill(`E2E-VITALS-${suffix}`);
+  await page.getByRole('button', { name: 'Create patient' }).click();
+  await page.waitForURL(/\/clinics\/[^/]+\/patients\/[^/]+$/, { timeout: 20_000 });
+  return page.url().split('/').at(-1);
+}
+
+async function createEncounter(page, patientId) {
+  const responsePromise = page.waitForResponse(
+    (response) =>
+      response.request().method() === 'POST' &&
+      /\/clinics\/[^/]+\/encounters$/.test(new URL(response.url()).pathname),
+  );
+  await page.goto(`/patients/${patientId}/encounters/new`);
+  const response = await responsePromise;
+  expect(response.ok()).toBeTruthy();
+  const encounter = await response.json();
+  await expect(page.getByRole('button', { name: 'Continue to Vitals' })).toBeVisible();
+  await page.getByRole('button', { name: 'Continue to Vitals' }).click();
+  return encounter.id;
+}
+
+async function chooseOption(page, label, option) {
+  await page.getByLabel(label, { exact: true }).click();
+  await page.getByRole('option', { name: option, exact: true }).click();
+}
+
+async function fillMeasurements(page) {
+  await page.getByLabel('Systolic BP (mmHg)').fill('120');
+  await page.getByLabel('Diastolic BP (mmHg)').fill('80');
+  await chooseOption(page, 'Measurement site', 'Left arm');
+  await chooseOption(page, 'Patient position', 'Sitting');
+  await chooseOption(page, 'Cuff size', 'Adult');
+  await page.getByLabel('Pulse (bpm)').fill('72');
+  await page.getByLabel('Respiratory rate (/min)').fill('16');
+  await page.getByLabel('SpO₂ (%)').fill('98');
+  await page.getByLabel('Temperature (°C)').fill('37');
+  await chooseOption(page, 'Temperature source', 'Oral');
+  await page.getByLabel('Weight (kg)').fill('70');
+  await page.getByLabel('Height (cm)').fill('170');
+  await chooseOption(page, 'Smoking status', 'Never');
+  await chooseOption(page, 'Smokeless tobacco', 'Not assessed');
+  await chooseOption(page, 'Passive exposure', 'No');
+  await chooseOption(page, 'Readiness to quit', 'Not applicable');
+  await chooseOption(page, 'Counseling given', 'No');
+}
+
+test('expanded vitals save, replay offline, review, finalize, and stay responsive', async ({
+  page,
+  context,
+}) => {
+  const patientId = await createPatient(page);
+  const encounterId = await createEncounter(page, patientId);
+
+  await page.getByLabel('Systolic BP (mmHg)').fill('120');
+  await page.getByRole('button', { name: 'Save measurements' }).click();
+  await expect(
+    page.getByText('Enter systolic and diastolic blood pressure together.').first(),
+  ).toBeVisible();
+
+  await fillMeasurements(page);
+  await expect(page.getByText('24.2', { exact: true })).toBeVisible();
+  const onlinePush = page.waitForResponse(
+    (response) =>
+      response.request().method() === 'POST' && new URL(response.url()).pathname === '/sync/push',
+  );
+  await page.getByRole('button', { name: 'Save measurements' }).click();
+  expect((await onlinePush).ok()).toBeTruthy();
+
+  await page.goto(`/encounters/${encounterId}`);
+  await expect(page.getByLabel('Pulse (bpm)')).toHaveValue('72');
+  await expect(page.getByText('24.2', { exact: true })).toBeVisible();
+
+  await context.setOffline(true);
+  await page.getByLabel('Pulse (bpm)').fill('80');
+  await chooseOption(page, 'Smoking status', 'Current');
+  await page.getByRole('button', { name: 'Save measurements' }).click();
+  await expect(page.getByText('Measurements saved on this device and pending sync.')).toBeVisible();
+
+  const queuedBundles = await page.evaluate(
+    () =>
+      new Promise((resolve, reject) => {
+        const request = indexedDB.open('NkwapaDb');
+        request.onerror = () => reject(request.error);
+        request.onsuccess = () => {
+          const transaction = request.result.transaction('outbox', 'readonly');
+          const count = transaction.objectStore('outbox').count();
+          count.onerror = () => reject(count.error);
+          count.onsuccess = () => resolve(count.result);
+        };
+      }),
+  );
+  expect(queuedBundles).toBeGreaterThan(0);
+
+  const reconnectPush = page.waitForResponse(
+    (response) =>
+      response.request().method() === 'POST' && new URL(response.url()).pathname === '/sync/push',
+  );
+  await context.setOffline(false);
+  expect((await reconnectPush).ok()).toBeTruthy();
+  await page.reload();
+  await expect(page.getByLabel('Pulse (bpm)')).toHaveValue('80');
+
+  const reviewPush = page.waitForResponse(
+    (response) =>
+      response.request().method() === 'POST' && new URL(response.url()).pathname === '/sync/push',
+  );
+  await page.getByRole('button', { name: 'Mark tobacco reviewed' }).click();
+  expect((await reviewPush).ok()).toBeTruthy();
+  await expect(page.getByText(/Reviewed \d/)).toBeVisible();
+
+  await page.getByLabel('Systolic BP (mmHg)').focus();
+  await page.keyboard.press('Tab');
+  await expect(page.getByLabel('Diastolic BP (mmHg)')).toBeFocused();
+
+  for (const viewport of [
+    { width: 375, height: 812 },
+    { width: 768, height: 1024 },
+    { width: 1024, height: 768 },
+    { width: 1440, height: 900 },
+  ]) {
+    await page.setViewportSize(viewport);
+    expect(
+      await page.evaluate(() => document.documentElement.scrollWidth > window.innerWidth + 1),
+    ).toBeFalsy();
+  }
+
+  await page.getByRole('button', { name: 'Submit for Review' }).click();
+  await page.getByRole('button', { name: 'Mark Reviewed' }).click();
+  await page.getByRole('button', { name: 'Finalize' }).click();
+  await expect(page.getByRole('heading', { name: 'Clinical measurements' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Save measurements' })).toHaveCount(0);
+  await expect(page.getByText('80 bpm', { exact: true })).toBeVisible();
+});

--- a/apps/web/lib/clinical-measurements.test.ts
+++ b/apps/web/lib/clinical-measurements.test.ts
@@ -1,0 +1,95 @@
+const mockVitalsPut = jest.fn().mockResolvedValue(undefined);
+const mockTobaccoPut = jest.fn().mockResolvedValue(undefined);
+const mockOutboxAdd = jest.fn().mockResolvedValue(undefined);
+const mockTransaction = jest.fn(async (...args: unknown[]) => {
+  const callback = args.at(-1) as () => Promise<void>;
+  await callback();
+});
+
+jest.mock('./db', () => ({
+  db: {
+    vitals: { put: mockVitalsPut },
+    tobacco_screenings: { put: mockTobaccoPut },
+    outbox: { add: mockOutboxAdd },
+    transaction: mockTransaction,
+  },
+}));
+
+import {
+  derivedBmi,
+  saveClinicalMeasurementsOffline,
+  validateClinicalMeasurements,
+  type TobaccoFormValues,
+  type VitalsFormValues,
+} from './clinical-measurements';
+
+const vitals: VitalsFormValues = {
+  systolicBp: '120',
+  diastolicBp: '80',
+  bpSite: 'LEFT_ARM',
+  bpSiteOther: '',
+  patientPosition: 'SITTING',
+  patientPositionOther: '',
+  cuffSize: 'ADULT',
+  cuffSizeOther: '',
+  pulseBpm: '72',
+  temperatureValue: '98.6',
+  temperatureUnit: 'FAHRENHEIT',
+  temperatureSource: 'ORAL',
+  temperatureSourceOther: '',
+  respiratoryRate: '16',
+  spo2Percent: '98',
+  weightKg: '70',
+  heightCm: '170',
+  notes: '',
+};
+
+const tobacco: TobaccoFormValues = {
+  smokingStatus: 'NEVER',
+  smokelessTobaccoStatus: 'NOT_ASSESSED',
+  passiveExposure: 'NO',
+  readinessToQuit: 'NOT_APPLICABLE',
+  counselingGiven: 'NO',
+};
+
+describe('clinical measurement offline helpers', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('validates relationships and derives BMI', () => {
+    expect(validateClinicalMeasurements(vitals, tobacco)).toEqual({});
+    expect(derivedBmi(vitals)).toBe(24.2);
+
+    expect(validateClinicalMeasurements({ ...vitals, diastolicBp: '' }, tobacco)).toMatchObject({
+      systolicBp: expect.any(String),
+      diastolicBp: expect.any(String),
+    });
+    expect(
+      validateClinicalMeasurements(
+        { ...vitals, temperatureSource: '', temperatureValue: '98.6' },
+        tobacco,
+      ),
+    ).toMatchObject({ temperatureSource: expect.any(String) });
+  });
+
+  it('writes vitals, tobacco, and one bundle mutation in a single Dexie transaction', async () => {
+    const result = await saveClinicalMeasurementsOffline({
+      clinicId: 'clinic-1',
+      encounterId: 'encounter-1',
+      vitalsId: 'vitals-1',
+      tobaccoScreeningId: 'tobacco-1',
+      vitals,
+      tobacco,
+      markTobaccoReviewed: true,
+    });
+
+    expect(result.errors).toEqual({});
+    expect(mockTransaction).toHaveBeenCalledTimes(1);
+    expect(mockVitalsPut).toHaveBeenCalledWith(
+      expect.objectContaining({ temperatureCelsius: 37, bmi: 24.2 }),
+    );
+    expect(mockTobaccoPut).toHaveBeenCalledWith(expect.objectContaining({ reviewPending: true }));
+    expect(mockOutboxAdd).toHaveBeenCalledWith(
+      expect.objectContaining({ entityType: 'encounter_vitals_bundle' }),
+    );
+  });
+});

--- a/apps/web/lib/clinical-measurements.ts
+++ b/apps/web/lib/clinical-measurements.ts
@@ -1,0 +1,285 @@
+import { computeBmi, toCelsius, type TemperatureUnit } from '@nkwapa/db/clinical-measurements';
+import { db, type TobaccoScreeningRecord, type VitalsRecord } from './db';
+import { buildOutboxMutation, SYNC_OPERATION } from './outbox';
+
+export const BP_SITES = ['LEFT_ARM', 'RIGHT_ARM', 'LEFT_LEG', 'RIGHT_LEG', 'OTHER'] as const;
+export const PATIENT_POSITIONS = ['SITTING', 'STANDING', 'SUPINE', 'OTHER'] as const;
+export const CUFF_SIZES = [
+  'INFANT',
+  'CHILD',
+  'SMALL_ADULT',
+  'ADULT',
+  'LARGE_ADULT',
+  'THIGH',
+  'OTHER',
+] as const;
+export const TEMPERATURE_SOURCES = [
+  'ORAL',
+  'AXILLARY',
+  'TYMPANIC',
+  'TEMPORAL',
+  'RECTAL',
+  'OTHER',
+] as const;
+export const TOBACCO_USE_STATUSES = ['NOT_ASSESSED', 'NEVER', 'FORMER', 'CURRENT'] as const;
+export const SCREENING_ANSWERS = ['NOT_ASSESSED', 'NO', 'YES'] as const;
+export const READINESS_OPTIONS = [
+  'NOT_ASSESSED',
+  'NOT_READY',
+  'CONSIDERING',
+  'READY',
+  'NOT_APPLICABLE',
+] as const;
+
+export type VitalsFormValues = {
+  systolicBp: string;
+  diastolicBp: string;
+  bpSite: string;
+  bpSiteOther: string;
+  patientPosition: string;
+  patientPositionOther: string;
+  cuffSize: string;
+  cuffSizeOther: string;
+  pulseBpm: string;
+  temperatureValue: string;
+  temperatureUnit: TemperatureUnit;
+  temperatureSource: string;
+  temperatureSourceOther: string;
+  respiratoryRate: string;
+  spo2Percent: string;
+  weightKg: string;
+  heightCm: string;
+  notes: string;
+};
+
+export type TobaccoFormValues = {
+  smokingStatus: string;
+  smokelessTobaccoStatus: string;
+  passiveExposure: string;
+  readinessToQuit: string;
+  counselingGiven: string;
+};
+
+export type ClinicalFieldErrors = Record<string, string>;
+
+export function generateClinicalId(): string {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) return crypto.randomUUID();
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (character) => {
+    const random = (Math.random() * 16) | 0;
+    const value = character === 'x' ? random : (random & 0x3) | 0x8;
+    return value.toString(16);
+  });
+}
+
+function optionalNumber(value: string): number | null {
+  if (!value.trim()) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : Number.NaN;
+}
+
+function validateRange(
+  errors: ClinicalFieldErrors,
+  field: string,
+  value: number | null,
+  min: number,
+  max: number,
+  label: string,
+) {
+  if (value != null && (!Number.isFinite(value) || value < min || value > max)) {
+    errors[field] = `${label} must be between ${min} and ${max}.`;
+  }
+}
+
+function validateOther(
+  errors: ClinicalFieldErrors,
+  field: string,
+  selected: string,
+  detail: string,
+) {
+  if (selected === 'OTHER' && !detail.trim()) errors[field] = 'Add a short description for Other.';
+  if (selected !== 'OTHER' && detail.trim()) errors[field] = 'Select Other before adding detail.';
+}
+
+export function validateClinicalMeasurements(
+  vitals: VitalsFormValues,
+  _tobacco: TobaccoFormValues,
+): ClinicalFieldErrors {
+  const errors: ClinicalFieldErrors = {};
+  const systolicBp = optionalNumber(vitals.systolicBp);
+  const diastolicBp = optionalNumber(vitals.diastolicBp);
+  const hasSystolic = systolicBp != null;
+  const hasDiastolic = diastolicBp != null;
+  if (hasSystolic !== hasDiastolic) {
+    errors.systolicBp = 'Enter systolic and diastolic blood pressure together.';
+    errors.diastolicBp = 'Enter systolic and diastolic blood pressure together.';
+  }
+  validateRange(errors, 'systolicBp', systolicBp, 40, 300, 'Systolic BP');
+  validateRange(errors, 'diastolicBp', diastolicBp, 20, 200, 'Diastolic BP');
+  if (systolicBp != null && diastolicBp != null && systolicBp <= diastolicBp) {
+    errors.systolicBp = 'Systolic BP must be greater than diastolic BP.';
+  }
+  if (hasSystolic && !vitals.bpSite) errors.bpSite = 'Select the blood pressure site.';
+  if (!hasSystolic && (vitals.bpSite || vitals.patientPosition || vitals.cuffSize)) {
+    errors.bpSite = 'Blood pressure context requires a blood pressure reading.';
+  }
+  validateOther(errors, 'bpSiteOther', vitals.bpSite, vitals.bpSiteOther);
+  validateOther(
+    errors,
+    'patientPositionOther',
+    vitals.patientPosition,
+    vitals.patientPositionOther,
+  );
+  validateOther(errors, 'cuffSizeOther', vitals.cuffSize, vitals.cuffSizeOther);
+
+  validateRange(errors, 'pulseBpm', optionalNumber(vitals.pulseBpm), 20, 300, 'Pulse');
+  validateRange(
+    errors,
+    'respiratoryRate',
+    optionalNumber(vitals.respiratoryRate),
+    1,
+    100,
+    'Respiratory rate',
+  );
+  validateRange(errors, 'spo2Percent', optionalNumber(vitals.spo2Percent), 1, 100, 'SpO₂');
+  validateRange(errors, 'weightKg', optionalNumber(vitals.weightKg), 0.1, 700, 'Weight');
+  validateRange(errors, 'heightCm', optionalNumber(vitals.heightCm), 20, 300, 'Height');
+
+  const temperatureValue = optionalNumber(vitals.temperatureValue);
+  if (temperatureValue != null) {
+    if (!Number.isFinite(temperatureValue)) errors.temperatureValue = 'Enter a valid temperature.';
+    if (!vitals.temperatureSource) errors.temperatureSource = 'Select the temperature source.';
+    const canonical = Number.isFinite(temperatureValue)
+      ? toCelsius(temperatureValue, vitals.temperatureUnit)
+      : null;
+    if (canonical != null && (canonical < 25 || canonical > 45)) {
+      errors.temperatureValue = 'Temperature must convert to a value between 25 and 45 °C.';
+    }
+  } else if (vitals.temperatureSource) {
+    errors.temperatureValue = 'Enter a temperature for the selected source.';
+  }
+  validateOther(
+    errors,
+    'temperatureSourceOther',
+    vitals.temperatureSource,
+    vitals.temperatureSourceOther,
+  );
+  if (vitals.notes.length > 2000) errors.notes = 'Notes cannot exceed 2,000 characters.';
+  return errors;
+}
+
+export function derivedBmi(vitals: Pick<VitalsFormValues, 'weightKg' | 'heightCm'>): number | null {
+  return computeBmi(optionalNumber(vitals.weightKg), optionalNumber(vitals.heightCm));
+}
+
+export async function saveClinicalMeasurementsOffline(params: {
+  clinicId: string;
+  encounterId: string;
+  vitalsId: string;
+  tobaccoScreeningId: string;
+  vitals: VitalsFormValues;
+  tobacco: TobaccoFormValues;
+  markTobaccoReviewed?: boolean;
+  existingVitals?: VitalsRecord | null;
+  existingTobacco?: TobaccoScreeningRecord | null;
+}) {
+  const errors = validateClinicalMeasurements(params.vitals, params.tobacco);
+  if (Object.keys(errors).length) return { errors };
+
+  const now = new Date().toISOString();
+  const temperatureValue = optionalNumber(params.vitals.temperatureValue);
+  const temperatureCelsius =
+    temperatureValue == null
+      ? undefined
+      : toCelsius(temperatureValue, params.vitals.temperatureUnit);
+  const tobaccoChanged =
+    !params.existingTobacco ||
+    params.existingTobacco.smokingStatus !== params.tobacco.smokingStatus ||
+    params.existingTobacco.smokelessTobaccoStatus !== params.tobacco.smokelessTobaccoStatus ||
+    params.existingTobacco.passiveExposure !== params.tobacco.passiveExposure ||
+    params.existingTobacco.readinessToQuit !== params.tobacco.readinessToQuit ||
+    params.existingTobacco.counselingGiven !== params.tobacco.counselingGiven;
+
+  const vitalsRecord: VitalsRecord = {
+    id: params.vitalsId,
+    clinicId: params.clinicId,
+    encounterId: params.encounterId,
+    systolicBp: optionalNumber(params.vitals.systolicBp) ?? undefined,
+    diastolicBp: optionalNumber(params.vitals.diastolicBp) ?? undefined,
+    bpSite: params.vitals.bpSite || undefined,
+    bpSiteOther: params.vitals.bpSiteOther.trim() || undefined,
+    patientPosition: params.vitals.patientPosition || undefined,
+    patientPositionOther: params.vitals.patientPositionOther.trim() || undefined,
+    cuffSize: params.vitals.cuffSize || undefined,
+    cuffSizeOther: params.vitals.cuffSizeOther.trim() || undefined,
+    pulseBpm: optionalNumber(params.vitals.pulseBpm) ?? undefined,
+    temperatureCelsius,
+    temperatureSource: params.vitals.temperatureSource || undefined,
+    temperatureSourceOther: params.vitals.temperatureSourceOther.trim() || undefined,
+    respiratoryRate: optionalNumber(params.vitals.respiratoryRate) ?? undefined,
+    spo2Percent: optionalNumber(params.vitals.spo2Percent) ?? undefined,
+    weightKg: optionalNumber(params.vitals.weightKg) ?? undefined,
+    heightCm: optionalNumber(params.vitals.heightCm) ?? undefined,
+    bmi: derivedBmi(params.vitals) ?? undefined,
+    notes: params.vitals.notes.trim() || undefined,
+    createdAt: params.existingVitals?.createdAt ?? now,
+    updatedAt: now,
+  };
+  const tobaccoRecord: TobaccoScreeningRecord = {
+    id: params.tobaccoScreeningId,
+    clinicId: params.clinicId,
+    encounterId: params.encounterId,
+    ...params.tobacco,
+    reviewedByUserId:
+      !params.markTobaccoReviewed && !tobaccoChanged
+        ? params.existingTobacco?.reviewedByUserId
+        : undefined,
+    reviewedAt:
+      !params.markTobaccoReviewed && !tobaccoChanged
+        ? params.existingTobacco?.reviewedAt
+        : undefined,
+    reviewPending: params.markTobaccoReviewed === true,
+    createdAt: params.existingTobacco?.createdAt ?? now,
+    updatedAt: now,
+  };
+  const outbox = buildOutboxMutation({
+    clinicId: params.clinicId,
+    entityType: 'encounter_vitals_bundle',
+    entityId: params.vitalsId,
+    operation: SYNC_OPERATION.UPSERT,
+    payloadJson: {
+      schemaVersion: 1,
+      encounterId: params.encounterId,
+      vitalsId: params.vitalsId,
+      tobaccoScreeningId: params.tobaccoScreeningId,
+      vitals: {
+        systolicBp: optionalNumber(params.vitals.systolicBp),
+        diastolicBp: optionalNumber(params.vitals.diastolicBp),
+        bpSite: params.vitals.bpSite || null,
+        bpSiteOther: params.vitals.bpSiteOther.trim() || null,
+        patientPosition: params.vitals.patientPosition || null,
+        patientPositionOther: params.vitals.patientPositionOther.trim() || null,
+        cuffSize: params.vitals.cuffSize || null,
+        cuffSizeOther: params.vitals.cuffSizeOther.trim() || null,
+        pulseBpm: optionalNumber(params.vitals.pulseBpm),
+        temperatureValue,
+        temperatureUnit: params.vitals.temperatureUnit,
+        temperatureSource: params.vitals.temperatureSource || null,
+        temperatureSourceOther: params.vitals.temperatureSourceOther.trim() || null,
+        respiratoryRate: optionalNumber(params.vitals.respiratoryRate),
+        spo2Percent: optionalNumber(params.vitals.spo2Percent),
+        weightKg: optionalNumber(params.vitals.weightKg),
+        heightCm: optionalNumber(params.vitals.heightCm),
+        notes: params.vitals.notes.trim() || null,
+      },
+      tobacco: params.tobacco,
+      markTobaccoReviewed: params.markTobaccoReviewed === true,
+    },
+  });
+
+  await db.transaction('rw', db.vitals, db.tobacco_screenings, db.outbox, async () => {
+    await db.vitals.put(vitalsRecord);
+    await db.tobacco_screenings.put(tobaccoRecord);
+    await db.outbox.add(outbox);
+  });
+  return { errors: {}, vitalsRecord, tobaccoRecord, outbox };
+}

--- a/apps/web/lib/db-migrations.test.ts
+++ b/apps/web/lib/db-migrations.test.ts
@@ -1,0 +1,19 @@
+import { migrateLegacyPulse } from './db-migrations';
+
+describe('Dexie clinical measurement migrations', () => {
+  it('preserves a legacy heart rate as pulse bpm', () => {
+    const record = { heartRate: 72 };
+
+    migrateLegacyPulse(record);
+
+    expect(record).toEqual({ pulseBpm: 72 });
+  });
+
+  it('does not replace a newer pulse value with the compatibility field', () => {
+    const record = { heartRate: 64, pulseBpm: 70 };
+
+    migrateLegacyPulse(record);
+
+    expect(record).toEqual({ pulseBpm: 70 });
+  });
+});

--- a/apps/web/lib/db-migrations.ts
+++ b/apps/web/lib/db-migrations.ts
@@ -1,0 +1,12 @@
+export interface LegacyPulseRecord {
+  heartRate?: number;
+  pulseBpm?: number;
+}
+
+/** Mutates a cached vitals row during the Dexie v4 upgrade. */
+export function migrateLegacyPulse(record: LegacyPulseRecord): void {
+  if (record.pulseBpm == null && record.heartRate != null) {
+    record.pulseBpm = record.heartRate;
+  }
+  delete record.heartRate;
+}

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -1,4 +1,5 @@
 import Dexie, { type Table } from 'dexie';
+import { migrateLegacyPulse } from './db-migrations';
 
 export interface PatientRecord {
   id: string;
@@ -230,12 +231,7 @@ export class NkwapaDb extends Dexie {
         await transaction
           .table<VitalsRecord, string>('vitals')
           .toCollection()
-          .modify((record) => {
-            if (record.pulseBpm == null && record.heartRate != null) {
-              record.pulseBpm = record.heartRate;
-            }
-            delete record.heartRate;
-          });
+          .modify(migrateLegacyPulse);
       });
   }
 }

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -37,11 +37,40 @@ export interface VitalsRecord {
   encounterId: string;
   systolicBp?: number;
   diastolicBp?: number;
+  /** @deprecated Migrated to pulseBpm in Dexie v4. */
   heartRate?: number;
+  pulseBpm?: number;
+  bpSite?: string;
+  bpSiteOther?: string;
+  patientPosition?: string;
+  patientPositionOther?: string;
+  cuffSize?: string;
+  cuffSizeOther?: string;
+  temperatureCelsius?: number;
+  temperatureSource?: string;
+  temperatureSourceOther?: string;
+  respiratoryRate?: number;
+  spo2Percent?: number;
   weightKg?: number;
   heightCm?: number;
   bmi?: number;
   notes?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface TobaccoScreeningRecord {
+  id: string;
+  clinicId: string;
+  encounterId: string;
+  smokingStatus: string;
+  smokelessTobaccoStatus: string;
+  passiveExposure: string;
+  readinessToQuit: string;
+  counselingGiven: string;
+  reviewedByUserId?: string;
+  reviewedAt?: string;
+  reviewPending?: boolean;
   createdAt?: string;
   updatedAt?: string;
 }
@@ -162,6 +191,7 @@ export class NkwapaDb extends Dexie {
   patients!: Table<PatientRecord, string>;
   encounters!: Table<EncounterRecord, string>;
   vitals!: Table<VitalsRecord, string>;
+  tobacco_screenings!: Table<TobaccoScreeningRecord, string>;
   diabetes_screenings!: Table<DiabetesScreeningRecord, string>;
   hypertension_assessments!: Table<HypertensionAssessmentRecord, string>;
   care_plans!: Table<CarePlanRecord, string>;
@@ -192,6 +222,21 @@ export class NkwapaDb extends Dexie {
       medical_history_records: 'id, clinicId, patientId, category, updatedAt',
       medical_history_revisions: 'id, recordId, status, createdAt',
     });
+    this.version(4)
+      .stores({
+        tobacco_screenings: 'id, clinicId, encounterId, reviewedAt, updatedAt',
+      })
+      .upgrade(async (transaction) => {
+        await transaction
+          .table<VitalsRecord, string>('vitals')
+          .toCollection()
+          .modify((record) => {
+            if (record.pulseBpm == null && record.heartRate != null) {
+              record.pulseBpm = record.heartRate;
+            }
+            delete record.heartRate;
+          });
+      });
   }
 }
 

--- a/apps/web/lib/patient-portal.ts
+++ b/apps/web/lib/patient-portal.ts
@@ -160,6 +160,16 @@ export interface GlucoseTrendPoint {
   source: 'ENCOUNTER' | 'PATIENT';
 }
 
+export interface ExpandedVitalsTrendPoint {
+  t: string;
+  temperatureCelsius: number | null;
+  respiratoryRate: number | null;
+  spo2Percent: number | null;
+  weightKg: number | null;
+  bmi: number | null;
+  source: 'ENCOUNTER';
+}
+
 export interface FollowUpSummary {
   requested: number;
   confirmed: number;
@@ -171,6 +181,7 @@ export interface FollowUpSummary {
 export interface PatientTrendsResponse {
   bp: BloodPressureTrendPoint[];
   glucose: GlucoseTrendPoint[];
+  measurements?: ExpandedVitalsTrendPoint[];
   followUp: FollowUpSummary;
 }
 

--- a/apps/web/lib/patient-trends.test.ts
+++ b/apps/web/lib/patient-trends.test.ts
@@ -1,8 +1,10 @@
 import {
   buildBloodPressureTrendData,
+  buildExpandedVitalsTrendData,
   buildGlucoseTrendData,
   formatTrendRangeFrom,
   getLatestBloodPressureTrend,
+  getLatestExpandedVital,
   getLatestGlucoseTrend,
 } from '@/lib/patient-trends';
 
@@ -64,5 +66,33 @@ describe('patient trend helpers', () => {
       expect.objectContaining({ glucose: 145 }),
     ]);
     expect(getLatestGlucoseTrend(points)).toEqual(points[1]);
+  });
+
+  it('filters expanded staff measurements and returns the latest recorded value', () => {
+    const points = [
+      {
+        t: '2026-03-18T08:00:00.000Z',
+        temperatureCelsius: 37,
+        respiratoryRate: 16,
+        spo2Percent: null,
+        weightKg: 70,
+        bmi: 24.2,
+        source: 'ENCOUNTER' as const,
+      },
+      {
+        t: '2026-03-20T08:00:00.000Z',
+        temperatureCelsius: null,
+        respiratoryRate: null,
+        spo2Percent: 98,
+        weightKg: null,
+        bmi: null,
+        source: 'ENCOUNTER' as const,
+      },
+    ];
+
+    expect(buildExpandedVitalsTrendData(points, 'spo2Percent')).toEqual([
+      expect.objectContaining({ value: 98 }),
+    ]);
+    expect(getLatestExpandedVital(points, 'temperatureCelsius')).toBe(37);
   });
 });

--- a/apps/web/lib/patient-trends.ts
+++ b/apps/web/lib/patient-trends.ts
@@ -1,6 +1,10 @@
 'use client';
 
-import type { BloodPressureTrendPoint, GlucoseTrendPoint } from '@/lib/patient-portal';
+import type {
+  BloodPressureTrendPoint,
+  ExpandedVitalsTrendPoint,
+  GlucoseTrendPoint,
+} from '@/lib/patient-portal';
 
 export const TREND_RANGE_OPTIONS = [30, 90, 180] as const;
 
@@ -41,6 +45,30 @@ export function buildGlucoseTrendData(points: GlucoseTrendPoint[]) {
     }),
     glucose: point.value,
   }));
+}
+
+export type ExpandedMeasurementKey = Exclude<keyof ExpandedVitalsTrendPoint, 't' | 'source'>;
+
+export function buildExpandedVitalsTrendData(
+  points: ExpandedVitalsTrendPoint[],
+  key: ExpandedMeasurementKey,
+) {
+  return points
+    .filter((point) => point[key] != null)
+    .map((point) => ({
+      label: new Date(point.t).toLocaleDateString(undefined, {
+        month: 'numeric',
+        day: 'numeric',
+      }),
+      value: point[key],
+    }));
+}
+
+export function getLatestExpandedVital(
+  points: ExpandedVitalsTrendPoint[],
+  key: ExpandedMeasurementKey,
+) {
+  return [...points].reverse().find((point) => point[key] != null)?.[key] ?? null;
 }
 
 export function getLatestBloodPressureTrend(points: BloodPressureTrendPoint[]) {

--- a/apps/web/lib/sync-types.ts
+++ b/apps/web/lib/sync-types.ts
@@ -3,6 +3,7 @@ export interface SyncPullResponseDto {
   patients: Array<Record<string, unknown>>;
   encounters: Array<Record<string, unknown>>;
   vitals: Array<Record<string, unknown>>;
+  tobaccoScreenings: Array<Record<string, unknown>>;
   diabetesScreenings: Array<Record<string, unknown>>;
   hypertensionAssessments: Array<Record<string, unknown>>;
   carePlans: Array<Record<string, unknown>>;

--- a/apps/web/lib/sync.ts
+++ b/apps/web/lib/sync.ts
@@ -10,6 +10,7 @@ export type SyncStatus = 'idle' | 'syncing' | 'success' | 'error';
 export type SyncStatusListener = (status: SyncStatus, error?: string) => void;
 
 const listeners: Set<SyncStatusListener> = new Set();
+const inFlightByClinic = new Map<string, Promise<SyncResult>>();
 
 export function onSyncStatusChange(listener: SyncStatusListener): () => void {
   listeners.add(listener);
@@ -25,7 +26,7 @@ export interface SyncNowOptions {
   getAccessToken?: () => Promise<string | null>;
 }
 
-export async function syncNow(options: SyncNowOptions): Promise<{
+export interface SyncResult {
   success: boolean;
   error?: string;
   conflicts?: Array<{
@@ -33,7 +34,9 @@ export async function syncNow(options: SyncNowOptions): Promise<{
     conflictType?: string;
     conflictDetails?: Record<string, unknown>;
   }>;
-}> {
+}
+
+async function performSync(options: SyncNowOptions): Promise<SyncResult> {
   const { clinicId, getAccessToken } = options;
   notifyStatus('syncing');
 
@@ -200,4 +203,18 @@ export async function syncNow(options: SyncNowOptions): Promise<{
     notifyStatus('error', msg);
     return { success: false, error: msg };
   }
+}
+
+/** Coalesces concurrent retries so one clinic never replays the same outbox batch twice. */
+export function syncNow(options: SyncNowOptions): Promise<SyncResult> {
+  const inFlight = inFlightByClinic.get(options.clinicId);
+  if (inFlight) return inFlight;
+
+  const request = performSync(options).finally(() => {
+    if (inFlightByClinic.get(options.clinicId) === request) {
+      inFlightByClinic.delete(options.clinicId);
+    }
+  });
+  inFlightByClinic.set(options.clinicId, request);
+  return request;
 }

--- a/apps/web/lib/sync.ts
+++ b/apps/web/lib/sync.ts
@@ -133,7 +133,15 @@ export async function syncNow(options: SyncNowOptions): Promise<{
       await db.encounters.put(toRecord(e) as unknown as Parameters<typeof db.encounters.put>[0]);
     }
     for (const v of pull.vitals) {
-      await db.vitals.put(toRecord(v) as unknown as Parameters<typeof db.vitals.put>[0]);
+      const record = toRecord(v);
+      if (record.pulseBpm == null && record.heartRate != null) record.pulseBpm = record.heartRate;
+      delete record.heartRate;
+      await db.vitals.put(record as unknown as Parameters<typeof db.vitals.put>[0]);
+    }
+    for (const tobacco of pull.tobaccoScreenings ?? []) {
+      await db.tobacco_screenings.put(
+        toRecord(tobacco) as unknown as Parameters<typeof db.tobacco_screenings.put>[0],
+      );
     }
     for (const d of pull.diabetesScreenings) {
       await db.diabetes_screenings.put(

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "@emotion/styled": "^11.14.1",
     "@mui/material": "^7.3.8",
     "@mui/x-data-grid": "^8.27.3",
+    "@nkwapa/db": "*",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/docs/clinic-ops/26_RESEARCH_EXPORT_TRANSFORMS_V1.md
+++ b/docs/clinic-ops/26_RESEARCH_EXPORT_TRANSFORMS_V1.md
@@ -53,7 +53,7 @@ The v1 sync target is one private GitHub repository.
 
 ## Fixed Pack Contract
 
-Every completed v2 export pack preserves all v1 files and columns:
+Every completed v3 export pack includes:
 
 - `manifest.json`
 - `SHA256SUMS.txt`
@@ -61,6 +61,7 @@ Every completed v2 export pack preserves all v1 files and columns:
 - `research_ops_checkins.csv`
 - `research_ops_assignments.csv`
 - `research_clinical_vitals.csv`
+- `research_clinical_tobacco.csv`
 - `research_clinical_screenings.csv`
 - `research_measurements.csv`
 - `research_appointments.csv`
@@ -70,11 +71,11 @@ Every completed v2 export pack preserves all v1 files and columns:
 The contract is versioned as:
 
 - `policyVersion = research-export-v1`
-- `datasetVersion = 2`
+- `datasetVersion = 3`
 
-The version increment adds only `research_medical_history.csv`; existing filenames and columns
-remain backward compatible. Any future schema change to the pack should increment the dataset
-version.
+Version 3 expands the canonical vitals columns, renames `heart_rate` to `pulse_bpm`, and adds the
+structured tobacco dataset. Reviewer identity is excluded; only reviewed state and rounded review
+time are exported. Consumers must select transforms by dataset version.
 
 The medical-history dataset contains current and historical revisions within the requested range.
 It includes de-identified patient, clinic, record, revision, and source-encounter keys; category,
@@ -159,6 +160,7 @@ The transform currently draws from:
 - consents
 - encounters
 - vitals
+- tobacco screenings
 - diabetes screenings
 - care context needed for encounter relation
 - staff shifts and patient check-ins through ops data

--- a/package-lock.json
+++ b/package-lock.json
@@ -16370,6 +16370,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -19061,6 +19062,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/tmpl": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,6 +101,7 @@
         "@emotion/styled": "^11.14.1",
         "@mui/material": "^7.3.8",
         "@mui/x-data-grid": "^8.27.3",
+        "@nkwapa/db": "*",
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1298,6 +1298,29 @@
         "node": ">= 4"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.3.tgz",
+      "integrity": "sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -2332,6 +2355,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -2344,6 +2377,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
@@ -11239,9 +11286,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -13846,9 +13893,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -15283,9 +15330,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -16323,7 +16370,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -18066,6 +18112,13 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/sqlstring": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
@@ -19008,18 +19061,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/tmpl": {

--- a/package.json
+++ b/package.json
@@ -57,13 +57,14 @@
     "@opentelemetry/resources": "2.8.0",
     "@opentelemetry/sdk-trace-base": "2.8.0",
     "@istanbuljs/load-nyc-config": {
-      "js-yaml": "4.3.0"
+      "js-yaml": "5.2.3"
     },
     "@tootallnate/once": "3.0.1",
     "anymatch": {
       "picomatch": "2.3.2"
     },
     "cosmiconfig": {
+      "js-yaml": "5.2.3",
       "yaml": "1.10.3"
     },
     "effect": "3.20.0",
@@ -74,7 +75,9 @@
       "ws": "8.21.0"
     },
     "file-type": "21.3.4",
+    "fast-uri": "3.1.5",
     "form-data": "4.0.6",
+    "js-yaml": "5.2.3",
     "jest-util": {
       "picomatch": "2.3.2"
     },
@@ -82,6 +85,7 @@
     "micromatch": {
       "picomatch": "2.3.2"
     },
+    "nanoid": "3.3.18",
     "next": {
       ".": "16.3.0-canary.104"
     },

--- a/packages/db/index.ts
+++ b/packages/db/index.ts
@@ -9,3 +9,9 @@ export {
 } from './src/national-id';
 export { generatePatientCode } from './src/patient-code';
 export { normalizePhoneToE164 } from './src/phone';
+export {
+  computeBmi,
+  roundClinicalValue,
+  toCelsius,
+  type TemperatureUnit,
+} from './src/clinical-measurements';

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -4,6 +4,16 @@
   "private": true,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./clinical-measurements": {
+      "types": "./dist/src/clinical-measurements.d.ts",
+      "default": "./dist/src/clinical-measurements.js"
+    }
+  },
   "scripts": {
     "build": "tsc",
     "lint": "eslint \"src/**/*.ts\" \"index.ts\" --max-warnings 0",

--- a/packages/db/prisma/migrations/20260811000000_expand_vitals_and_tobacco_screening/migration.sql
+++ b/packages/db/prisma/migrations/20260811000000_expand_vitals_and_tobacco_screening/migration.sql
@@ -1,0 +1,149 @@
+CREATE TYPE "BloodPressureSite" AS ENUM (
+  'LEFT_ARM',
+  'RIGHT_ARM',
+  'LEFT_LEG',
+  'RIGHT_LEG',
+  'OTHER'
+);
+
+CREATE TYPE "PatientPosition" AS ENUM ('SITTING', 'STANDING', 'SUPINE', 'OTHER');
+
+CREATE TYPE "BloodPressureCuffSize" AS ENUM (
+  'INFANT',
+  'CHILD',
+  'SMALL_ADULT',
+  'ADULT',
+  'LARGE_ADULT',
+  'THIGH',
+  'OTHER'
+);
+
+CREATE TYPE "TemperatureSource" AS ENUM (
+  'ORAL',
+  'AXILLARY',
+  'TYMPANIC',
+  'TEMPORAL',
+  'RECTAL',
+  'OTHER'
+);
+
+CREATE TYPE "TobaccoUseStatus" AS ENUM ('NOT_ASSESSED', 'NEVER', 'FORMER', 'CURRENT');
+CREATE TYPE "ScreeningAnswer" AS ENUM ('NOT_ASSESSED', 'NO', 'YES');
+CREATE TYPE "ReadinessToQuit" AS ENUM (
+  'NOT_ASSESSED',
+  'NOT_READY',
+  'CONSIDERING',
+  'READY',
+  'NOT_APPLICABLE'
+);
+
+ALTER TABLE "Vitals" RENAME COLUMN "heartRate" TO "pulseBpm";
+
+ALTER TABLE "Vitals"
+  ADD COLUMN "bpSite" "BloodPressureSite",
+  ADD COLUMN "bpSiteOther" VARCHAR(120),
+  ADD COLUMN "patientPosition" "PatientPosition",
+  ADD COLUMN "patientPositionOther" VARCHAR(120),
+  ADD COLUMN "cuffSize" "BloodPressureCuffSize",
+  ADD COLUMN "cuffSizeOther" VARCHAR(120),
+  ADD COLUMN "temperatureCelsius" DOUBLE PRECISION,
+  ADD COLUMN "temperatureSource" "TemperatureSource",
+  ADD COLUMN "temperatureSourceOther" VARCHAR(120),
+  ADD COLUMN "respiratoryRate" INTEGER,
+  ADD COLUMN "spo2Percent" INTEGER;
+
+ALTER TABLE "Vitals"
+  ADD CONSTRAINT "Vitals_blood_pressure_pair_check" CHECK (
+    ("systolicBp" IS NULL AND "diastolicBp" IS NULL)
+    OR (
+      "systolicBp" BETWEEN 40 AND 300
+      AND "diastolicBp" BETWEEN 20 AND 200
+      AND "systolicBp" > "diastolicBp"
+    )
+  ),
+  ADD CONSTRAINT "Vitals_bp_site_other_check" CHECK (
+    ("bpSite" = 'OTHER' AND NULLIF(BTRIM("bpSiteOther"), '') IS NOT NULL)
+    OR ("bpSite" IS DISTINCT FROM 'OTHER' AND "bpSiteOther" IS NULL)
+  ),
+  ADD CONSTRAINT "Vitals_position_other_check" CHECK (
+    ("patientPosition" = 'OTHER' AND NULLIF(BTRIM("patientPositionOther"), '') IS NOT NULL)
+    OR ("patientPosition" IS DISTINCT FROM 'OTHER' AND "patientPositionOther" IS NULL)
+  ),
+  ADD CONSTRAINT "Vitals_cuff_other_check" CHECK (
+    ("cuffSize" = 'OTHER' AND NULLIF(BTRIM("cuffSizeOther"), '') IS NOT NULL)
+    OR ("cuffSize" IS DISTINCT FROM 'OTHER' AND "cuffSizeOther" IS NULL)
+  ),
+  ADD CONSTRAINT "Vitals_pulse_check" CHECK ("pulseBpm" IS NULL OR "pulseBpm" BETWEEN 20 AND 300),
+  ADD CONSTRAINT "Vitals_temperature_check" CHECK (
+    ("temperatureCelsius" IS NULL AND "temperatureSource" IS NULL AND "temperatureSourceOther" IS NULL)
+    OR (
+      "temperatureCelsius" BETWEEN 25 AND 45
+      AND "temperatureSource" IS NOT NULL
+      AND (
+        ("temperatureSource" = 'OTHER' AND NULLIF(BTRIM("temperatureSourceOther"), '') IS NOT NULL)
+        OR ("temperatureSource" <> 'OTHER' AND "temperatureSourceOther" IS NULL)
+      )
+    )
+  ),
+  ADD CONSTRAINT "Vitals_respiratory_rate_check" CHECK (
+    "respiratoryRate" IS NULL OR "respiratoryRate" BETWEEN 1 AND 100
+  ),
+  ADD CONSTRAINT "Vitals_spo2_check" CHECK ("spo2Percent" IS NULL OR "spo2Percent" BETWEEN 1 AND 100),
+  ADD CONSTRAINT "Vitals_weight_check" CHECK ("weightKg" IS NULL OR "weightKg" BETWEEN 0.1 AND 700),
+  ADD CONSTRAINT "Vitals_height_check" CHECK ("heightCm" IS NULL OR "heightCm" BETWEEN 20 AND 300),
+  ADD CONSTRAINT "Vitals_bmi_check" CHECK ("bmi" IS NULL OR "bmi" > 0);
+
+CREATE TABLE "TobaccoScreening" (
+  "id" UUID NOT NULL,
+  "clinicId" UUID NOT NULL,
+  "encounterId" UUID NOT NULL,
+  "smokingStatus" "TobaccoUseStatus" NOT NULL DEFAULT 'NOT_ASSESSED',
+  "smokelessTobaccoStatus" "TobaccoUseStatus" NOT NULL DEFAULT 'NOT_ASSESSED',
+  "passiveExposure" "ScreeningAnswer" NOT NULL DEFAULT 'NOT_ASSESSED',
+  "readinessToQuit" "ReadinessToQuit" NOT NULL DEFAULT 'NOT_ASSESSED',
+  "counselingGiven" "ScreeningAnswer" NOT NULL DEFAULT 'NOT_ASSESSED',
+  "reviewedByUserId" UUID,
+  "reviewedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "TobaccoScreening_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "TobaccoScreening_review_pair_check" CHECK (
+    ("reviewedByUserId" IS NULL AND "reviewedAt" IS NULL)
+    OR ("reviewedByUserId" IS NOT NULL AND "reviewedAt" IS NOT NULL)
+  )
+);
+
+CREATE UNIQUE INDEX "TobaccoScreening_encounterId_key" ON "TobaccoScreening"("encounterId");
+CREATE INDEX "TobaccoScreening_clinicId_updatedAt_idx" ON "TobaccoScreening"("clinicId", "updatedAt");
+CREATE INDEX "TobaccoScreening_clinicId_reviewedAt_idx" ON "TobaccoScreening"("clinicId", "reviewedAt");
+CREATE INDEX "TobaccoScreening_reviewedByUserId_idx" ON "TobaccoScreening"("reviewedByUserId");
+
+ALTER TABLE "TobaccoScreening"
+  ADD CONSTRAINT "TobaccoScreening_encounterId_fkey"
+  FOREIGN KEY ("encounterId") REFERENCES "Encounter"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "TobaccoScreening"
+  ADD CONSTRAINT "TobaccoScreening_clinicId_fkey"
+  FOREIGN KEY ("clinicId") REFERENCES "Clinic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "TobaccoScreening"
+  ADD CONSTRAINT "TobaccoScreening_reviewedByUserId_fkey"
+  FOREIGN KEY ("reviewedByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "TobaccoScreening" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "TobaccoScreening_clinic_scope_policy" ON "TobaccoScreening"
+FOR ALL
+USING (
+  app.can_access_clinic("clinicId")
+  AND EXISTS (
+    SELECT 1 FROM "Encounter" e
+    WHERE e."id" = "encounterId" AND e."clinicId" = "clinicId"
+  )
+)
+WITH CHECK (
+  app.can_access_clinic("clinicId")
+  AND EXISTS (
+    SELECT 1 FROM "Encounter" e
+    WHERE e."id" = "encounterId" AND e."clinicId" = "clinicId"
+  )
+);

--- a/packages/db/prisma/migrations/20260811000000_expand_vitals_and_tobacco_screening/migration.sql
+++ b/packages/db/prisma/migrations/20260811000000_expand_vitals_and_tobacco_screening/migration.sql
@@ -60,20 +60,20 @@ ALTER TABLE "Vitals"
       AND "diastolicBp" BETWEEN 20 AND 200
       AND "systolicBp" > "diastolicBp"
     )
-  ),
+  ) NOT VALID,
   ADD CONSTRAINT "Vitals_bp_site_other_check" CHECK (
     ("bpSite" = 'OTHER' AND NULLIF(BTRIM("bpSiteOther"), '') IS NOT NULL)
     OR ("bpSite" IS DISTINCT FROM 'OTHER' AND "bpSiteOther" IS NULL)
-  ),
+  ) NOT VALID,
   ADD CONSTRAINT "Vitals_position_other_check" CHECK (
     ("patientPosition" = 'OTHER' AND NULLIF(BTRIM("patientPositionOther"), '') IS NOT NULL)
     OR ("patientPosition" IS DISTINCT FROM 'OTHER' AND "patientPositionOther" IS NULL)
-  ),
+  ) NOT VALID,
   ADD CONSTRAINT "Vitals_cuff_other_check" CHECK (
     ("cuffSize" = 'OTHER' AND NULLIF(BTRIM("cuffSizeOther"), '') IS NOT NULL)
     OR ("cuffSize" IS DISTINCT FROM 'OTHER' AND "cuffSizeOther" IS NULL)
-  ),
-  ADD CONSTRAINT "Vitals_pulse_check" CHECK ("pulseBpm" IS NULL OR "pulseBpm" BETWEEN 20 AND 300),
+  ) NOT VALID,
+  ADD CONSTRAINT "Vitals_pulse_check" CHECK ("pulseBpm" IS NULL OR "pulseBpm" BETWEEN 20 AND 300) NOT VALID,
   ADD CONSTRAINT "Vitals_temperature_check" CHECK (
     ("temperatureCelsius" IS NULL AND "temperatureSource" IS NULL AND "temperatureSourceOther" IS NULL)
     OR (
@@ -84,14 +84,14 @@ ALTER TABLE "Vitals"
         OR ("temperatureSource" <> 'OTHER' AND "temperatureSourceOther" IS NULL)
       )
     )
-  ),
+  ) NOT VALID,
   ADD CONSTRAINT "Vitals_respiratory_rate_check" CHECK (
     "respiratoryRate" IS NULL OR "respiratoryRate" BETWEEN 1 AND 100
-  ),
-  ADD CONSTRAINT "Vitals_spo2_check" CHECK ("spo2Percent" IS NULL OR "spo2Percent" BETWEEN 1 AND 100),
-  ADD CONSTRAINT "Vitals_weight_check" CHECK ("weightKg" IS NULL OR "weightKg" BETWEEN 0.1 AND 700),
-  ADD CONSTRAINT "Vitals_height_check" CHECK ("heightCm" IS NULL OR "heightCm" BETWEEN 20 AND 300),
-  ADD CONSTRAINT "Vitals_bmi_check" CHECK ("bmi" IS NULL OR "bmi" > 0);
+  ) NOT VALID,
+  ADD CONSTRAINT "Vitals_spo2_check" CHECK ("spo2Percent" IS NULL OR "spo2Percent" BETWEEN 1 AND 100) NOT VALID,
+  ADD CONSTRAINT "Vitals_weight_check" CHECK ("weightKg" IS NULL OR "weightKg" BETWEEN 0.1 AND 700) NOT VALID,
+  ADD CONSTRAINT "Vitals_height_check" CHECK ("heightCm" IS NULL OR "heightCm" BETWEEN 20 AND 300) NOT VALID,
+  ADD CONSTRAINT "Vitals_bmi_check" CHECK ("bmi" IS NULL OR "bmi" > 0) NOT VALID;
 
 CREATE TABLE "TobaccoScreening" (
   "id" UUID NOT NULL,

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -197,6 +197,61 @@ enum MedicalHistoryStatus {
   ENTERED_IN_ERROR
 }
 
+enum BloodPressureSite {
+  LEFT_ARM
+  RIGHT_ARM
+  LEFT_LEG
+  RIGHT_LEG
+  OTHER
+}
+
+enum PatientPosition {
+  SITTING
+  STANDING
+  SUPINE
+  OTHER
+}
+
+enum BloodPressureCuffSize {
+  INFANT
+  CHILD
+  SMALL_ADULT
+  ADULT
+  LARGE_ADULT
+  THIGH
+  OTHER
+}
+
+enum TemperatureSource {
+  ORAL
+  AXILLARY
+  TYMPANIC
+  TEMPORAL
+  RECTAL
+  OTHER
+}
+
+enum TobaccoUseStatus {
+  NOT_ASSESSED
+  NEVER
+  FORMER
+  CURRENT
+}
+
+enum ScreeningAnswer {
+  NOT_ASSESSED
+  NO
+  YES
+}
+
+enum ReadinessToQuit {
+  NOT_ASSESSED
+  NOT_READY
+  CONSIDERING
+  READY
+  NOT_APPLICABLE
+}
+
 model Organization {
   id       String @id @default(uuid()) @db.Uuid
   name     String
@@ -235,6 +290,7 @@ model Clinic {
   auditEvents            AuditEvent[]
   syncMutations          SyncMutation[]
   vitals                 Vitals[]
+  tobaccoScreenings      TobaccoScreening[]
   diabetesScreening      DiabetesScreening[]
   hypertensionAssessment HypertensionAssessment[]
   carePlans              CarePlan[]
@@ -302,6 +358,7 @@ model User {
   conversationParticipants      ConversationParticipant[]
   sentMessages                  Message[]                 @relation("MessageSender")
   authoredHistoryRevisions      MedicalHistoryRevision[]  @relation("MedicalHistoryRevisionAuthor")
+  reviewedTobaccoScreenings     TobaccoScreening[]        @relation("TobaccoScreeningReviewedBy")
 
   @@index([isActive])
 }
@@ -434,6 +491,7 @@ model Encounter {
   doctorFinalizedBy   User? @relation("EncounterDoctorFinalizedBy", fields: [doctorFinalizedById], references: [id])
 
   vitals                 Vitals?
+  tobaccoScreening       TobaccoScreening?
   diabetesScreening      DiabetesScreening?
   hypertensionAssessment HypertensionAssessment?
   carePlan               CarePlan?
@@ -519,7 +577,20 @@ model Vitals {
 
   systolicBp  Int?
   diastolicBp Int?
-  heartRate   Int?
+  bpSite      BloodPressureSite?
+  bpSiteOther String?            @db.VarChar(120)
+
+  patientPosition      PatientPosition?
+  patientPositionOther String?                @db.VarChar(120)
+  cuffSize             BloodPressureCuffSize?
+  cuffSizeOther        String?                @db.VarChar(120)
+
+  pulseBpm               Int?
+  temperatureCelsius     Float?
+  temperatureSource      TemperatureSource?
+  temperatureSourceOther String?            @db.VarChar(120)
+  respiratoryRate        Int?
+  spo2Percent            Int?
 
   weightKg Float?
   heightCm Float?
@@ -534,6 +605,31 @@ model Vitals {
   clinic    Clinic    @relation(fields: [clinicId], references: [id], onDelete: Cascade)
 
   @@index([clinicId, updatedAt])
+}
+
+model TobaccoScreening {
+  id          String @id @default(uuid()) @db.Uuid
+  clinicId    String @db.Uuid
+  encounterId String @unique @db.Uuid
+
+  smokingStatus          TobaccoUseStatus @default(NOT_ASSESSED)
+  smokelessTobaccoStatus TobaccoUseStatus @default(NOT_ASSESSED)
+  passiveExposure        ScreeningAnswer  @default(NOT_ASSESSED)
+  readinessToQuit        ReadinessToQuit  @default(NOT_ASSESSED)
+  counselingGiven        ScreeningAnswer  @default(NOT_ASSESSED)
+  reviewedByUserId       String?          @db.Uuid
+  reviewedAt             DateTime?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  encounter  Encounter @relation(fields: [encounterId], references: [id], onDelete: Cascade)
+  clinic     Clinic    @relation(fields: [clinicId], references: [id], onDelete: Cascade)
+  reviewedBy User?     @relation("TobaccoScreeningReviewedBy", fields: [reviewedByUserId], references: [id], onDelete: SetNull)
+
+  @@index([clinicId, updatedAt])
+  @@index([clinicId, reviewedAt])
+  @@index([reviewedByUserId])
 }
 
 model DiabetesScreening {

--- a/packages/db/src/clinical-measurements.spec.ts
+++ b/packages/db/src/clinical-measurements.spec.ts
@@ -1,0 +1,14 @@
+import { computeBmi, toCelsius } from './clinical-measurements';
+
+describe('clinical measurement normalization', () => {
+  it('converts Fahrenheit to canonical Celsius', () => {
+    expect(toCelsius(98.6, 'FAHRENHEIT')).toBe(37);
+    expect(toCelsius(37.04, 'CELSIUS')).toBe(37);
+  });
+
+  it('computes BMI from canonical kilograms and centimeters', () => {
+    expect(computeBmi(70, 170)).toBe(24.2);
+    expect(computeBmi(null, 170)).toBeNull();
+    expect(computeBmi(70, 0)).toBeNull();
+  });
+});

--- a/packages/db/src/clinical-measurements.ts
+++ b/packages/db/src/clinical-measurements.ts
@@ -1,0 +1,16 @@
+export type TemperatureUnit = 'CELSIUS' | 'FAHRENHEIT';
+
+export function roundClinicalValue(value: number, precision = 1): number {
+  const factor = 10 ** precision;
+  return Math.round((value + Number.EPSILON) * factor) / factor;
+}
+
+export function toCelsius(value: number, unit: TemperatureUnit): number {
+  return roundClinicalValue(unit === 'FAHRENHEIT' ? ((value - 32) * 5) / 9 : value);
+}
+
+export function computeBmi(weightKg?: number | null, heightCm?: number | null): number | null {
+  if (weightKg == null || heightCm == null || weightKg <= 0 || heightCm <= 0) return null;
+  const heightM = heightCm / 100;
+  return roundClinicalValue(weightKg / (heightM * heightM));
+}

--- a/packages/db/src/vitals-migration.integration.spec.ts
+++ b/packages/db/src/vitals-migration.integration.spec.ts
@@ -1,0 +1,155 @@
+import { readFile, readdir } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { Client } from 'pg';
+
+const TARGET_MIGRATION = '20260811000000_expand_vitals_and_tobacco_screening';
+const describeMigration = process.env.RUN_MIGRATION_TESTS === '1' ? describe : describe.skip;
+
+function databaseUrl(source: string, database: string): string {
+  const url = new URL(source);
+  url.pathname = `/${database}`;
+  return url.toString();
+}
+
+describeMigration('expanded vitals legacy database migration', () => {
+  jest.setTimeout(120_000);
+
+  it('preserves populated legacy vitals and enforces checks for new rows', async () => {
+    const sourceUrl = process.env.DATABASE_URL;
+    if (!sourceUrl) throw new Error('DATABASE_URL is required for migration integration tests');
+
+    const database = `nkwapa_vitals_${process.pid}_${Date.now()}`;
+    const admin = new Client({ connectionString: databaseUrl(sourceUrl, 'postgres') });
+    const target = new Client({ connectionString: databaseUrl(sourceUrl, database) });
+
+    await admin.connect();
+    try {
+      await admin.query(`CREATE DATABASE "${database}"`);
+      await target.connect();
+      try {
+        const migrationsRoot = resolve(__dirname, '../prisma/migrations');
+        const migrationNames = (await readdir(migrationsRoot))
+          .filter((name) => /^\d/.test(name))
+          .sort();
+        const targetIndex = migrationNames.indexOf(TARGET_MIGRATION);
+        expect(targetIndex).toBeGreaterThan(0);
+
+        for (const migrationName of migrationNames.slice(0, targetIndex)) {
+          const sql = await readFile(
+            resolve(migrationsRoot, migrationName, 'migration.sql'),
+            'utf8',
+          );
+          await target.query(sql);
+        }
+
+        await target.query(`
+          INSERT INTO "Clinic" (
+            "id", "name", "organizationId", "timezone", "locationCode", "updatedAt"
+          ) SELECT
+            '00000000-0000-4000-8000-000000000001',
+            'Migration Clinic',
+            "id",
+            'Africa/Accra',
+            'migration-clinic',
+            CURRENT_TIMESTAMP
+          FROM "Organization"
+          WHERE "slug" = 'default';
+
+          INSERT INTO "User" (
+            "id", "keycloakSub", "displayName", "firstName", "lastName", "updatedAt"
+          ) VALUES (
+            '00000000-0000-4000-8000-000000000002',
+            'migration-user',
+            'Migration User',
+            'Migration',
+            'User',
+            CURRENT_TIMESTAMP
+          );
+
+          INSERT INTO "Patient" (
+            "id", "patientCode", "primaryClinicId", "firstName", "lastName",
+            "nationalIdType", "nationalIdCiphertext", "nationalIdHash", "updatedAt"
+          ) VALUES (
+            '00000000-0000-4000-8000-000000000003',
+            'NKP-MIGRATION-1',
+            '00000000-0000-4000-8000-000000000001',
+            'Legacy',
+            'Patient',
+            'OTHER',
+            'encrypted',
+            'migration-hash',
+            CURRENT_TIMESTAMP
+          );
+
+          INSERT INTO "Encounter" (
+            "id", "clinicId", "patientId", "createdByUserId", "updatedAt"
+          ) VALUES (
+            '00000000-0000-4000-8000-000000000004',
+            '00000000-0000-4000-8000-000000000001',
+            '00000000-0000-4000-8000-000000000003',
+            '00000000-0000-4000-8000-000000000002',
+            CURRENT_TIMESTAMP
+          );
+
+          INSERT INTO "Vitals" (
+            "id", "clinicId", "encounterId", "systolicBp", "heartRate", "bmi", "updatedAt"
+          ) VALUES (
+            '00000000-0000-4000-8000-000000000005',
+            '00000000-0000-4000-8000-000000000001',
+            '00000000-0000-4000-8000-000000000004',
+            120,
+            72,
+            -1,
+            CURRENT_TIMESTAMP
+          );
+        `);
+
+        const migrationSql = await readFile(
+          resolve(migrationsRoot, TARGET_MIGRATION, 'migration.sql'),
+          'utf8',
+        );
+        await target.query(migrationSql);
+
+        const preserved = await target.query<{ pulseBpm: number }>(
+          `SELECT "pulseBpm" FROM "Vitals" WHERE "id" = $1`,
+          ['00000000-0000-4000-8000-000000000005'],
+        );
+        expect(preserved.rows).toEqual([{ pulseBpm: 72 }]);
+
+        await target.query(`
+          INSERT INTO "Encounter" (
+            "id", "clinicId", "patientId", "createdByUserId", "updatedAt"
+          ) VALUES (
+            '00000000-0000-4000-8000-000000000006',
+            '00000000-0000-4000-8000-000000000001',
+            '00000000-0000-4000-8000-000000000003',
+            '00000000-0000-4000-8000-000000000002',
+            CURRENT_TIMESTAMP
+          );
+        `);
+        await expect(
+          target.query(`
+            INSERT INTO "Vitals" (
+              "id", "clinicId", "encounterId", "pulseBpm", "updatedAt"
+            ) VALUES (
+              '00000000-0000-4000-8000-000000000007',
+              '00000000-0000-4000-8000-000000000001',
+              '00000000-0000-4000-8000-000000000006',
+              10,
+              CURRENT_TIMESTAMP
+            );
+          `),
+        ).rejects.toMatchObject({ code: '23514' });
+      } finally {
+        await target.end().catch(() => undefined);
+      }
+    } finally {
+      await admin.query(
+        `SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1`,
+        [database],
+      );
+      await admin.query(`DROP DATABASE IF EXISTS "${database}"`);
+      await admin.end();
+    }
+  });
+});

--- a/packages/db/src/vitals-migration.spec.ts
+++ b/packages/db/src/vitals-migration.spec.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('expanded vitals and tobacco screening migration', () => {
+  const migration = readFileSync(
+    resolve(
+      __dirname,
+      '../prisma/migrations/20260811000000_expand_vitals_and_tobacco_screening/migration.sql',
+    ),
+    'utf8',
+  );
+
+  it('preserves legacy pulse data by renaming the existing column', () => {
+    expect(migration).toContain('ALTER TABLE "Vitals" RENAME COLUMN "heartRate" TO "pulseBpm"');
+    expect(migration).not.toContain('DROP COLUMN "heartRate"');
+  });
+
+  it('adds canonical measurement constraints and structured tobacco storage', () => {
+    expect(migration).toContain('"Vitals_blood_pressure_pair_check"');
+    expect(migration).toContain('"Vitals_temperature_check"');
+    expect(migration).toContain('CREATE TABLE "TobaccoScreening"');
+    expect(migration).toContain('"TobaccoScreening_review_pair_check"');
+  });
+
+  it('enforces clinic ownership through foreign keys and RLS', () => {
+    expect(migration).toContain('ALTER TABLE "TobaccoScreening" ENABLE ROW LEVEL SECURITY');
+    expect(migration).toContain('"TobaccoScreening_clinic_scope_policy"');
+    expect(migration).toContain('e."clinicId" = "clinicId"');
+  });
+});

--- a/packages/db/src/vitals-migration.spec.ts
+++ b/packages/db/src/vitals-migration.spec.ts
@@ -15,6 +15,12 @@ describe('expanded vitals and tobacco screening migration', () => {
     expect(migration).not.toContain('DROP COLUMN "heartRate"');
   });
 
+  it('keeps populated legacy rows readable while enforcing checks on new writes', () => {
+    const vitalsChecks = migration.match(/ADD CONSTRAINT "Vitals_[^"]+" CHECK[\s\S]*?NOT VALID/g);
+
+    expect(vitalsChecks).toHaveLength(11);
+  });
+
   it('adds canonical measurement constraints and structured tobacco storage', () => {
     expect(migration).toContain('"Vitals_blood_pressure_pair_check"');
     expect(migration).toContain('"Vitals_temperature_check"');


### PR DESCRIPTION
## Summary

Closes #58.

This PR expands encounter vitals and tobacco screening across database storage, validated sync contracts, offline workflows, encounter UI, patient trends, clinic dashboards, finalized records, and research exports.

It preserves existing vitals while introducing canonical measurement storage, server-authoritative BMI and temperature conversion, structured tobacco screening, clinic isolation, finalized-record protection, and resilient offline replay.

## What changed

### Database and migration

- Expanded `Vitals` with:
  - blood-pressure measurement site
  - patient position
  - cuff size
  - pulse in bpm
  - canonical Celsius temperature and measurement source
  - respiratory rate
  - SpO₂ percentage
  - bounded `OTHER` details
- Renamed legacy `heartRate` storage to `pulseBpm` while preserving populated rows.
- Added one-to-one `TobaccoScreening` storage with:
  - smoking status
  - smokeless tobacco status
  - passive exposure
  - readiness to quit
  - counseling documentation
  - server-derived reviewer and review timestamp
- Added foreign keys, indexes, range checks, paired-field checks, reviewer consistency checks, and clinic-scoped RLS.
- Marked new vitals checks `NOT VALID` so existing historical rows remain readable while new and updated records are constrained.
- Added an isolated CI migration test that:
  - creates the pre-issue schema
  - inserts a populated legacy vitals row
  - applies the new migration
  - verifies pulse preservation
  - verifies invalid new writes are rejected

### API and sync

- Added the versioned `encounter_vitals_bundle` mutation.
- Retained legacy `vitals` mutations through the same normalization service.
- Added nested DTO validation with field-level errors for:
  - invalid enum values
  - partial or incorrectly ordered blood pressure
  - measurement ranges
  - missing temperature unit or source
  - invalid `OTHER` detail usage
  - oversized notes
- Added Fahrenheit-to-Celsius conversion with canonical rounding.
- Made BMI server-authoritative and derived exclusively from canonical kilograms and centimeters.
- Accepted deprecated `heartRate` and client BMI inputs for compatibility without treating them as authoritative.
- Applied vitals, tobacco screening, audit events, and idempotency state transactionally.
- Added server-side enforcement for:
  - `SCREENING.WRITE`
  - active-clinic ownership
  - finalized encounter conflicts
  - clinic-scoped vitals deletion
- Added explicit tobacco review behavior.
- Editing tobacco answers invalidates stale review metadata.
- Added replay and concurrent-sync protection through idempotency and per-clinic sync coalescing.
- Finalized encounter reads include all expanded measurements and tobacco screening context.

### Offline and encounter UI

- Upgraded Dexie to v4.
- Added typed tobacco screening storage.
- Migrated cached `heartRate` values to `pulseBpm`.
- Save vitals, tobacco screening, and one outbox bundle atomically in one Dexie transaction.
- Automatically replay queued mutations after reconnecting.
- Added clear synced, queued, review-pending, and validation feedback.
- Rebuilt the Vitals tab into scan-friendly sections:
  - Blood Pressure
  - Other Measurements
  - Anthropometrics
  - Tobacco Use
  - Notes
- Added:
  - explicit units
  - Celsius/Fahrenheit input selection
  - computed BMI preview
  - structured tobacco choices that distinguish `NOT_ASSESSED` from negative responses
  - explicit tobacco review
  - accessible labels and validation states
  - keyboard-safe ordering
  - minimum 44 px controls
- Reused the same measurement composition across both encounter routes.
- Finalized encounters and users without write permission receive the complete read-only view.
- Verified no horizontal overflow at 375, 768, 1024, and 1440 px.

### Trends and dashboards

- Expanded staff-only patient trends with:
  - temperature
  - respiratory rate
  - SpO₂
  - weight
  - BMI
- Added latest-value cards and a compact measurement selector.
- Patient self-service endpoints do not expose the new clinical measurements.
- Added clinic-scoped rolling 30-day metrics:
  - vitals capture rate
  - tobacco assessment rate
  - counseling-documentation rate
  - pending tobacco reviews
  - temperature, respiratory-rate, SpO₂, and BMI counts and averages
  - smoking-status distribution
  - sample-size and time-window labels
- Clinical aggregates are available to applicable clinic workflow dashboards and are not added to cross-clinic system-admin summaries.
- Metrics remain descriptive and provide no automated diagnosis or classification.

### Research exports

- Bumped the research dataset version to v3.
- Expanded canonical vitals export columns.
- Added `research_clinical_tobacco.csv`.
- Exported tobacco review state and rounded review time.
- Reviewer identity is never exported.
- Updated manifest, header, hash, row-count, and de-identification tests.

### Security and dependency maintenance

- Added authorization, clinic-isolation, finalized-record, and scoped-delete coverage.
- Patched transitive `fast-uri`, `nanoid`, and `js-yaml` advisories.
- The complete workspace dependency audit now reports zero vulnerabilities.
- No private reference screenshots are included.

## Migration and compatibility notes

- Apply Prisma migration:
  - `20260811000000_expand_vitals_and_tobacco_screening`
- Existing `Vitals.heartRate` data is preserved as `pulseBpm`.
- Legacy `heartRate` remains accepted and returned as a temporary compatibility alias.
- Legacy client BMI is accepted but ignored as authoritative.
- Research dataset consumers must update to dataset version 3 and handle the new tobacco CSV.
- Offline clients migrate cached vitals automatically when Dexie opens version 4.

## Verification

- Prisma migration deployment: passed
- Isolated legacy migration integration test: passed
- API unit tests: 255 passed
- Web unit tests: 43 passed
- Database unit tests: 17 passed
- Full Playwright E2E suite: 13 passed
- Production API build: passed
- Production web build: passed
- Database package build: passed
- All workspace lint checks: passed
- All workspace typechecks: passed
- Prettier check: passed
- Keycloak realm validation: passed
- Secret scan: passed
- Dependency audit: zero vulnerabilities
- Responsive and keyboard QA: passed at 375, 768, 1024, and 1440 px