### PR TITLE
Clinical records/promote diabetes screening to a dedicated tab

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,12 @@ jobs:
           RUN_MIGRATION_TESTS: '1'
           DATABASE_URL: ${{ env.DATABASE_URL }}
 
+      - name: Verify diabetes screening migration compatibility
+        run: npm run test --workspace=@nkwapa/db -- --runInBand src/diabetes-migration.integration.spec.ts
+        env:
+          RUN_DIABETES_MIGRATION_TESTS: '1'
+          DATABASE_URL: ${{ env.DATABASE_URL }}
+
       - name: Run tests with coverage
         run: npm run test --workspaces --if-present -- --coverage --ci
         env:

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -25,6 +25,7 @@ import { SecurityHeadersMiddleware } from './common/security-headers.middleware'
 import { RateLimitGuard } from './common/rate-limit.guard';
 import { MedicalHistoryModule } from './medical-history/medical-history.module';
 import { MedicationReconciliationModule } from './medication-reconciliation/medication-reconciliation.module';
+import { DiabetesScreeningModule } from './diabetes-screening/diabetes-screening.module';
 
 const REDIS_URL = process.env.REDIS_URL ?? 'redis://localhost:6379';
 
@@ -54,6 +55,7 @@ const REDIS_URL = process.env.REDIS_URL ?? 'redis://localhost:6379';
     ChatModule,
     MedicalHistoryModule,
     MedicationReconciliationModule,
+    DiabetesScreeningModule,
   ],
   providers: [RateLimitGuard],
 })

--- a/apps/api/src/dashboard/dashboard.service.spec.ts
+++ b/apps/api/src/dashboard/dashboard.service.spec.ts
@@ -1,6 +1,16 @@
-import { DashboardService } from './dashboard.service';
+import { DashboardService, FLAGGED_DIABETES_WHERE } from './dashboard.service';
 
 describe('DashboardService clinical measurement metrics', () => {
+  it('keeps approved fasting and random flag thresholds and excludes unknown context', () => {
+    expect(FLAGGED_DIABETES_WHERE).toEqual({
+      OR: [
+        { glucoseType: 'FASTING', glucoseMgDl: { gte: 126 } },
+        { glucoseType: 'RANDOM', glucoseMgDl: { gte: 200 } },
+      ],
+    });
+    expect(JSON.stringify(FLAGGED_DIABETES_WHERE)).not.toContain('UNKNOWN');
+  });
+
   it('computes clinic-scoped 30-day coverage and descriptive averages', async () => {
     const prisma = {
       encounter: { count: jest.fn().mockResolvedValue(10) },

--- a/apps/api/src/dashboard/dashboard.service.ts
+++ b/apps/api/src/dashboard/dashboard.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
+import { Prisma } from '@prisma/client';
 import type {
   DashboardResponse,
   DashboardSummary,
@@ -14,6 +15,13 @@ import type {
   ClinicComparisonRow,
   ClinicalMeasurementMetrics,
 } from './dto/dashboard-response.dto';
+
+export const FLAGGED_DIABETES_WHERE = {
+  OR: [
+    { glucoseType: 'FASTING', glucoseMgDl: { gte: 126 } },
+    { glucoseType: 'RANDOM', glucoseMgDl: { gte: 200 } },
+  ],
+} satisfies Prisma.DiabetesScreeningWhereInput;
 
 @Injectable()
 export class DashboardService {
@@ -144,10 +152,7 @@ export class DashboardService {
       this.prisma.diabetesScreening.count({
         where: {
           clinicId,
-          OR: [
-            { glucoseType: 'FASTING', glucoseMgDl: { gte: 126 } },
-            { glucoseType: 'RANDOM', glucoseMgDl: { gte: 200 } },
-          ],
+          ...FLAGGED_DIABETES_WHERE,
         },
       }),
       this.prisma.diabetesScreening.count({ where: { clinicId } }),
@@ -454,10 +459,7 @@ export class DashboardService {
         where: {
           clinicId,
           encounter: { createdByUserId: userId },
-          OR: [
-            { glucoseType: 'FASTING', glucoseMgDl: { gte: 126 } },
-            { glucoseType: 'RANDOM', glucoseMgDl: { gte: 200 } },
-          ],
+          ...FLAGGED_DIABETES_WHERE,
         },
       }),
       this.prisma.diabetesScreening.count({

--- a/apps/api/src/diabetes-screening/diabetes-screening.controller.ts
+++ b/apps/api/src/diabetes-screening/diabetes-screening.controller.ts
@@ -1,0 +1,64 @@
+import { Body, Controller, Get, Param, Put, Query, Request, UseGuards } from '@nestjs/common';
+import type { UserRole } from '@prisma/client';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RequirePermission } from '../auth/decorators/require-permission.decorator';
+import { ClinicScoped } from '../auth/decorators/clinic-scoped.decorator';
+import { ClinicScopeGuard } from '../auth/guards/clinic-scope.guard';
+import { RbacGuard } from '../auth/guards/rbac.guard';
+import { PERMISSIONS } from '../auth/constants/permissions';
+import {
+  ClinicAndEncounterParamsDto,
+  ClinicAndPatientParamsDto,
+  CursorLimitQueryDto,
+} from '../common/request-dto';
+import { DiabetesScreeningService } from './diabetes-screening.service';
+import { UpsertDiabetesScreeningDto } from './dto/diabetes-screening.dto';
+
+type DiabetesRequest = {
+  user: { user: { id: string }; roles: Array<{ role: UserRole }> };
+  headers?: { 'x-request-id'?: string; 'user-agent'?: string };
+  ip?: string;
+};
+
+@Controller('clinics/:clinicId')
+@UseGuards(JwtAuthGuard, ClinicScopeGuard, RbacGuard)
+export class DiabetesScreeningController {
+  constructor(private readonly diabetesScreeningService: DiabetesScreeningService) {}
+
+  @Get('patients/:patientId/diabetes-screenings')
+  @ClinicScoped({ type: 'param', paramKey: 'clinicId' })
+  @RequirePermission(PERMISSIONS.SCREENING_READ)
+  list(
+    @Param() params: ClinicAndPatientParamsDto,
+    @Query() query: CursorLimitQueryDto,
+    @Request() request: DiabetesRequest,
+  ) {
+    return this.diabetesScreeningService.list(
+      params.clinicId,
+      params.patientId,
+      { userId: request.user.user.id, roles: request.user.roles },
+      query,
+    );
+  }
+
+  @Put('encounters/:encounterId/diabetes-screening')
+  @ClinicScoped({ type: 'param', paramKey: 'clinicId' })
+  @RequirePermission(PERMISSIONS.SCREENING_WRITE)
+  upsert(
+    @Param() params: ClinicAndEncounterParamsDto,
+    @Body() dto: UpsertDiabetesScreeningDto,
+    @Request() request: DiabetesRequest,
+  ) {
+    return this.diabetesScreeningService.upsert(
+      params.clinicId,
+      params.encounterId,
+      { userId: request.user.user.id, roles: request.user.roles },
+      dto,
+      {
+        requestId: request.headers?.['x-request-id'],
+        userAgent: request.headers?.['user-agent'],
+        ipAddress: request.ip,
+      },
+    );
+  }
+}

--- a/apps/api/src/diabetes-screening/diabetes-screening.module.ts
+++ b/apps/api/src/diabetes-screening/diabetes-screening.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
+import { DiabetesScreeningController } from './diabetes-screening.controller';
+import { DiabetesScreeningService } from './diabetes-screening.service';
+
+@Module({
+  imports: [AuthModule],
+  controllers: [DiabetesScreeningController],
+  providers: [DiabetesScreeningService],
+  exports: [DiabetesScreeningService],
+})
+export class DiabetesScreeningModule {}

--- a/apps/api/src/diabetes-screening/diabetes-screening.service.spec.ts
+++ b/apps/api/src/diabetes-screening/diabetes-screening.service.spec.ts
@@ -1,0 +1,163 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { DiabetesScreeningService } from './diabetes-screening.service';
+
+const doctor = { userId: 'user-1', roles: [{ role: 'DOCTOR' }] } as never;
+const director = { userId: 'director-1', roles: [{ role: 'DIRECTOR' }] } as never;
+
+const dto = {
+  glucoseMgDl: 126,
+  glucoseType: 'FASTING',
+  hba1cPercent: 6.4,
+  symptoms: ['POLYURIA'],
+  notes: 'Clinical note',
+  collectedAt: '2026-08-12T12:00:00.000Z',
+};
+
+function saved(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'screening-1',
+    clinicId: 'clinic-1',
+    encounterId: 'encounter-1',
+    glucoseMgDl: 126,
+    glucoseType: 'FASTING',
+    hba1cPercent: 6.4,
+    symptoms: ['POLYURIA'],
+    symptomsJson: null,
+    legacySymptomsUnmapped: false,
+    notes: 'Clinical note',
+    collectedAt: new Date('2026-08-12T12:00:00.000Z'),
+    authoredByUserId: 'user-1',
+    authoredBy: { id: 'user-1', displayName: 'Dr Example' },
+    encounter: {
+      id: 'encounter-1',
+      patientId: 'patient-1',
+      createdAt: new Date('2026-08-12T11:00:00.000Z'),
+      status: 'DRAFT',
+    },
+    createdAt: new Date('2026-08-12T12:00:00.000Z'),
+    updatedAt: new Date('2026-08-12T12:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('DiabetesScreeningService', () => {
+  function setup(encounter = { clinicId: 'clinic-1', patientId: 'patient-1', status: 'DRAFT' }) {
+    const tx = {
+      encounter: { findUnique: jest.fn().mockResolvedValue(encounter) },
+      diabetesScreening: {
+        findUnique: jest.fn().mockResolvedValue(null),
+        upsert: jest.fn().mockResolvedValue(saved()),
+      },
+      auditEvent: { create: jest.fn().mockResolvedValue({}) },
+    };
+    const prisma = {
+      $transaction: jest.fn((callback: (client: typeof tx) => unknown) => callback(tx)),
+      patient: { findFirst: jest.fn().mockResolvedValue({ id: 'patient-1' }) },
+      diabetesScreening: { findMany: jest.fn().mockResolvedValue([saved()]) },
+    };
+    return { service: new DiabetesScreeningService(prisma as never), prisma, tx };
+  }
+
+  it('creates a scoped screening with server-controlled author and audit metadata', async () => {
+    const { service, tx } = setup();
+    const result = await service.upsert('clinic-1', 'encounter-1', doctor, dto as never, {
+      requestId: 'request-1',
+    });
+
+    expect(tx.diabetesScreening.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          clinicId: 'clinic-1',
+          encounterId: 'encounter-1',
+          authoredByUserId: 'user-1',
+          symptoms: ['POLYURIA'],
+        }),
+      }),
+    );
+    expect(tx.auditEvent.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        action: 'DIABETES_SCREENING.CREATE',
+        requestId: 'request-1',
+      }),
+    });
+    expect(result).toMatchObject({
+      author: { id: 'user-1', displayName: 'Dr Example' },
+      sourceEncounter: { id: 'encounter-1', status: 'DRAFT' },
+      isEditable: true,
+    });
+  });
+
+  it('preserves explicit nulls and the existing id on update', async () => {
+    const { service, tx } = setup();
+    tx.diabetesScreening.findUnique.mockResolvedValue(saved());
+    await service.upsert(
+      'clinic-1',
+      'encounter-1',
+      doctor,
+      { ...dto, glucoseMgDl: null, hba1cPercent: null, notes: null, symptoms: [] } as never,
+      {},
+      'different-client-id',
+    );
+
+    expect(tx.diabetesScreening.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          glucoseMgDl: null,
+          hba1cPercent: null,
+          notes: null,
+          symptoms: [],
+          legacySymptomsUnmapped: false,
+        }),
+      }),
+    );
+  });
+
+  it('rejects writes without screening permission', async () => {
+    const { service, tx } = setup();
+    await expect(
+      service.upsert('clinic-1', 'encounter-1', director, dto as never),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(tx.diabetesScreening.upsert).not.toHaveBeenCalled();
+  });
+
+  it('rejects cross-clinic and finalized encounter writes', async () => {
+    const crossClinic = setup({ clinicId: 'clinic-2', patientId: 'patient-1', status: 'DRAFT' });
+    await expect(
+      crossClinic.service.upsert('clinic-1', 'encounter-1', doctor, dto as never),
+    ).rejects.toBeInstanceOf(NotFoundException);
+
+    const finalized = setup({ clinicId: 'clinic-1', patientId: 'patient-1', status: 'FINALIZED' });
+    await expect(
+      finalized.service.upsert('clinic-1', 'encounter-1', doctor, dto as never),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('rejects collection times more than five minutes in the future', async () => {
+    const { service } = setup();
+    await expect(
+      service.upsert('clinic-1', 'encounter-1', doctor, {
+        ...dto,
+        collectedAt: new Date(Date.now() + 6 * 60 * 1000).toISOString(),
+      } as never),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('lists newest records with source context and read-only status for directors', async () => {
+    const { service, prisma } = setup();
+    const response = await service.list('clinic-1', 'patient-1', director, { limit: 25 });
+
+    expect(prisma.patient.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ primaryClinicId: 'clinic-1' }) }),
+    );
+    expect(response.items[0]).toMatchObject({
+      id: 'screening-1',
+      patientId: 'patient-1',
+      isEditable: false,
+    });
+  });
+});

--- a/apps/api/src/diabetes-screening/diabetes-screening.service.spec.ts
+++ b/apps/api/src/diabetes-screening/diabetes-screening.service.spec.ts
@@ -54,6 +54,7 @@ describe('DiabetesScreeningService', () => {
         upsert: jest.fn().mockResolvedValue(saved()),
       },
       auditEvent: { create: jest.fn().mockResolvedValue({}) },
+      syncMutation: { create: jest.fn().mockResolvedValue({}) },
     };
     const prisma = {
       $transaction: jest.fn((callback: (client: typeof tx) => unknown) => callback(tx)),
@@ -115,6 +116,57 @@ describe('DiabetesScreeningService', () => {
         }),
       }),
     );
+  });
+
+  it('normalizes deprecated symptoms JSON and rejects ambiguous contracts', async () => {
+    const { service } = setup();
+    await expect(
+      service.validateSyncPayload(
+        {
+          glucoseMgDl: 145,
+          glucoseType: 'RANDOM',
+          hba1cPercent: null,
+          symptomsJson: '["Polydipsia","Other"]',
+          notes: null,
+        },
+        '2026-08-12T12:00:00.000Z',
+      ),
+    ).resolves.toMatchObject({
+      dto: { symptoms: ['POLYDIPSIA'], collectedAt: '2026-08-12T12:00:00.000Z' },
+      compatibility: {
+        symptomsJson: '["Polydipsia","Other"]',
+        legacySymptomsUnmapped: true,
+      },
+    });
+
+    await expect(
+      service.validateSyncPayload(
+        { symptoms: ['FATIGUE'], symptomsJson: '["Fatigue"]' },
+        '2026-08-12T12:00:00.000Z',
+      ),
+    ).rejects.toMatchObject({
+      response: expect.objectContaining({ code: 'AMBIGUOUS_SYMPTOMS_CONTRACT' }),
+    });
+  });
+
+  it('records sync idempotency in the same transaction as the screening', async () => {
+    const { service, tx } = setup();
+    await service.upsert('clinic-1', 'encounter-1', doctor, dto as never, {
+      requestId: 'sync-idempotency-1',
+      syncMutation: {
+        entityType: 'diabetes_screening',
+        entityId: 'screening-1',
+        idempotencyKey: 'sync-idempotency-1',
+      },
+    });
+
+    expect(tx.syncMutation.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        entityType: 'diabetes_screening',
+        idempotencyKey: 'sync-idempotency-1',
+        status: 'APPLIED',
+      }),
+    });
   });
 
   it('rejects writes without screening permission', async () => {

--- a/apps/api/src/diabetes-screening/diabetes-screening.service.ts
+++ b/apps/api/src/diabetes-screening/diabetes-screening.service.ts
@@ -7,6 +7,9 @@ import {
 } from '@nestjs/common';
 import { EncounterStatus, Prisma, type UserRole } from '@prisma/client';
 import { randomUUID } from 'node:crypto';
+import { plainToInstance } from 'class-transformer';
+import { validate, type ValidationError } from 'class-validator';
+import { parseLegacyDiabetesSymptoms } from '@nkwapa/db';
 import { hasPermission, PERMISSIONS } from '../auth/constants/permissions';
 import { PrismaService } from '../prisma/prisma.service';
 import { UpsertDiabetesScreeningDto } from './dto/diabetes-screening.dto';
@@ -30,6 +33,16 @@ export interface DiabetesRequestMetadata {
   requestId?: string;
   ipAddress?: string;
   userAgent?: string;
+  syncMutation?: {
+    entityType: string;
+    entityId: string;
+    idempotencyKey: string;
+  };
+}
+
+export interface DiabetesCompatibilityInput {
+  symptomsJson?: string | null;
+  legacySymptomsUnmapped?: boolean;
 }
 
 @Injectable()
@@ -81,6 +94,7 @@ export class DiabetesScreeningService {
     dto: UpsertDiabetesScreeningDto,
     metadata: DiabetesRequestMetadata = {},
     screeningId?: string,
+    compatibility: DiabetesCompatibilityInput = {},
   ) {
     this.assertWritePermission(actor.roles);
     const collectedAt = this.validateCollectionTime(dto.collectedAt);
@@ -112,6 +126,8 @@ export class DiabetesScreeningService {
           glucoseType: dto.glucoseType,
           hba1cPercent: dto.hba1cPercent,
           symptoms: dto.symptoms,
+          symptomsJson: compatibility.symptomsJson ?? null,
+          legacySymptomsUnmapped: compatibility.legacySymptomsUnmapped ?? false,
           notes: dto.notes,
           collectedAt,
           authoredByUserId: actor.userId,
@@ -124,7 +140,10 @@ export class DiabetesScreeningService {
           notes: dto.notes,
           collectedAt,
           authoredByUserId: actor.userId,
-          legacySymptomsUnmapped: false,
+          legacySymptomsUnmapped: compatibility.legacySymptomsUnmapped ?? false,
+          ...(compatibility.symptomsJson !== undefined
+            ? { symptomsJson: compatibility.symptomsJson }
+            : {}),
         },
         include: this.contextInclude(),
       });
@@ -143,10 +162,68 @@ export class DiabetesScreeningService {
           userAgent: metadata.userAgent,
         },
       });
+      if (metadata.syncMutation) {
+        await tx.syncMutation.create({
+          data: {
+            clinicId,
+            entityType: metadata.syncMutation.entityType,
+            entityId: metadata.syncMutation.entityId,
+            operation: 'UPSERT',
+            idempotencyKey: metadata.syncMutation.idempotencyKey,
+            status: 'APPLIED',
+          },
+        });
+      }
       return saved;
     });
 
     return this.toResponse(screening, actor.roles);
+  }
+
+  async validateSyncPayload(payload: Record<string, unknown>, fallbackCollectedAt: string) {
+    const hasStructuredSymptoms = Object.prototype.hasOwnProperty.call(payload, 'symptoms');
+    const hasLegacySymptoms = Object.prototype.hasOwnProperty.call(payload, 'symptomsJson');
+    if (hasStructuredSymptoms && hasLegacySymptoms) {
+      throw new BadRequestException({
+        code: 'AMBIGUOUS_SYMPTOMS_CONTRACT',
+        message: 'Provide symptoms or the deprecated symptomsJson field, not both.',
+      });
+    }
+
+    const legacy = hasLegacySymptoms
+      ? parseLegacyDiabetesSymptoms(payload.symptomsJson)
+      : { symptoms: [], hasUnmapped: false };
+    const candidate = {
+      glucoseMgDl: payload.glucoseMgDl ?? null,
+      glucoseType: payload.glucoseType ?? 'UNKNOWN',
+      hba1cPercent: payload.hba1cPercent ?? null,
+      symptoms: hasStructuredSymptoms ? payload.symptoms : legacy.symptoms,
+      notes: payload.notes ?? null,
+      collectedAt: payload.collectedAt ?? fallbackCollectedAt,
+    };
+    const dto = plainToInstance(UpsertDiabetesScreeningDto, candidate);
+    const errors = await validate(dto, {
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      forbidUnknownValues: true,
+    });
+    if (errors.length) {
+      throw new BadRequestException({
+        code: 'VALIDATION_ERROR',
+        message: 'Diabetes screening validation failed.',
+        fieldErrors: this.flattenValidationErrors(errors),
+      });
+    }
+    this.validateCollectionTime(dto.collectedAt);
+    return {
+      dto,
+      compatibility: hasLegacySymptoms
+        ? {
+            symptomsJson: typeof payload.symptomsJson === 'string' ? payload.symptomsJson : null,
+            legacySymptomsUnmapped: legacy.hasUnmapped,
+          }
+        : {},
+    };
   }
 
   toResponse(record: DiabetesWithContext, roles: Array<{ role: UserRole }>) {
@@ -190,6 +267,19 @@ export class DiabetesScreeningService {
       });
     }
     return collectedAt;
+  }
+
+  private flattenValidationErrors(
+    errors: ValidationError[],
+    parentPath?: string,
+  ): Array<{ field: string; message: string }> {
+    return errors.flatMap((error) => {
+      const field = parentPath ? `${parentPath}.${error.property}` : error.property;
+      const own = error.constraints
+        ? Object.values(error.constraints).map((message) => ({ field, message }))
+        : [];
+      return [...own, ...this.flattenValidationErrors(error.children ?? [], field)];
+    });
   }
 
   private async assertPatientScope(clinicId: string, patientId: string): Promise<void> {

--- a/apps/api/src/diabetes-screening/diabetes-screening.service.ts
+++ b/apps/api/src/diabetes-screening/diabetes-screening.service.ts
@@ -1,0 +1,241 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { EncounterStatus, Prisma, type UserRole } from '@prisma/client';
+import { randomUUID } from 'node:crypto';
+import { hasPermission, PERMISSIONS } from '../auth/constants/permissions';
+import { PrismaService } from '../prisma/prisma.service';
+import { UpsertDiabetesScreeningDto } from './dto/diabetes-screening.dto';
+
+const MAX_FUTURE_COLLECTION_SKEW_MS = 5 * 60 * 1000;
+const DEFAULT_PAGE_SIZE = 25;
+
+type DiabetesWithContext = Prisma.DiabetesScreeningGetPayload<{
+  include: {
+    authoredBy: { select: { id: true; displayName: true } };
+    encounter: { select: { id: true; patientId: true; createdAt: true; status: true } };
+  };
+}>;
+
+export interface DiabetesActor {
+  userId: string;
+  roles: Array<{ role: UserRole }>;
+}
+
+export interface DiabetesRequestMetadata {
+  requestId?: string;
+  ipAddress?: string;
+  userAgent?: string;
+}
+
+@Injectable()
+export class DiabetesScreeningService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async list(
+    clinicId: string,
+    patientId: string,
+    actor: DiabetesActor,
+    params: { cursor?: string; limit?: number } = {},
+  ) {
+    this.assertReadPermission(actor.roles);
+    await this.assertPatientScope(clinicId, patientId);
+
+    const cursor = params.cursor ? this.decodeCursor(params.cursor) : null;
+    const limit = params.limit ?? DEFAULT_PAGE_SIZE;
+    const records = await this.prisma.diabetesScreening.findMany({
+      where: {
+        clinicId,
+        encounter: { patientId },
+        ...(cursor
+          ? {
+              OR: [
+                { collectedAt: { lt: cursor.collectedAt } },
+                { collectedAt: cursor.collectedAt, id: { lt: cursor.id } },
+              ],
+            }
+          : {}),
+      },
+      include: this.contextInclude(),
+      orderBy: [{ collectedAt: 'desc' }, { id: 'desc' }],
+      take: limit + 1,
+    });
+
+    const hasMore = records.length > limit;
+    const items = records.slice(0, limit).map((record) => this.toResponse(record, actor.roles));
+    const last = items.at(-1);
+    return {
+      items,
+      nextCursor: hasMore && last ? this.encodeCursor(new Date(last.collectedAt), last.id) : null,
+    };
+  }
+
+  async upsert(
+    clinicId: string,
+    encounterId: string,
+    actor: DiabetesActor,
+    dto: UpsertDiabetesScreeningDto,
+    metadata: DiabetesRequestMetadata = {},
+    screeningId?: string,
+  ) {
+    this.assertWritePermission(actor.roles);
+    const collectedAt = this.validateCollectionTime(dto.collectedAt);
+
+    const screening = await this.prisma.$transaction(async (tx) => {
+      const encounter = await tx.encounter.findUnique({
+        where: { id: encounterId },
+        select: { clinicId: true, patientId: true, status: true },
+      });
+      if (!encounter || encounter.clinicId !== clinicId) {
+        throw new NotFoundException('Encounter not found in the active clinic');
+      }
+      if (encounter.status === EncounterStatus.FINALIZED) {
+        throw new ConflictException({
+          code: 'CONFLICT_FINALIZED',
+          message: 'Cannot modify diabetes screening for a finalized encounter',
+          existingStatus: encounter.status,
+        });
+      }
+
+      const existing = await tx.diabetesScreening.findUnique({ where: { encounterId } });
+      const saved = await tx.diabetesScreening.upsert({
+        where: { encounterId },
+        create: {
+          id: screeningId ?? randomUUID(),
+          clinicId,
+          encounterId,
+          glucoseMgDl: dto.glucoseMgDl,
+          glucoseType: dto.glucoseType,
+          hba1cPercent: dto.hba1cPercent,
+          symptoms: dto.symptoms,
+          notes: dto.notes,
+          collectedAt,
+          authoredByUserId: actor.userId,
+        },
+        update: {
+          glucoseMgDl: dto.glucoseMgDl,
+          glucoseType: dto.glucoseType,
+          hba1cPercent: dto.hba1cPercent,
+          symptoms: dto.symptoms,
+          notes: dto.notes,
+          collectedAt,
+          authoredByUserId: actor.userId,
+          legacySymptomsUnmapped: false,
+        },
+        include: this.contextInclude(),
+      });
+
+      await tx.auditEvent.create({
+        data: {
+          clinicId,
+          actorUserId: actor.userId,
+          action: existing ? 'DIABETES_SCREENING.UPSERT' : 'DIABETES_SCREENING.CREATE',
+          entityType: 'DiabetesScreening',
+          entityId: saved.id,
+          beforeJson: existing ? JSON.stringify(existing) : undefined,
+          afterJson: JSON.stringify(saved),
+          requestId: metadata.requestId ?? randomUUID(),
+          ipAddress: metadata.ipAddress,
+          userAgent: metadata.userAgent,
+        },
+      });
+      return saved;
+    });
+
+    return this.toResponse(screening, actor.roles);
+  }
+
+  toResponse(record: DiabetesWithContext, roles: Array<{ role: UserRole }>) {
+    return {
+      id: record.id,
+      clinicId: record.clinicId,
+      patientId: record.encounter.patientId,
+      glucoseMgDl: record.glucoseMgDl,
+      glucoseType: record.glucoseType,
+      hba1cPercent: record.hba1cPercent,
+      symptoms: record.symptoms,
+      notes: record.notes,
+      collectedAt: record.collectedAt.toISOString(),
+      author: record.authoredBy,
+      sourceEncounter: {
+        id: record.encounter.id,
+        createdAt: record.encounter.createdAt.toISOString(),
+        status: record.encounter.status,
+      },
+      legacySymptomsUnmapped: record.legacySymptomsUnmapped,
+      isEditable:
+        record.encounter.status !== EncounterStatus.FINALIZED &&
+        hasPermission(roles, PERMISSIONS.SCREENING_WRITE),
+      createdAt: record.createdAt.toISOString(),
+      updatedAt: record.updatedAt.toISOString(),
+    };
+  }
+
+  private validateCollectionTime(value: string): Date {
+    const collectedAt = new Date(value);
+    if (!Number.isFinite(collectedAt.getTime())) {
+      throw new BadRequestException({
+        code: 'INVALID_COLLECTION_TIME',
+        message: 'Collection time must be a valid ISO timestamp.',
+      });
+    }
+    if (collectedAt.getTime() > Date.now() + MAX_FUTURE_COLLECTION_SKEW_MS) {
+      throw new BadRequestException({
+        code: 'COLLECTION_TIME_IN_FUTURE',
+        message: 'Collection time cannot be more than five minutes in the future.',
+      });
+    }
+    return collectedAt;
+  }
+
+  private async assertPatientScope(clinicId: string, patientId: string): Promise<void> {
+    const patient = await this.prisma.patient.findFirst({
+      where: { id: patientId, primaryClinicId: clinicId, mergedIntoPatientId: null },
+      select: { id: true },
+    });
+    if (!patient) throw new NotFoundException('Patient not found in the active clinic');
+  }
+
+  private assertReadPermission(roles: Array<{ role: UserRole }>): void {
+    if (!hasPermission(roles, PERMISSIONS.SCREENING_READ)) {
+      throw new ForbiddenException('SCREENING.READ permission is required');
+    }
+  }
+
+  private assertWritePermission(roles: Array<{ role: UserRole }>): void {
+    if (!hasPermission(roles, PERMISSIONS.SCREENING_WRITE)) {
+      throw new ForbiddenException('SCREENING.WRITE permission is required');
+    }
+  }
+
+  private contextInclude() {
+    return {
+      authoredBy: { select: { id: true, displayName: true } },
+      encounter: { select: { id: true, patientId: true, createdAt: true, status: true } },
+    } satisfies Prisma.DiabetesScreeningInclude;
+  }
+
+  private encodeCursor(collectedAt: Date, id: string): string {
+    return Buffer.from(`${collectedAt.toISOString()}|${id}`).toString('base64url');
+  }
+
+  private decodeCursor(cursor: string): { collectedAt: Date; id: string } {
+    try {
+      const decoded = Buffer.from(cursor, 'base64url').toString('utf8');
+      const separator = decoded.lastIndexOf('|');
+      const collectedAt = new Date(decoded.slice(0, separator));
+      const id = decoded.slice(separator + 1);
+      if (separator < 1 || !id || !Number.isFinite(collectedAt.getTime())) throw new Error();
+      return { collectedAt, id };
+    } catch {
+      throw new BadRequestException({
+        code: 'INVALID_CURSOR',
+        message: 'The diabetes history cursor is invalid.',
+      });
+    }
+  }
+}

--- a/apps/api/src/diabetes-screening/dto/diabetes-screening.dto.spec.ts
+++ b/apps/api/src/diabetes-screening/dto/diabetes-screening.dto.spec.ts
@@ -1,0 +1,55 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { UpsertDiabetesScreeningDto } from './diabetes-screening.dto';
+
+function validPayload() {
+  return {
+    glucoseMgDl: 126,
+    glucoseType: 'FASTING',
+    hba1cPercent: 6.4,
+    symptoms: ['POLYURIA', 'FATIGUE'],
+    notes: 'Reports symptoms',
+    collectedAt: '2026-08-12T12:00:00.000Z',
+  };
+}
+
+describe('UpsertDiabetesScreeningDto', () => {
+  it.each(['FASTING', 'RANDOM', 'UNKNOWN'])('accepts %s glucose context', async (glucoseType) => {
+    const dto = plainToInstance(UpsertDiabetesScreeningDto, { ...validPayload(), glucoseType });
+    expect(await validate(dto)).toEqual([]);
+  });
+
+  it('accepts explicit null measurements and notes', async () => {
+    const dto = plainToInstance(UpsertDiabetesScreeningDto, {
+      ...validPayload(),
+      glucoseMgDl: null,
+      hba1cPercent: null,
+      notes: null,
+    });
+    expect(await validate(dto)).toEqual([]);
+  });
+
+  it.each([
+    ['glucoseMgDl', -1],
+    ['glucoseMgDl', 601],
+    ['hba1cPercent', -0.1],
+    ['hba1cPercent', 100.1],
+    ['glucoseType', 'OTHER'],
+    ['symptoms', ['OTHER']],
+    ['symptoms', ['FATIGUE', 'FATIGUE']],
+    ['collectedAt', 'not-a-date'],
+  ])('rejects invalid %s', async (field, value) => {
+    const dto = plainToInstance(UpsertDiabetesScreeningDto, {
+      ...validPayload(),
+      [field]: value,
+    });
+    expect(await validate(dto)).not.toEqual([]);
+  });
+
+  it.each(['glucoseMgDl', 'hba1cPercent', 'notes'])('requires nullable field %s', async (field) => {
+    const payload = validPayload() as Record<string, unknown>;
+    delete payload[field];
+    expect(await validate(plainToInstance(UpsertDiabetesScreeningDto, payload))).not.toEqual([]);
+  });
+});

--- a/apps/api/src/diabetes-screening/dto/diabetes-screening.dto.ts
+++ b/apps/api/src/diabetes-screening/dto/diabetes-screening.dto.ts
@@ -1,0 +1,61 @@
+import { Type } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  ArrayUnique,
+  IsArray,
+  IsDateString,
+  IsDefined,
+  IsEnum,
+  IsInt,
+  IsNumber,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  ValidateIf,
+} from 'class-validator';
+import { DiabetesSymptom, GlucoseType } from '@prisma/client';
+import {
+  DIABETES_GLUCOSE_MAX_MG_DL,
+  DIABETES_GLUCOSE_MIN_MG_DL,
+  DIABETES_HBA1C_MAX_PERCENT,
+  DIABETES_HBA1C_MIN_PERCENT,
+} from '@nkwapa/db';
+import { ToSanitizedString } from '../../common/validation';
+
+export class UpsertDiabetesScreeningDto {
+  @IsDefined()
+  @ValidateIf((_, value) => value !== null)
+  @Type(() => Number)
+  @IsInt()
+  @Min(DIABETES_GLUCOSE_MIN_MG_DL)
+  @Max(DIABETES_GLUCOSE_MAX_MG_DL)
+  glucoseMgDl!: number | null;
+
+  @IsEnum(GlucoseType)
+  glucoseType!: GlucoseType;
+
+  @IsDefined()
+  @ValidateIf((_, value) => value !== null)
+  @Type(() => Number)
+  @IsNumber({ allowInfinity: false, allowNaN: false, maxDecimalPlaces: 2 })
+  @Min(DIABETES_HBA1C_MIN_PERCENT)
+  @Max(DIABETES_HBA1C_MAX_PERCENT)
+  hba1cPercent!: number | null;
+
+  @IsArray()
+  @ArrayUnique()
+  @ArrayMaxSize(5)
+  @IsEnum(DiabetesSymptom, { each: true })
+  symptoms!: DiabetesSymptom[];
+
+  @IsDefined()
+  @ValidateIf((_, value) => value !== null)
+  @ToSanitizedString({ maxLength: 2000, preserveNewlines: true })
+  @IsString()
+  @MaxLength(2000)
+  notes!: string | null;
+
+  @IsDateString({ strict: true })
+  collectedAt!: string;
+}

--- a/apps/api/src/encounters/encounter.service.ts
+++ b/apps/api/src/encounters/encounter.service.ts
@@ -61,7 +61,9 @@ export class EncounterService {
           tobaccoScreening: {
             include: { reviewedBy: { select: { id: true, displayName: true } } },
           },
-          diabetesScreening: true,
+          diabetesScreening: {
+            include: { authoredBy: { select: { id: true, displayName: true } } },
+          },
           hypertensionAssessment: true,
           carePlan: true,
         }

--- a/apps/api/src/patient-portal/patient-portal.service.spec.ts
+++ b/apps/api/src/patient-portal/patient-portal.service.spec.ts
@@ -39,6 +39,9 @@ function createPrismaMock() {
       findFirst: jest.fn(),
       findMany: jest.fn(),
     },
+    diabetesScreening: {
+      findMany: jest.fn(),
+    },
     reminder: {
       findMany: jest.fn(),
       update: jest.fn(),
@@ -155,6 +158,7 @@ describe('PatientPortalService', () => {
     prisma.patientAccountLink.findFirst.mockResolvedValue({ patient: portalPatient });
     prisma.encounter.findFirst.mockResolvedValue(null);
     prisma.encounter.findMany.mockResolvedValue([]);
+    prisma.diabetesScreening.findMany.mockResolvedValue([]);
     prisma.reminder.findMany.mockResolvedValue([]);
     prisma.patient.findFirst.mockResolvedValue({ id: 'patient-1' });
     prisma.patient.findUnique.mockResolvedValue({
@@ -429,7 +433,13 @@ describe('PatientPortalService', () => {
       {
         createdAt: new Date('2026-03-19T08:00:00.000Z'),
         vitals: { systolicBp: 132, diastolicBp: 86 },
-        diabetesScreening: { glucoseMgDl: 201, glucoseType: 'RANDOM' },
+      },
+    ]);
+    prisma.diabetesScreening.findMany.mockResolvedValue([
+      {
+        collectedAt: new Date('2026-03-19T08:15:00.000Z'),
+        glucoseMgDl: 201,
+        glucoseType: 'RANDOM',
       },
     ]);
     prisma.appointmentRequest.count.mockResolvedValueOnce(2).mockResolvedValueOnce(1);
@@ -470,6 +480,18 @@ describe('PatientPortalService', () => {
         }),
       }),
     );
+    expect(prisma.diabetesScreening.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          clinicId: 'clinic-1',
+          encounter: { patientId: 'patient-1', status: { in: ['FINALIZED'] } },
+          collectedAt: {
+            gte: new Date('2026-03-01T00:00:00.000Z'),
+            lte: new Date('2026-03-31T23:59:59.999Z'),
+          },
+        }),
+      }),
+    );
     expect(result.bp).toEqual([
       {
         t: '2026-03-19T08:00:00.000Z',
@@ -486,7 +508,7 @@ describe('PatientPortalService', () => {
     ]);
     expect(result.glucose).toEqual([
       {
-        t: '2026-03-19T08:00:00.000Z',
+        t: '2026-03-19T08:15:00.000Z',
         value: 201,
         type: 'RANDOM',
         source: 'ENCOUNTER',

--- a/apps/api/src/patient-portal/patient-portal.service.ts
+++ b/apps/api/src/patient-portal/patient-portal.service.ts
@@ -1726,6 +1726,7 @@ export class PatientPortalService {
     const [
       measurements,
       encounters,
+      diabetesScreenings,
       requested,
       confirmed,
       completed,
@@ -1762,13 +1763,15 @@ export class PatientPortalService {
               bmi: true,
             },
           },
-          diabetesScreening: {
-            select: {
-              glucoseMgDl: true,
-              glucoseType: true,
-            },
-          },
         },
+      }),
+      this.prisma.diabetesScreening.findMany({
+        where: {
+          clinicId,
+          encounter: { patientId, status: { in: encounterStatuses } },
+          ...(dateFilter ? { collectedAt: dateFilter } : {}),
+        },
+        select: { collectedAt: true, glucoseMgDl: true, glucoseType: true },
       }),
       this.prisma.appointmentRequest.count({
         where: {
@@ -1859,16 +1862,16 @@ export class PatientPortalService {
     ].sort((left, right) => new Date(left.t).getTime() - new Date(right.t).getTime());
 
     const glucose: GlucoseTrendPoint[] = [
-      ...encounters.flatMap((encounter) => {
-        if (encounter.diabetesScreening?.glucoseMgDl == null) {
+      ...diabetesScreenings.flatMap((screening) => {
+        if (screening.glucoseMgDl == null) {
           return [];
         }
 
         return [
           {
-            t: encounter.createdAt.toISOString(),
-            value: encounter.diabetesScreening.glucoseMgDl,
-            type: this.normalizeTrendGlucoseType(encounter.diabetesScreening.glucoseType),
+            t: screening.collectedAt.toISOString(),
+            value: screening.glucoseMgDl,
+            type: this.normalizeTrendGlucoseType(screening.glucoseType),
             source: 'ENCOUNTER' as const,
           },
         ];

--- a/apps/api/src/research/research-transform.service.spec.ts
+++ b/apps/api/src/research/research-transform.service.spec.ts
@@ -182,6 +182,7 @@ describe('ResearchTransformService', () => {
         },
         diabetesScreening: {
           createdAt: new Date('2026-03-18T08:38:00.000Z'),
+          collectedAt: new Date('2026-03-18T08:53:00.000Z'),
           glucoseMgDl: 96,
           glucoseType: 'FASTING',
           hba1cPercent: 5.4,
@@ -320,6 +321,9 @@ describe('ResearchTransformService', () => {
     const tobaccoCsv = result.repoFiles.find(
       (file) => file.name === 'research_clinical_tobacco.csv',
     );
+    const screeningsCsv = result.repoFiles.find(
+      (file) => file.name === 'research_clinical_screenings.csv',
+    );
 
     expect(result.recordCount).toBeGreaterThan(0);
     expect(result.manifest.datasetVersion).toBe(3);
@@ -332,6 +336,7 @@ describe('ResearchTransformService', () => {
     expect(tobaccoCsv?.content).toContain('smoking_status');
     expect(tobaccoCsv?.content).toContain('NEVER');
     expect(tobaccoCsv?.content).not.toContain('doctor-private-id');
+    expect(screeningsCsv?.content).toContain('2026-03-18T08:45:00.000Z');
     expect(appointmentsCsv?.content).toContain('2026-03-25');
     expect(appointmentsCsv?.content).not.toContain('Should not leak');
     expect(revocationsCsv?.content).toContain('REVOKED');

--- a/apps/api/src/research/research-transform.service.ts
+++ b/apps/api/src/research/research-transform.service.ts
@@ -501,7 +501,7 @@ export class ResearchTransformService {
         encounter_status: encounter.status,
         encounter_created_at: this.deIdService.roundTimestamp(encounter.createdAt),
         recorded_at: this.deIdService.roundTimestamp(
-          encounter.diabetesScreening?.createdAt ??
+          encounter.diabetesScreening?.collectedAt ??
             encounter.hypertensionAssessment?.createdAt ??
             null,
         ),

--- a/apps/api/src/sync/sync.module.ts
+++ b/apps/api/src/sync/sync.module.ts
@@ -7,6 +7,7 @@ import { EncounterModule } from '../encounters/encounter.module';
 import { MedicalHistoryModule } from '../medical-history/medical-history.module';
 import { ClinicalMeasurementsService } from './clinical-measurements.service';
 import { MedicationReconciliationModule } from '../medication-reconciliation/medication-reconciliation.module';
+import { DiabetesScreeningModule } from '../diabetes-screening/diabetes-screening.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { MedicationReconciliationModule } from '../medication-reconciliation/med
     EncounterModule,
     MedicalHistoryModule,
     MedicationReconciliationModule,
+    DiabetesScreeningModule,
   ],
   controllers: [SyncController],
   providers: [SyncService, ClinicalMeasurementsService],

--- a/apps/api/src/sync/sync.service.spec.ts
+++ b/apps/api/src/sync/sync.service.spec.ts
@@ -8,9 +8,10 @@ import { EncounterStatus } from '@prisma/client';
 import { SYNC_MUTATION_RESULT_STATUS } from './dto/sync-push-response.dto';
 import type { SyncMutationDto } from './dto/sync-mutation.dto';
 import { MedicalHistoryService } from '../medical-history/medical-history.service';
-import { ConflictException } from '@nestjs/common';
+import { ConflictException, ForbiddenException } from '@nestjs/common';
 import { ClinicalMeasurementsService } from './clinical-measurements.service';
 import { MedicationReconciliationService } from '../medication-reconciliation/medication-reconciliation.service';
+import { DiabetesScreeningService } from '../diabetes-screening/diabetes-screening.service';
 
 const mockUser = {
   user: { id: 'user-1' },
@@ -25,6 +26,7 @@ describe('SyncService', () => {
   let medicalHistoryService: jest.Mocked<MedicalHistoryService>;
   let clinicalMeasurementsService: jest.Mocked<ClinicalMeasurementsService>;
   let medicationReconciliationService: jest.Mocked<MedicationReconciliationService>;
+  let diabetesScreeningService: jest.Mocked<DiabetesScreeningService>;
   beforeEach(async () => {
     const mockPrisma = {
       syncMutation: {
@@ -45,6 +47,14 @@ describe('SyncService', () => {
       vitals: {
         findFirst: jest.fn().mockResolvedValue({
           id: 'vitals-1',
+          clinicId: 'clinic-1',
+          encounter: { status: EncounterStatus.DRAFT },
+        }),
+        deleteMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+      diabetesScreening: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'diabetes-1',
           clinicId: 'clinic-1',
           encounter: { status: EncounterStatus.DRAFT },
         }),
@@ -93,6 +103,23 @@ describe('SyncService', () => {
             endPreferredPharmacy: jest.fn().mockResolvedValue({}),
           },
         },
+        {
+          provide: DiabetesScreeningService,
+          useValue: {
+            validateSyncPayload: jest.fn().mockResolvedValue({
+              dto: {
+                glucoseMgDl: 126,
+                glucoseType: 'FASTING',
+                hba1cPercent: 6.4,
+                symptoms: ['POLYURIA'],
+                notes: null,
+                collectedAt: '2026-08-12T12:00:00.000Z',
+              },
+              compatibility: {},
+            }),
+            upsert: jest.fn().mockResolvedValue({ id: 'diabetes-1' }),
+          },
+        },
       ],
     }).compile();
 
@@ -103,6 +130,95 @@ describe('SyncService', () => {
     medicalHistoryService = module.get(MedicalHistoryService);
     clinicalMeasurementsService = module.get(ClinicalMeasurementsService);
     medicationReconciliationService = module.get(MedicationReconciliationService);
+    diabetesScreeningService = module.get(DiabetesScreeningService);
+  });
+
+  it('routes structured diabetes replay through the shared validated service', async () => {
+    const mutation: SyncMutationDto = {
+      id: 'mut-diabetes-1',
+      entityType: 'diabetes_screening',
+      entityId: 'diabetes-1',
+      operation: 'UPSERT',
+      clinicId: 'clinic-1',
+      idempotencyKey: 'diabetes-idem-1',
+      createdAt: '2026-08-12T12:00:00.000Z',
+      payloadJson: {
+        encounterId: 'enc-1',
+        glucoseMgDl: 126,
+        glucoseType: 'FASTING',
+        hba1cPercent: 6.4,
+        symptoms: ['POLYURIA'],
+        notes: null,
+        collectedAt: '2026-08-12T12:00:00.000Z',
+      },
+    };
+
+    const results = await service.applyMutations('clinic-1', mockUser as never, [mutation]);
+
+    expect(results).toEqual([{ id: 'mut-diabetes-1', status: 'APPLIED' }]);
+    expect(diabetesScreeningService.validateSyncPayload).toHaveBeenCalledWith(
+      mutation.payloadJson,
+      mutation.createdAt,
+    );
+    expect(diabetesScreeningService.upsert).toHaveBeenCalledWith(
+      'clinic-1',
+      'enc-1',
+      expect.objectContaining({ userId: 'user-1' }),
+      expect.objectContaining({ symptoms: ['POLYURIA'] }),
+      expect.objectContaining({
+        syncMutation: expect.objectContaining({ idempotencyKey: 'diabetes-idem-1' }),
+      }),
+      'diabetes-1',
+      {},
+    );
+  });
+
+  it('rejects diabetes replay for a read-only director', async () => {
+    diabetesScreeningService.upsert.mockRejectedValue(
+      new ForbiddenException('SCREENING.WRITE is required'),
+    );
+    const results = await service.applyMutations(
+      'clinic-1',
+      {
+        user: { id: 'director-1' },
+        roles: [{ clinicId: 'clinic-1', role: 'DIRECTOR' }],
+      } as never,
+      [
+        {
+          id: 'mut-diabetes-2',
+          entityType: 'diabetes_screening',
+          entityId: 'diabetes-1',
+          operation: 'UPSERT',
+          clinicId: 'clinic-1',
+          idempotencyKey: 'diabetes-idem-2',
+          payloadJson: { encounterId: 'enc-1' },
+        },
+      ],
+    );
+
+    expect(results[0]).toMatchObject({ status: 'ERROR', conflictType: 'APPLICATION_REJECTED' });
+  });
+
+  it('rejects deleting diabetes screening from a finalized encounter', async () => {
+    (prisma.diabetesScreening.findFirst as jest.Mock).mockResolvedValue({
+      encounter: { status: EncounterStatus.FINALIZED },
+    });
+    const results = await service.applyMutations('clinic-1', mockUser as never, [
+      {
+        id: 'mut-delete-diabetes',
+        entityType: 'diabetes_screening',
+        entityId: 'diabetes-1',
+        operation: 'DELETE',
+        clinicId: 'clinic-1',
+        idempotencyKey: 'delete-diabetes-1',
+      },
+    ]);
+
+    expect(results[0]).toMatchObject({
+      status: 'CONFLICT',
+      conflictType: 'CONFLICT_FINALIZED',
+    });
+    expect(prisma.diabetesScreening.deleteMany).not.toHaveBeenCalled();
   });
 
   it('replays an applied vitals bundle idempotently without writing again', async () => {

--- a/apps/api/src/sync/sync.service.ts
+++ b/apps/api/src/sync/sync.service.ts
@@ -592,6 +592,7 @@ export class SyncService {
         hba1cPercent: (payload.hba1cPercent as number) ?? null,
         symptomsJson: (payload.symptomsJson as string) ?? null,
         notes: (payload.notes as string) ?? null,
+        authoredByUserId: actorUserId,
       },
       update: {
         glucoseMgDl: (payload.glucoseMgDl as number) ?? existing?.glucoseMgDl ?? null,

--- a/apps/api/src/sync/sync.service.ts
+++ b/apps/api/src/sync/sync.service.ts
@@ -44,6 +44,8 @@ import type {
   RevisePatientPharmacyDto,
   SetPreferredPharmacyDto,
 } from '../medication-reconciliation/dto/medication-reconciliation.dto';
+import { DiabetesScreeningService } from '../diabetes-screening/diabetes-screening.service';
+import { serializeLegacyDiabetesSymptoms } from '@nkwapa/db';
 
 export type EntityType =
   | 'patient'
@@ -81,6 +83,7 @@ export class SyncService {
     private readonly medicalHistoryService: MedicalHistoryService,
     private readonly clinicalMeasurementsService: ClinicalMeasurementsService,
     private readonly medicationReconciliationService: MedicationReconciliationService,
+    private readonly diabetesScreeningService: DiabetesScreeningService,
   ) {}
 
   async applyMutations(
@@ -229,6 +232,7 @@ export class SyncService {
         return this.applyDiabetesScreeningUpsert(
           clinicId,
           actorUserId,
+          user,
           mut,
           payload,
           idempotencyKey,
@@ -567,6 +571,7 @@ export class SyncService {
   private async applyDiabetesScreeningUpsert(
     clinicId: string,
     actorUserId: string,
+    user: UserWithId,
     mut: SyncMutationDto,
     payload: Record<string, unknown>,
     idempotencyKey: string,
@@ -574,61 +579,28 @@ export class SyncService {
   ): Promise<SyncMutationResultDto> {
     const encounterId = payload.encounterId as string;
     if (!encounterId) throw new Error('DiabetesScreening payload must include encounterId');
-    await this.ensureEncounterNotFinalized(encounterId);
-
-    const existing = await this.prisma.diabetesScreening.findUnique({
-      where: { encounterId },
-    });
-    const before = existing ? JSON.stringify(existing) : null;
-
-    const screening = await this.prisma.diabetesScreening.upsert({
-      where: { encounterId },
-      create: {
-        id: mut.entityId,
-        clinicId,
-        encounterId,
-        glucoseMgDl: (payload.glucoseMgDl as number) ?? null,
-        glucoseType: (payload.glucoseType as 'FASTING' | 'RANDOM' | 'UNKNOWN') ?? 'UNKNOWN',
-        hba1cPercent: (payload.hba1cPercent as number) ?? null,
-        symptomsJson: (payload.symptomsJson as string) ?? null,
-        notes: (payload.notes as string) ?? null,
-        authoredByUserId: actorUserId,
-      },
-      update: {
-        glucoseMgDl: (payload.glucoseMgDl as number) ?? existing?.glucoseMgDl ?? null,
-        glucoseType:
-          (payload.glucoseType as 'FASTING' | 'RANDOM' | 'UNKNOWN') ??
-          existing?.glucoseType ??
-          'UNKNOWN',
-        hba1cPercent: (payload.hba1cPercent as number) ?? existing?.hba1cPercent ?? null,
-        symptomsJson: (payload.symptomsJson as string) ?? existing?.symptomsJson ?? null,
-        notes: (payload.notes as string) ?? existing?.notes ?? null,
-      },
-    });
-
-    await this.auditService.logWrite({
+    const normalized = await this.diabetesScreeningService.validateSyncPayload(
+      payload,
+      mut.createdAt ?? new Date().toISOString(),
+    );
+    await this.diabetesScreeningService.upsert(
       clinicId,
-      actorUserId,
-      action: existing ? 'DIABETES_SCREENING.UPSERT' : 'DIABETES_SCREENING.CREATE',
-      entityType: 'DiabetesScreening',
-      entityId: screening.id,
-      beforeJson: before,
-      afterJson: JSON.stringify(screening),
-      requestId: idempotencyKey,
-      ipAddress: metadata?.ipAddress,
-      userAgent: metadata?.userAgent,
-    });
-
-    await this.prisma.syncMutation.create({
-      data: {
-        clinicId,
-        entityType: 'diabetes_screening',
-        entityId: mut.entityId,
-        operation: SyncOperation.UPSERT,
-        idempotencyKey,
-        status: SyncMutationStatus.APPLIED,
+      encounterId,
+      { userId: actorUserId, roles: user.roles },
+      normalized.dto,
+      {
+        requestId: idempotencyKey,
+        ipAddress: metadata?.ipAddress,
+        userAgent: metadata?.userAgent,
+        syncMutation: {
+          entityType: mut.entityType,
+          entityId: mut.entityId,
+          idempotencyKey,
+        },
       },
-    });
+      mut.entityId,
+      normalized.compatibility,
+    );
 
     return { id: mut.id, status: SYNC_MUTATION_RESULT_STATUS.APPLIED };
   }
@@ -1254,6 +1226,28 @@ export class SyncService {
       }
     }
 
+    if (entityType === 'diabetes_screening') {
+      if (!hasPermission(user.roles, PERMISSIONS.SCREENING_WRITE)) {
+        throw new ForbiddenException(
+          'SCREENING.WRITE permission is required to delete diabetes screening',
+        );
+      }
+      const screening = await this.prisma.diabetesScreening.findFirst({
+        where: { id: mut.entityId, clinicId },
+        select: { encounter: { select: { status: true } } },
+      });
+      if (!screening) {
+        throw new NotFoundException('Diabetes screening not found in the active clinic');
+      }
+      if (screening.encounter.status === EncounterStatus.FINALIZED) {
+        throw new ConflictException({
+          code: 'CONFLICT_FINALIZED',
+          message: 'Cannot delete diabetes screening for a finalized encounter',
+          existingStatus: EncounterStatus.FINALIZED,
+        });
+      }
+    }
+
     const beforeMap: Record<string, (id: string) => Promise<unknown>> = {
       vitals: (id) => this.prisma.vitals.findFirst({ where: { id, clinicId } }),
       diabetes_screening: (id) =>
@@ -1366,6 +1360,7 @@ export class SyncService {
       }),
       this.prisma.diabetesScreening.findMany({
         where: { ...where, ...updatedAtFilter },
+        include: { authoredBy: { select: { id: true, displayName: true } } },
       }),
       this.prisma.hypertensionAssessment.findMany({
         where: { ...where, ...updatedAtFilter },
@@ -1404,6 +1399,11 @@ export class SyncService {
     const vitals = vitalsRows.map((record) => ({
       ...record,
       heartRate: record.pulseBpm,
+    }));
+
+    const diabetesScreeningRecords = diabetesScreenings.map((record) => ({
+      ...record,
+      symptomsJson: serializeLegacyDiabetesSymptoms(record.symptoms),
     }));
 
     const allRows = [
@@ -1460,7 +1460,7 @@ export class SyncService {
       encounters,
       vitals,
       tobaccoScreenings,
-      diabetesScreenings,
+      diabetesScreenings: diabetesScreeningRecords,
       hypertensionAssessments,
       carePlans,
       patientConsents,

--- a/apps/web/app/(workspace)/clinics/[clinicId]/encounters/[encounterId]/page.tsx
+++ b/apps/web/app/(workspace)/clinics/[clinicId]/encounters/[encounterId]/page.tsx
@@ -9,21 +9,27 @@ import { useSync } from '@/app/ServiceWorkerAndSyncProvider';
 import { apiFetch } from '@/lib/api';
 import { AppMetricCard } from '@/components/app-shell/AppMetricCard';
 import { AppPageHeader } from '@/components/app-shell/AppPageHeader';
-import { EmptyStateCard, InlineNotice } from '@/components/ops/OpsShared';
+import { InlineNotice } from '@/components/ops/OpsShared';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Card, CardHeader } from '@/components/ui/card';
 import { VitalsForm } from '@/components/VitalsForm';
 import { DiabetesScreeningForm } from '@/components/DiabetesScreeningForm';
 import { HypertensionForm } from '@/components/HypertensionForm';
-import { db, type TobaccoScreeningRecord, type VitalsRecord } from '@/lib/db';
+import {
+  db,
+  type DiabetesScreeningRecord,
+  type TobaccoScreeningRecord,
+  type VitalsRecord,
+} from '@/lib/db';
 import { enqueueOutboxMutation } from '@/lib/outbox';
 import { SYNC_OPERATION } from '@/lib/outbox';
 import { ArrowLeft, ClipboardPlus, HeartPulse, ShieldCheck } from 'lucide-react';
 import { PrescriptionPanel } from '@/components/patients/PrescriptionPanel';
 import { isWebFeatureEnabled } from '@/lib/feature-flags';
 import { hasPermission } from '@/lib/ops';
+import { DiabetesHistoryPanel } from '@/components/patients/DiabetesHistoryPanel';
 
 interface EncounterDetail {
   id: string;
@@ -53,17 +59,11 @@ export default function EncounterDetailPage() {
   const [savingBeforeSwitch, setSavingBeforeSwitch] = useState(false);
 
   const vitalsSaveRef = useRef<(() => Promise<void>) | null>(null);
-  const screeningSaveRef = useRef<(() => Promise<void>) | null>(null);
+  const diabetesSaveRef = useRef<(() => Promise<void>) | null>(null);
   const hypertensionSaveRef = useRef<(() => Promise<void>) | null>(null);
   const [vitals, setVitals] = useState<VitalsRecord | null>(null);
   const [tobacco, setTobacco] = useState<TobaccoScreeningRecord | null>(null);
-  const [diabetesScreening, setDiabetesScreening] = useState<{
-    glucoseMgDl?: number | null;
-    glucoseType?: string | null;
-    hba1cPercent?: number | null;
-    symptomsJson?: string | null;
-    notes?: string | null;
-  } | null>(null);
+  const [diabetesScreening, setDiabetesScreening] = useState<DiabetesScreeningRecord | null>(null);
   const [hypertension, setHypertension] = useState<{
     classification?: string | null;
     suspected?: boolean | null;
@@ -133,7 +133,7 @@ export default function EncounterDetailPage() {
   }, [fetchData]);
 
   const saveAllForms = useCallback(async () => {
-    const refs = [vitalsSaveRef.current, screeningSaveRef.current, hypertensionSaveRef.current];
+    const refs = [vitalsSaveRef.current, diabetesSaveRef.current, hypertensionSaveRef.current];
     for (const saveFn of refs) {
       if (saveFn) await saveFn();
     }
@@ -144,7 +144,7 @@ export default function EncounterDetailPage() {
       if (newValue === activeTab) return;
       const saveFns: Record<string, (() => Promise<void>) | null> = {
         vitals: vitalsSaveRef.current,
-        screening: screeningSaveRef.current,
+        diabetes: diabetesSaveRef.current,
         hypertension: hypertensionSaveRef.current,
       };
       const saveCurrent = saveFns[activeTab];
@@ -274,7 +274,7 @@ export default function EncounterDetailPage() {
       <AppPageHeader
         eyebrow="Clinic encounter"
         title="Encounter Workspace"
-        description="Capture vitals, screening data, and hypertension findings in a cleaner encounter flow with clearer state transitions."
+        description="Capture vitals, diabetes screening data, and hypertension findings with longitudinal clinical context."
         badges={
           <Badge
             variant={
@@ -360,71 +360,67 @@ export default function EncounterDetailPage() {
         />
       ) : null}
 
-      {!isFinalized && (
-        <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
-          <TabsList className="h-auto flex-wrap justify-start gap-2 rounded-3xl border border-border/80 bg-card/75 p-2">
+      <Tabs
+        value={activeTab}
+        onValueChange={isFinalized ? setActiveTab : handleTabChange}
+        className="w-full"
+      >
+        <div className="max-w-full overflow-x-auto pb-1" aria-label="Encounter clinical sections">
+          <TabsList className="min-h-11 w-max justify-start gap-2 rounded-3xl border border-border/80 bg-card/75 p-2">
             <TabsTrigger value="vitals" disabled={savingBeforeSwitch}>
               Vitals
             </TabsTrigger>
-            <TabsTrigger value="screening" disabled={savingBeforeSwitch}>
-              Screening
+            <TabsTrigger value="diabetes" disabled={savingBeforeSwitch}>
+              Diabetes
             </TabsTrigger>
             <TabsTrigger value="hypertension" disabled={savingBeforeSwitch}>
               Hypertension
             </TabsTrigger>
           </TabsList>
-          <TabsContent value="vitals">
-            <VitalsForm
-              clinicId={clinicId}
-              encounterId={encounterId}
-              recordedByUserId={userId}
-              initialData={vitals ?? undefined}
-              initialTobaccoData={tobacco}
-              canEdit={canEditMeasurements}
-              onSaved={fetchData}
-              saveRef={vitalsSaveRef}
-            />
-          </TabsContent>
-          <TabsContent value="screening">
-            <DiabetesScreeningForm
-              clinicId={clinicId}
-              encounterId={encounterId}
-              initialData={diabetesScreening ?? undefined}
-              onSaved={fetchData}
-              saveRef={screeningSaveRef}
-            />
-          </TabsContent>
-          <TabsContent value="hypertension">
-            <HypertensionForm
-              clinicId={clinicId}
-              encounterId={encounterId}
-              initialData={hypertension ?? undefined}
-              onSaved={fetchData}
-              saveRef={hypertensionSaveRef}
-            />
-          </TabsContent>
-        </Tabs>
-      )}
-
-      {isFinalized && (
-        <div className="space-y-4">
-          <Card className="rounded-[28px] border-border/80 bg-card/90 shadow-lg shadow-black/5">
-            <CardContent className="pt-6">
-              <EmptyStateCard
-                title="Encounter finalized"
-                description="This encounter is complete and all measurements are read-only."
-              />
-            </CardContent>
-          </Card>
+        </div>
+        <TabsContent value="vitals">
           <VitalsForm
             clinicId={clinicId}
             encounterId={encounterId}
             recordedByUserId={userId}
-            initialData={vitals}
+            initialData={vitals ?? undefined}
             initialTobaccoData={tobacco}
-            canEdit={false}
+            canEdit={canEditMeasurements}
+            onSaved={fetchData}
+            saveRef={vitalsSaveRef}
           />
-        </div>
+        </TabsContent>
+        <TabsContent value="diabetes" className="space-y-4">
+          <DiabetesScreeningForm
+            clinicId={clinicId}
+            encounterId={encounterId}
+            recordedByUserId={userId}
+            initialData={diabetesScreening}
+            canEdit={canEditMeasurements}
+            onSaved={fetchData}
+            saveRef={diabetesSaveRef}
+          />
+          <DiabetesHistoryPanel
+            clinicId={clinicId}
+            patientId={encounter.patientId}
+            currentEncounterId={encounterId}
+          />
+        </TabsContent>
+        <TabsContent value="hypertension">
+          <HypertensionForm
+            clinicId={clinicId}
+            encounterId={encounterId}
+            initialData={hypertension ?? undefined}
+            onSaved={fetchData}
+            saveRef={hypertensionSaveRef}
+          />
+        </TabsContent>
+      </Tabs>
+
+      {isFinalized && (
+        <InlineNotice tone="info">
+          This encounter is finalized. Every clinical tab remains available in read-only mode.
+        </InlineNotice>
       )}
     </div>
   );

--- a/apps/web/app/(workspace)/clinics/[clinicId]/encounters/[encounterId]/page.tsx
+++ b/apps/web/app/(workspace)/clinics/[clinicId]/encounters/[encounterId]/page.tsx
@@ -411,6 +411,7 @@ export default function EncounterDetailPage() {
             clinicId={clinicId}
             encounterId={encounterId}
             initialData={hypertension ?? undefined}
+            canEdit={canEditMeasurements}
             onSaved={fetchData}
             saveRef={hypertensionSaveRef}
           />

--- a/apps/web/app/(workspace)/clinics/[clinicId]/patients/[patientId]/page.tsx
+++ b/apps/web/app/(workspace)/clinics/[clinicId]/patients/[patientId]/page.tsx
@@ -30,6 +30,7 @@ import {
 import { PatientTrendsPanel } from '@/components/patients/PatientTrendsPanel';
 import { MedicalHistoryPanel } from '@/components/patients/MedicalHistoryPanel';
 import { MedicationReconciliationPanel } from '@/components/patients/MedicationReconciliationPanel';
+import { DiabetesHistoryPanel } from '@/components/patients/DiabetesHistoryPanel';
 import { isWebFeatureEnabled } from '@/lib/feature-flags';
 import { EmptyStateCard, InlineNotice } from '@/components/ops/OpsShared';
 import {
@@ -120,6 +121,7 @@ export default function PatientDetailPage() {
   const canWriteMedicationReconciliation =
     perms.includes('*') || perms.includes('MEDICATION_RECONCILIATION.WRITE');
   const canReadPrescriptions = perms.includes('*') || perms.includes('PRESCRIPTION.READ');
+  const canReadDiabetes = perms.includes('*') || perms.includes('SCREENING.READ');
   const medicalHistoryEnabled = isWebFeatureEnabled('medicalHistory');
   const medicationReconciliationEnabled = isWebFeatureEnabled('medicationReconciliation');
   const userId = bootstrap?.userId ?? '';
@@ -739,6 +741,7 @@ export default function PatientDetailPage() {
           <TabsList className="min-h-11 w-max justify-start gap-2 rounded-3xl border border-border/80 bg-card/75 p-2">
             <TabsTrigger value="overview">Overview</TabsTrigger>
             <TabsTrigger value="trends">Trends</TabsTrigger>
+            {canReadDiabetes ? <TabsTrigger value="diabetes">Diabetes</TabsTrigger> : null}
             <TabsTrigger value="encounters">Encounters</TabsTrigger>
             {medicalHistoryEnabled && canReadMedicalHistory ? (
               <TabsTrigger value="medical-history">Medical History</TabsTrigger>
@@ -1129,6 +1132,12 @@ export default function PatientDetailPage() {
         <TabsContent value="trends">
           <PatientTrendsPanel patientId={patientId} clinicId={clinicId} />
         </TabsContent>
+
+        {canReadDiabetes ? (
+          <TabsContent value="diabetes">
+            <DiabetesHistoryPanel clinicId={clinicId} patientId={patientId} />
+          </TabsContent>
+        ) : null}
 
         <TabsContent value="encounters">
           <Card className="rounded-[28px] border-border/80 bg-card/90 shadow-lg shadow-black/5">

--- a/apps/web/app/(workspace)/encounters/[encounterId]/page.tsx
+++ b/apps/web/app/(workspace)/encounters/[encounterId]/page.tsx
@@ -10,7 +10,7 @@ import { apiFetch } from '@/lib/api';
 import { getBootstrapActiveClinicId } from '@/lib/bootstrap-clinics';
 import { AppMetricCard } from '@/components/app-shell/AppMetricCard';
 import { AppPageHeader } from '@/components/app-shell/AppPageHeader';
-import { EmptyStateCard, InlineNotice } from '@/components/ops/OpsShared';
+import { InlineNotice } from '@/components/ops/OpsShared';
 import { RouteGuard } from '@/components/RouteGuard';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
@@ -20,10 +20,16 @@ import { VitalsForm } from '@/components/VitalsForm';
 import { DiabetesScreeningForm } from '@/components/DiabetesScreeningForm';
 import { HypertensionForm } from '@/components/HypertensionForm';
 import { CarePlanForm } from '@/components/CarePlanForm';
-import { db, type TobaccoScreeningRecord, type VitalsRecord } from '@/lib/db';
+import {
+  db,
+  type DiabetesScreeningRecord,
+  type TobaccoScreeningRecord,
+  type VitalsRecord,
+} from '@/lib/db';
 import { ArrowLeft, ClipboardPlus, HeartPulse, ShieldCheck } from 'lucide-react';
 import { PrescriptionPanel } from '@/components/patients/PrescriptionPanel';
 import { isWebFeatureEnabled } from '@/lib/feature-flags';
+import { DiabetesHistoryPanel } from '@/components/patients/DiabetesHistoryPanel';
 
 function hasPermission(permissions: string[], perm: string): boolean {
   return permissions.includes('*') || permissions.includes(perm);
@@ -61,7 +67,7 @@ export default function EncounterDetailPage() {
   const [encounter, setEncounter] = useState<EncounterDetail | null>(null);
   const [vitals, setVitals] = useState<VitalsRecord | null>(null);
   const [tobacco, setTobacco] = useState<TobaccoScreeningRecord | null>(null);
-  const [diabetes, setDiabetes] = useState<Record<string, unknown> | null>(null);
+  const [diabetes, setDiabetes] = useState<DiabetesScreeningRecord | null>(null);
   const [hypertension, setHypertension] = useState<Record<string, unknown> | null>(null);
   const [carePlan, setCarePlan] = useState<Record<string, unknown> | null>(null);
   const [loading, setLoading] = useState(true);
@@ -71,7 +77,7 @@ export default function EncounterDetailPage() {
   const [savingBeforeSwitch, setSavingBeforeSwitch] = useState(false);
 
   const vitalsSaveRef = useRef<(() => Promise<void>) | null>(null);
-  const screeningSaveRef = useRef<(() => Promise<void>) | null>(null);
+  const diabetesSaveRef = useRef<(() => Promise<void>) | null>(null);
   const hypertensionSaveRef = useRef<(() => Promise<void>) | null>(null);
   const carePlanSaveRef = useRef<(() => Promise<void>) | null>(null);
 
@@ -86,7 +92,7 @@ export default function EncounterDetailPage() {
       setEncounter(enc);
       setVitals((enc.vitals as VitalsRecord | undefined) ?? null);
       setTobacco((enc.tobaccoScreening as TobaccoScreeningRecord | undefined) ?? null);
-      setDiabetes(enc.diabetesScreening ?? null);
+      setDiabetes((enc.diabetesScreening as DiabetesScreeningRecord | undefined) ?? null);
       setHypertension(enc.hypertensionAssessment ?? null);
       setCarePlan(enc.carePlan ?? null);
     } catch {
@@ -110,7 +116,7 @@ export default function EncounterDetailPage() {
         ]);
         if (v) setVitals(v);
         if (tobaccoRecord) setTobacco(tobaccoRecord);
-        if (d) setDiabetes(d as unknown as Record<string, unknown>);
+        if (d) setDiabetes(d);
         if (h) setHypertension(h as unknown as Record<string, unknown>);
         if (c) setCarePlan(c as unknown as Record<string, unknown>);
       } catch {
@@ -128,7 +134,7 @@ export default function EncounterDetailPage() {
   const saveAllForms = useCallback(async () => {
     const refs = [
       vitalsSaveRef.current,
-      screeningSaveRef.current,
+      diabetesSaveRef.current,
       hypertensionSaveRef.current,
       carePlanSaveRef.current,
     ];
@@ -142,7 +148,7 @@ export default function EncounterDetailPage() {
       if (newValue === activeTab) return;
       const saveFns: Record<string, (() => Promise<void>) | null> = {
         vitals: vitalsSaveRef.current,
-        screening: screeningSaveRef.current,
+        diabetes: diabetesSaveRef.current,
         hypertension: hypertensionSaveRef.current,
         careplan: carePlanSaveRef.current,
       };
@@ -244,7 +250,7 @@ export default function EncounterDetailPage() {
               ? `${encounter.patient.firstName} ${encounter.patient.lastName}`
               : 'Encounter Workspace'
           }
-          description="Capture vitals, screening assessments, hypertension evaluation, and care plan decisions from a shared charting flow."
+          description="Capture vitals, diabetes assessments, hypertension evaluation, and care plan decisions from a shared charting flow."
           badges={
             <>
               {encounter.patient ? (
@@ -314,7 +320,7 @@ export default function EncounterDetailPage() {
             title="Forms"
             value={canFinalize ? '4' : '3'}
             icon={HeartPulse}
-            detail="Vitals, screening, hypertension, and care plan appear based on workflow state."
+            detail="Vitals, diabetes, hypertension, and care plan appear based on workflow state."
           />
           <AppMetricCard
             title="Editability"
@@ -354,24 +360,33 @@ export default function EncounterDetailPage() {
           />
         ) : null}
 
-        {!isFinalized && clinicId && (
-          <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
-            <TabsList className="h-auto flex-wrap justify-start gap-2 rounded-3xl border border-border/80 bg-card/75 p-2">
-              <TabsTrigger value="vitals" disabled={savingBeforeSwitch}>
-                Vitals
-              </TabsTrigger>
-              <TabsTrigger value="screening" disabled={savingBeforeSwitch}>
-                Screening
-              </TabsTrigger>
-              <TabsTrigger value="hypertension" disabled={savingBeforeSwitch}>
-                Hypertension
-              </TabsTrigger>
-              {canFinalize && (
-                <TabsTrigger value="careplan" disabled={savingBeforeSwitch}>
-                  Care Plan
+        {clinicId && (
+          <Tabs
+            value={activeTab}
+            onValueChange={isFinalized ? setActiveTab : handleTabChange}
+            className="w-full"
+          >
+            <div
+              className="max-w-full overflow-x-auto pb-1"
+              aria-label="Encounter clinical sections"
+            >
+              <TabsList className="min-h-11 w-max justify-start gap-2 rounded-3xl border border-border/80 bg-card/75 p-2">
+                <TabsTrigger value="vitals" disabled={savingBeforeSwitch}>
+                  Vitals
                 </TabsTrigger>
-              )}
-            </TabsList>
+                <TabsTrigger value="diabetes" disabled={savingBeforeSwitch}>
+                  Diabetes
+                </TabsTrigger>
+                <TabsTrigger value="hypertension" disabled={savingBeforeSwitch}>
+                  Hypertension
+                </TabsTrigger>
+                {canFinalize && (
+                  <TabsTrigger value="careplan" disabled={savingBeforeSwitch}>
+                    Care Plan
+                  </TabsTrigger>
+                )}
+              </TabsList>
+            </div>
             <TabsContent value="vitals">
               <VitalsForm
                 clinicId={clinicId}
@@ -384,13 +399,20 @@ export default function EncounterDetailPage() {
                 saveRef={vitalsSaveRef}
               />
             </TabsContent>
-            <TabsContent value="screening">
+            <TabsContent value="diabetes" className="space-y-4">
               <DiabetesScreeningForm
                 clinicId={clinicId}
                 encounterId={encounterId}
-                initialData={diabetes as Parameters<typeof DiabetesScreeningForm>[0]['initialData']}
+                recordedByUserId={userId}
+                initialData={diabetes}
+                canEdit={canEditMeasurements}
                 onSaved={fetchData}
-                saveRef={screeningSaveRef}
+                saveRef={diabetesSaveRef}
+              />
+              <DiabetesHistoryPanel
+                clinicId={clinicId}
+                patientId={encounter.patientId}
+                currentEncounterId={encounterId}
               />
             </TabsContent>
             <TabsContent value="hypertension">
@@ -418,22 +440,9 @@ export default function EncounterDetailPage() {
 
         {isFinalized && (
           <div className="space-y-4">
-            <Card className="rounded-[28px] border-border/80 bg-card/90 shadow-lg shadow-black/5">
-              <CardContent className="pt-6">
-                <EmptyStateCard
-                  title="Encounter finalized"
-                  description="This encounter is complete and all measurements are read-only."
-                />
-              </CardContent>
-            </Card>
-            <VitalsForm
-              clinicId={encounter.clinicId}
-              encounterId={encounterId}
-              recordedByUserId={userId}
-              initialData={vitals}
-              initialTobaccoData={tobacco}
-              canEdit={false}
-            />
+            <InlineNotice tone="info">
+              This encounter is finalized. Every clinical tab remains available in read-only mode.
+            </InlineNotice>
             <Card className="rounded-[28px] border-border/80 bg-card/90 shadow-lg shadow-black/5">
               <CardContent className="pt-6">
                 {carePlan && (

--- a/apps/web/app/(workspace)/encounters/[encounterId]/page.tsx
+++ b/apps/web/app/(workspace)/encounters/[encounterId]/page.tsx
@@ -420,6 +420,7 @@ export default function EncounterDetailPage() {
                 clinicId={clinicId}
                 encounterId={encounterId}
                 initialData={hypertension as Parameters<typeof HypertensionForm>[0]['initialData']}
+                canEdit={canEditMeasurements}
                 onSaved={fetchData}
                 saveRef={hypertensionSaveRef}
               />
@@ -430,6 +431,7 @@ export default function EncounterDetailPage() {
                   clinicId={clinicId}
                   encounterId={encounterId}
                   initialData={carePlan as Parameters<typeof CarePlanForm>[0]['initialData']}
+                  canEdit={!isFinalized}
                   onSaved={fetchData}
                   saveRef={carePlanSaveRef}
                 />

--- a/apps/web/app/(workspace)/patients/[patientId]/encounters/new/page.tsx
+++ b/apps/web/app/(workspace)/patients/[patientId]/encounters/new/page.tsx
@@ -191,6 +191,7 @@ export default function NewEncounterPage() {
         <DiabetesScreeningForm
           clinicId={clinicId}
           encounterId={encounterId}
+          recordedByUserId={userId}
           onSaved={() => setStep(4)}
         />
       )}

--- a/apps/web/app/(workspace)/patients/[patientId]/page.tsx
+++ b/apps/web/app/(workspace)/patients/[patientId]/page.tsx
@@ -20,6 +20,7 @@ import { ArrowLeft, Stethoscope, FileCheck } from 'lucide-react';
 import { PatientTrendsPanel } from '@/components/patients/PatientTrendsPanel';
 import { MedicalHistoryPanel } from '@/components/patients/MedicalHistoryPanel';
 import { MedicationReconciliationPanel } from '@/components/patients/MedicationReconciliationPanel';
+import { DiabetesHistoryPanel } from '@/components/patients/DiabetesHistoryPanel';
 import { isWebFeatureEnabled } from '@/lib/feature-flags';
 
 interface ConsentStatusItem {
@@ -66,6 +67,7 @@ export default function PatientDetailPage() {
   const canReadMedicationReconciliation = hasPermission(perms, 'MEDICATION_RECONCILIATION.READ');
   const canWriteMedicationReconciliation = hasPermission(perms, 'MEDICATION_RECONCILIATION.WRITE');
   const canReadPrescriptions = hasPermission(perms, 'PRESCRIPTION.READ');
+  const canReadDiabetes = hasPermission(perms, 'SCREENING.READ');
   const medicalHistoryEnabled = isWebFeatureEnabled('medicalHistory');
   const medicationReconciliationEnabled = isWebFeatureEnabled('medicationReconciliation');
   const userId = bootstrap?.userId ?? '';
@@ -366,6 +368,7 @@ export default function PatientDetailPage() {
             <TabsList className="min-h-11 w-max justify-start">
               <TabsTrigger value="overview">Overview</TabsTrigger>
               <TabsTrigger value="trends">Trends</TabsTrigger>
+              {canReadDiabetes ? <TabsTrigger value="diabetes">Diabetes</TabsTrigger> : null}
               <TabsTrigger value="encounters">Encounters</TabsTrigger>
               {medicalHistoryEnabled && canReadMedicalHistory ? (
                 <TabsTrigger value="medical-history">Medical History</TabsTrigger>
@@ -406,6 +409,11 @@ export default function PatientDetailPage() {
           <TabsContent value="trends">
             <PatientTrendsPanel patientId={patientId} clinicId={clinicId} />
           </TabsContent>
+          {canReadDiabetes ? (
+            <TabsContent value="diabetes">
+              <DiabetesHistoryPanel clinicId={clinicId} patientId={patientId} />
+            </TabsContent>
+          ) : null}
           <TabsContent value="encounters">
             <Card>
               <CardHeader>

--- a/apps/web/components/CarePlanForm.tsx
+++ b/apps/web/components/CarePlanForm.tsx
@@ -31,6 +31,7 @@ interface CarePlanFormProps {
     notes?: string | null;
   };
   onSaved?: () => void;
+  canEdit?: boolean;
   /** Optional ref to expose save for parent-driven save (e.g. on tab change) */
   saveRef?: React.MutableRefObject<(() => Promise<void>) | null>;
 }
@@ -40,6 +41,7 @@ export function CarePlanForm({
   encounterId,
   initialData,
   onSaved,
+  canEdit = true,
   saveRef,
 }: CarePlanFormProps) {
   const [counselingGiven, setCounselingGiven] = useState(initialData?.counselingGiven ?? false);
@@ -54,6 +56,7 @@ export function CarePlanForm({
   const [error, setError] = useState<string | null>(null);
 
   const handleSave = useCallback(async () => {
+    if (!canEdit || saving) return;
     setSaving(true);
     setError(null);
     const existing = await db.care_plans.where('encounterId').equals(encounterId).first();
@@ -96,7 +99,17 @@ export function CarePlanForm({
     } finally {
       setSaving(false);
     }
-  }, [clinicId, encounterId, counselingGiven, medicationPrescribed, followUpDate, notes, onSaved]);
+  }, [
+    canEdit,
+    saving,
+    clinicId,
+    encounterId,
+    counselingGiven,
+    medicationPrescribed,
+    followUpDate,
+    notes,
+    onSaved,
+  ]);
 
   useEffect(() => {
     if (saveRef) saveRef.current = handleSave;
@@ -111,44 +124,51 @@ export function CarePlanForm({
         <h2 className="text-lg font-semibold">Care Plan</h2>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="flex items-center gap-2">
-          <Checkbox
-            id="counselingGiven"
-            checked={counselingGiven}
-            onCheckedChange={(v) => setCounselingGiven(v === true)}
-          />
-          <Label htmlFor="counselingGiven">Counseling given</Label>
-        </div>
-        <div className="flex items-center gap-2">
-          <Checkbox
-            id="medicationPrescribed"
-            checked={medicationPrescribed}
-            onCheckedChange={(v) => setMedicationPrescribed(v === true)}
-          />
-          <Label htmlFor="medicationPrescribed">Medication prescribed</Label>
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="followUpDate">Follow-up date</Label>
-          <Input
-            id="followUpDate"
-            type="date"
-            value={followUpDate}
-            onChange={(e) => setFollowUpDate(e.target.value)}
-          />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="notes">Notes</Label>
-          <Input
-            id="notes"
-            value={notes}
-            onChange={(e) => setNotes(e.target.value)}
-            placeholder="Optional notes"
-          />
-        </div>
+        <fieldset disabled={!canEdit || saving} className="space-y-4 disabled:opacity-75">
+          <legend className="sr-only">Care plan details</legend>
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="counselingGiven"
+              checked={counselingGiven}
+              onCheckedChange={(v) => setCounselingGiven(v === true)}
+            />
+            <Label htmlFor="counselingGiven">Counseling given</Label>
+          </div>
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="medicationPrescribed"
+              checked={medicationPrescribed}
+              onCheckedChange={(v) => setMedicationPrescribed(v === true)}
+            />
+            <Label htmlFor="medicationPrescribed">Medication prescribed</Label>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="followUpDate">Follow-up date</Label>
+            <Input
+              id="followUpDate"
+              type="date"
+              value={followUpDate}
+              onChange={(e) => setFollowUpDate(e.target.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="notes">Notes</Label>
+            <Input
+              id="notes"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="Optional notes"
+            />
+          </div>
+        </fieldset>
         {error && <p className="text-sm text-destructive">{error}</p>}
-        <Button onClick={handleSave} disabled={saving}>
-          {saving ? 'Saving…' : 'Save Care Plan'}
-        </Button>
+        {canEdit ? (
+          <Button onClick={handleSave} disabled={saving}>
+            {saving ? 'Saving…' : 'Save Care Plan'}
+          </Button>
+        ) : (
+          <p className="text-sm text-muted-foreground">This care plan is read-only.</p>
+        )}
       </CardContent>
     </Card>
   );

--- a/apps/web/components/DiabetesScreeningForm.tsx
+++ b/apps/web/components/DiabetesScreeningForm.tsx
@@ -1,6 +1,18 @@
 'use client';
 
-import { useState, useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import {
+  DIABETES_GLUCOSE_MAX_MG_DL,
+  DIABETES_GLUCOSE_MIN_MG_DL,
+  DIABETES_HBA1C_MAX_PERCENT,
+  DIABETES_HBA1C_MIN_PERCENT,
+  DIABETES_SYMPTOMS,
+  DIABETES_SYMPTOM_LABELS,
+  parseLegacyDiabetesSymptoms,
+  type DiabetesGlucoseType,
+  type DiabetesSymptom,
+} from '@nkwapa/db';
+import { AlertTriangle, CalendarClock, CheckCircle2, CloudOff, Droplets } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -13,213 +25,373 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Checkbox } from '@/components/ui/checkbox';
-import { db } from '@/lib/db';
-import { enqueueOutboxMutation } from '@/lib/outbox';
-import { SYNC_OPERATION } from '@/lib/outbox';
+import { Textarea } from '@/components/ui/textarea';
+import { InlineNotice } from '@/components/ops/OpsShared';
+import { db, type DiabetesScreeningRecord } from '@/lib/db';
+import { enqueueOutboxMutation, SYNC_OPERATION } from '@/lib/outbox';
+
+const GLUCOSE_CONTEXTS: Array<{ value: DiabetesGlucoseType; label: string }> = [
+  { value: 'FASTING', label: 'Fasting' },
+  { value: 'RANDOM', label: 'Random' },
+  { value: 'UNKNOWN', label: 'Unknown / not documented' },
+];
 
 function generateId(): string {
-  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
-    return crypto.randomUUID();
-  }
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-    const r = (Math.random() * 16) | 0;
-    const v = c === 'x' ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) return crypto.randomUUID();
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (character) => {
+    const random = (Math.random() * 16) | 0;
+    const value = character === 'x' ? random : (random & 0x3) | 0x8;
+    return value.toString(16);
   });
 }
 
-const GLUCOSE_TYPES = ['FASTING', 'RANDOM', 'UNKNOWN'] as const;
-const SYMPTOM_OPTIONS = [
-  'Polyuria',
-  'Polydipsia',
-  'Weight loss',
-  'Blurred vision',
-  'Fatigue',
-] as const;
+function toLocalDateTime(value: string | null | undefined): string {
+  const date = value ? new Date(value) : new Date();
+  const offset = date.getTimezoneOffset();
+  return new Date(date.getTime() - offset * 60_000).toISOString().slice(0, 16);
+}
 
-interface DiabetesScreeningFormProps {
+function initialSymptoms(data?: DiabetesScreeningRecord | null): DiabetesSymptom[] {
+  if (data?.symptoms) return data.symptoms;
+  return parseLegacyDiabetesSymptoms(data?.symptomsJson).symptoms;
+}
+
+export interface DiabetesScreeningFormProps {
   clinicId: string;
   encounterId: string;
-  initialData?: {
-    glucoseMgDl?: number | null;
-    glucoseType?: string | null;
-    hba1cPercent?: number | null;
-    symptomsJson?: string | null;
-    notes?: string | null;
-  };
+  recordedByUserId: string;
+  initialData?: DiabetesScreeningRecord | null;
+  canEdit?: boolean;
   onSaved?: () => void;
-  /** Optional ref to expose save for parent-driven save (e.g. on tab change) */
   saveRef?: React.MutableRefObject<(() => Promise<void>) | null>;
 }
 
 export function DiabetesScreeningForm({
   clinicId,
   encounterId,
+  recordedByUserId,
   initialData,
+  canEdit = true,
   onSaved,
   saveRef,
 }: DiabetesScreeningFormProps) {
-  const [glucoseMgDl, setGlucoseMgDl] = useState<string>(String(initialData?.glucoseMgDl ?? ''));
-  const [glucoseType, setGlucoseType] = useState<string>(initialData?.glucoseType ?? 'UNKNOWN');
-  const [hba1cPercent, setHba1cPercent] = useState<string>(String(initialData?.hba1cPercent ?? ''));
-  const [symptoms, setSymptoms] = useState<Set<string>>(() => {
-    try {
-      const parsed = initialData?.symptomsJson
-        ? (JSON.parse(initialData.symptomsJson) as string[])
-        : [];
-      return new Set(Array.isArray(parsed) ? parsed : []);
-    } catch {
-      return new Set();
-    }
-  });
-  const [notes, setNotes] = useState<string>(initialData?.notes ?? '');
+  const idPrefix = useId();
+  const screeningId = useRef(initialData?.id ?? generateId());
+  const [glucoseMgDl, setGlucoseMgDl] = useState(String(initialData?.glucoseMgDl ?? ''));
+  const [glucoseType, setGlucoseType] = useState<DiabetesGlucoseType>(
+    (initialData?.glucoseType as DiabetesGlucoseType) ?? 'UNKNOWN',
+  );
+  const [hba1cPercent, setHba1cPercent] = useState(String(initialData?.hba1cPercent ?? ''));
+  const [symptoms, setSymptoms] = useState<Set<DiabetesSymptom>>(
+    () => new Set(initialSymptoms(initialData)),
+  );
+  const [notes, setNotes] = useState(initialData?.notes ?? '');
+  const [collectedAt, setCollectedAt] = useState(toLocalDateTime(initialData?.collectedAt));
   const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<{
+    tone: 'success' | 'error' | 'info';
+    text: string;
+  } | null>(null);
 
-  const toggleSymptom = useCallback((symptom: string) => {
-    setSymptoms((prev) => {
-      const next = new Set(prev);
-      if (next.has(symptom)) {
-        next.delete(symptom);
-      } else {
-        next.add(symptom);
-      }
+  useEffect(() => {
+    if (!initialData) return;
+    screeningId.current = initialData.id;
+    setGlucoseMgDl(String(initialData.glucoseMgDl ?? ''));
+    setGlucoseType((initialData.glucoseType as DiabetesGlucoseType) ?? 'UNKNOWN');
+    setHba1cPercent(String(initialData.hba1cPercent ?? ''));
+    setSymptoms(new Set(initialSymptoms(initialData)));
+    setNotes(initialData.notes ?? '');
+    setCollectedAt(toLocalDateTime(initialData.collectedAt));
+  }, [initialData]);
+
+  const validateForm = useCallback((): string | null => {
+    const glucose = glucoseMgDl === '' ? null : Number(glucoseMgDl);
+    const hba1c = hba1cPercent === '' ? null : Number(hba1cPercent);
+    if (
+      glucose != null &&
+      (!Number.isInteger(glucose) ||
+        glucose < DIABETES_GLUCOSE_MIN_MG_DL ||
+        glucose > DIABETES_GLUCOSE_MAX_MG_DL)
+    ) {
+      return `Glucose must be a whole number from ${DIABETES_GLUCOSE_MIN_MG_DL} to ${DIABETES_GLUCOSE_MAX_MG_DL} mg/dL.`;
+    }
+    if (
+      hba1c != null &&
+      (hba1c < DIABETES_HBA1C_MIN_PERCENT || hba1c > DIABETES_HBA1C_MAX_PERCENT)
+    ) {
+      return `HbA1c must be from ${DIABETES_HBA1C_MIN_PERCENT} to ${DIABETES_HBA1C_MAX_PERCENT}%.`;
+    }
+    const timestamp = new Date(collectedAt);
+    if (!Number.isFinite(timestamp.getTime())) return 'Enter a valid collection date and time.';
+    if (timestamp.getTime() > Date.now() + 5 * 60 * 1000) {
+      return 'Collection time cannot be more than five minutes in the future.';
+    }
+    return null;
+  }, [collectedAt, glucoseMgDl, hba1cPercent]);
+
+  const toggleSymptom = useCallback((symptom: DiabetesSymptom) => {
+    setSymptoms((current) => {
+      const next = new Set(current);
+      if (next.has(symptom)) next.delete(symptom);
+      else next.add(symptom);
       return next;
     });
   }, []);
 
   const handleSave = useCallback(async () => {
+    if (!canEdit || saving) return;
+    const validationError = validateForm();
+    if (validationError) {
+      setMessage({ tone: 'error', text: validationError });
+      throw new Error(validationError);
+    }
+
     setSaving(true);
-    setError(null);
-    const screeningId = generateId();
+    setMessage(null);
     const now = new Date().toISOString();
-
-    const symptomsArray = Array.from(symptoms);
-    const symptomsJson = JSON.stringify(symptomsArray);
-
     const payload = {
       encounterId,
-      clinicId,
-      glucoseMgDl: glucoseMgDl ? parseInt(glucoseMgDl, 10) : null,
-      glucoseType: GLUCOSE_TYPES.includes(glucoseType as (typeof GLUCOSE_TYPES)[number])
-        ? (glucoseType as 'FASTING' | 'RANDOM' | 'UNKNOWN')
-        : 'UNKNOWN',
-      hba1cPercent: hba1cPercent ? parseFloat(hba1cPercent) : null,
-      symptomsJson: symptomsArray.length > 0 ? symptomsJson : null,
+      glucoseMgDl: glucoseMgDl === '' ? null : Number(glucoseMgDl),
+      glucoseType,
+      hba1cPercent: hba1cPercent === '' ? null : Number(hba1cPercent),
+      symptoms: Array.from(symptoms),
       notes: notes.trim() || null,
+      collectedAt: new Date(collectedAt).toISOString(),
     };
-
-    const record = {
-      id: screeningId,
+    const record: DiabetesScreeningRecord = {
+      id: screeningId.current,
       clinicId,
       encounterId,
       glucoseMgDl: payload.glucoseMgDl ?? undefined,
       glucoseType: payload.glucoseType,
       hba1cPercent: payload.hba1cPercent ?? undefined,
-      symptomsJson: payload.symptomsJson ?? undefined,
+      symptoms: payload.symptoms,
       notes: payload.notes ?? undefined,
-      createdAt: now,
+      collectedAt: payload.collectedAt,
+      authoredByUserId: recordedByUserId,
+      legacySymptomsUnmapped: false,
+      createdAt: initialData?.createdAt ?? now,
       updatedAt: now,
     };
 
     try {
-      await db.diabetes_screenings.put(record);
-      await enqueueOutboxMutation(db, {
-        clinicId,
-        entityType: 'diabetes_screening',
-        entityId: screeningId,
-        operation: SYNC_OPERATION.UPSERT,
-        payloadJson: payload,
+      await db.transaction('rw', db.diabetes_screenings, db.outbox, async () => {
+        await db.diabetes_screenings.put(record);
+        await enqueueOutboxMutation(db, {
+          clinicId,
+          entityType: 'diabetes_screening',
+          entityId: screeningId.current,
+          operation: SYNC_OPERATION.UPSERT,
+          payloadJson: payload,
+        });
+      });
+      setMessage({
+        tone: 'success',
+        text: navigator.onLine
+          ? 'Diabetes screening saved and queued for sync.'
+          : 'Diabetes screening saved on this device and pending sync.',
       });
       onSaved?.();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to save screening');
+    } catch (error) {
+      const text = error instanceof Error ? error.message : 'Unable to save diabetes screening.';
+      setMessage({ tone: 'error', text });
+      throw error;
     } finally {
       setSaving(false);
     }
-  }, [clinicId, encounterId, glucoseMgDl, glucoseType, hba1cPercent, symptoms, notes, onSaved]);
+  }, [
+    canEdit,
+    clinicId,
+    collectedAt,
+    encounterId,
+    glucoseMgDl,
+    glucoseType,
+    hba1cPercent,
+    initialData?.createdAt,
+    notes,
+    onSaved,
+    recordedByUserId,
+    saving,
+    symptoms,
+    validateForm,
+  ]);
 
   useEffect(() => {
-    if (saveRef) saveRef.current = handleSave;
+    if (!saveRef) return;
+    saveRef.current = handleSave;
     return () => {
-      if (saveRef) saveRef.current = null;
+      saveRef.current = null;
     };
-  }, [saveRef, handleSave]);
+  }, [handleSave, saveRef]);
+
+  const contextHelp = useMemo(
+    () =>
+      glucoseType === 'UNKNOWN'
+        ? 'Unknown context remains distinct and is not interpreted as fasting or random.'
+        : `${glucoseType === 'FASTING' ? 'Fasting' : 'Random'} context is recorded exactly as selected.`,
+    [glucoseType],
+  );
 
   return (
-    <Card>
-      <CardHeader>
-        <h2 className="text-lg font-semibold">Diabetes Screening</h2>
+    <Card className="rounded-[28px] border-border/80 bg-card/90 shadow-lg shadow-black/5">
+      <CardHeader className="space-y-2">
+        <div className="flex items-start gap-3">
+          <span className="rounded-2xl bg-primary/10 p-2 text-primary" aria-hidden="true">
+            <Droplets className="h-5 w-5" />
+          </span>
+          <div>
+            <h2 className="font-heading text-xl font-semibold">Current diabetes screening</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Record the measurement context and collection time without inferring a diagnosis.
+            </p>
+          </div>
+        </div>
       </CardHeader>
-      <CardContent className="space-y-4">
-        <div className="grid gap-4 sm:grid-cols-2">
-          <div className="space-y-2">
-            <Label htmlFor="glucoseMgDl">Glucose (mg/dL)</Label>
-            <Input
-              id="glucoseMgDl"
-              type="number"
-              value={glucoseMgDl}
-              onChange={(e) => setGlucoseMgDl(e.target.value)}
-              placeholder="100"
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="glucoseType">Glucose Type</Label>
-            <Select value={glucoseType} onValueChange={setGlucoseType}>
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {GLUCOSE_TYPES.map((t) => (
-                  <SelectItem key={t} value={t}>
-                    {t}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="hba1cPercent">HbA1c (%)</Label>
-            <Input
-              id="hba1cPercent"
-              type="number"
-              step="0.1"
-              value={hba1cPercent}
-              onChange={(e) => setHba1cPercent(e.target.value)}
-              placeholder="5.7"
-            />
-          </div>
-        </div>
-        <div className="space-y-2">
-          <Label>Symptoms</Label>
-          <div className="flex flex-wrap gap-4">
-            {SYMPTOM_OPTIONS.map((s) => (
-              <div key={s} className="flex items-center space-x-2">
-                <Checkbox
-                  id={`symptom-${s}`}
-                  checked={symptoms.has(s)}
-                  onCheckedChange={() => toggleSymptom(s)}
+      <CardContent className="space-y-6">
+        {initialData?.legacySymptomsUnmapped ? (
+          <InlineNotice tone="info">
+            <AlertTriangle className="h-4 w-4 shrink-0" aria-hidden="true" />
+            Some legacy symptom content could not be mapped. The original value remains preserved
+            for audit review.
+          </InlineNotice>
+        ) : null}
+
+        <fieldset disabled={!canEdit || saving} className="space-y-6 disabled:opacity-75">
+          <legend className="sr-only">Diabetes screening measurements</legend>
+          <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
+            <div className="space-y-2">
+              <Label htmlFor={`${idPrefix}-glucose`}>Glucose (mg/dL)</Label>
+              <Input
+                id={`${idPrefix}-glucose`}
+                type="number"
+                inputMode="numeric"
+                min={DIABETES_GLUCOSE_MIN_MG_DL}
+                max={DIABETES_GLUCOSE_MAX_MG_DL}
+                step="1"
+                value={glucoseMgDl}
+                onChange={(event) => setGlucoseMgDl(event.target.value)}
+                placeholder="100"
+                className="min-h-11"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor={`${idPrefix}-context`}>Glucose context</Label>
+              <Select
+                value={glucoseType}
+                onValueChange={(value) => setGlucoseType(value as DiabetesGlucoseType)}
+                disabled={!canEdit || saving}
+              >
+                <SelectTrigger id={`${idPrefix}-context`} className="min-h-11">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {GLUCOSE_CONTEXTS.map((context) => (
+                    <SelectItem key={context.value} value={context.value}>
+                      {context.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs leading-5 text-muted-foreground">{contextHelp}</p>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor={`${idPrefix}-hba1c`}>HbA1c (%)</Label>
+              <Input
+                id={`${idPrefix}-hba1c`}
+                type="number"
+                inputMode="decimal"
+                min={DIABETES_HBA1C_MIN_PERCENT}
+                max={DIABETES_HBA1C_MAX_PERCENT}
+                step="0.1"
+                value={hba1cPercent}
+                onChange={(event) => setHba1cPercent(event.target.value)}
+                placeholder="5.7"
+                className="min-h-11"
+              />
+            </div>
+            <div className="space-y-2 md:col-span-2 xl:col-span-3">
+              <Label htmlFor={`${idPrefix}-collected-at`}>Measurement collection time</Label>
+              <div className="relative max-w-md">
+                <CalendarClock
+                  className="pointer-events-none absolute left-3 top-3 h-5 w-5 text-muted-foreground"
+                  aria-hidden="true"
                 />
-                <Label htmlFor={`symptom-${s}`} className="cursor-pointer text-sm font-normal">
-                  {s}
-                </Label>
+                <Input
+                  id={`${idPrefix}-collected-at`}
+                  type="datetime-local"
+                  value={collectedAt}
+                  onChange={(event) => setCollectedAt(event.target.value)}
+                  className="min-h-11 pl-10"
+                />
               </div>
-            ))}
+              <p className="text-xs text-muted-foreground">
+                Use when the sample was collected, which may differ from when this record is saved.
+              </p>
+            </div>
           </div>
+
+          <fieldset className="space-y-3">
+            <legend className="text-sm font-medium">Symptoms reported or observed</legend>
+            <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
+              {DIABETES_SYMPTOMS.map((symptom) => {
+                const checkboxId = `${idPrefix}-symptom-${symptom.toLowerCase()}`;
+                return (
+                  <label
+                    key={symptom}
+                    htmlFor={checkboxId}
+                    className="flex min-h-11 cursor-pointer items-center gap-3 rounded-2xl border border-border/80 bg-background/70 px-4 py-2.5 transition-colors hover:bg-accent/60 focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2"
+                  >
+                    <Checkbox
+                      id={checkboxId}
+                      checked={symptoms.has(symptom)}
+                      onCheckedChange={() => toggleSymptom(symptom)}
+                    />
+                    <span className="text-sm">{DIABETES_SYMPTOM_LABELS[symptom]}</span>
+                  </label>
+                );
+              })}
+            </div>
+          </fieldset>
+
+          <div className="space-y-2">
+            <Label htmlFor={`${idPrefix}-notes`}>Clinical notes</Label>
+            <Textarea
+              id={`${idPrefix}-notes`}
+              value={notes}
+              onChange={(event) => setNotes(event.target.value)}
+              placeholder="Optional context for interpreting this screening"
+              maxLength={2000}
+              rows={4}
+            />
+            <p className="text-right text-xs text-muted-foreground">{notes.length}/2000</p>
+          </div>
+        </fieldset>
+
+        {message ? (
+          <InlineNotice tone={message.tone}>
+            {message.tone === 'success' ? (
+              <CheckCircle2 className="h-4 w-4 shrink-0" aria-hidden="true" />
+            ) : message.tone === 'info' ? (
+              <CloudOff className="h-4 w-4 shrink-0" aria-hidden="true" />
+            ) : (
+              <AlertTriangle className="h-4 w-4 shrink-0" aria-hidden="true" />
+            )}
+            {message.text}
+          </InlineNotice>
+        ) : null}
+
+        <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border/70 pt-5">
+          <p className="text-sm text-muted-foreground">
+            {canEdit
+              ? 'Changes save locally first and sync automatically.'
+              : 'This screening is read-only.'}
+          </p>
+          {canEdit ? (
+            <Button onClick={handleSave} disabled={saving} className="min-h-11 rounded-2xl">
+              {saving ? 'Saving…' : 'Save diabetes screening'}
+            </Button>
+          ) : null}
         </div>
-        <div className="space-y-2">
-          <Label htmlFor="notes">Notes</Label>
-          <Input
-            id="notes"
-            value={notes}
-            onChange={(e) => setNotes(e.target.value)}
-            placeholder="Optional notes"
-          />
-        </div>
-        {error && <p className="text-sm text-destructive">{error}</p>}
-        <Button onClick={handleSave} disabled={saving}>
-          {saving ? 'Saving…' : 'Save Screening'}
-        </Button>
       </CardContent>
     </Card>
   );

--- a/apps/web/components/DiabetesScreeningForm.tsx
+++ b/apps/web/components/DiabetesScreeningForm.tsx
@@ -27,6 +27,7 @@ import {
 import { Checkbox } from '@/components/ui/checkbox';
 import { Textarea } from '@/components/ui/textarea';
 import { InlineNotice } from '@/components/ops/OpsShared';
+import { useSync } from '@/app/ServiceWorkerAndSyncProvider';
 import { db, type DiabetesScreeningRecord } from '@/lib/db';
 import { enqueueOutboxMutation, SYNC_OPERATION } from '@/lib/outbox';
 
@@ -75,6 +76,7 @@ export function DiabetesScreeningForm({
   onSaved,
   saveRef,
 }: DiabetesScreeningFormProps) {
+  const { isOnline, syncNow } = useSync();
   const idPrefix = useId();
   const screeningId = useRef(initialData?.id ?? generateId());
   const [glucoseMgDl, setGlucoseMgDl] = useState(String(initialData?.glucoseMgDl ?? ''));
@@ -185,10 +187,11 @@ export function DiabetesScreeningForm({
           payloadJson: payload,
         });
       });
+      const syncResult = isOnline ? await syncNow(clinicId) : null;
       setMessage({
         tone: 'success',
-        text: navigator.onLine
-          ? 'Diabetes screening saved and queued for sync.'
+        text: syncResult?.success
+          ? 'Diabetes screening saved and synced.'
           : 'Diabetes screening saved on this device and pending sync.',
       });
       onSaved?.();
@@ -208,13 +211,19 @@ export function DiabetesScreeningForm({
     glucoseType,
     hba1cPercent,
     initialData?.createdAt,
+    isOnline,
     notes,
     onSaved,
     recordedByUserId,
     saving,
     symptoms,
+    syncNow,
     validateForm,
   ]);
+
+  const handleButtonSave = useCallback(() => {
+    void handleSave().catch(() => undefined);
+  }, [handleSave]);
 
   useEffect(() => {
     if (!saveRef) return;
@@ -387,7 +396,7 @@ export function DiabetesScreeningForm({
               : 'This screening is read-only.'}
           </p>
           {canEdit ? (
-            <Button onClick={handleSave} disabled={saving} className="min-h-11 rounded-2xl">
+            <Button onClick={handleButtonSave} disabled={saving} className="min-h-11 rounded-2xl">
               {saving ? 'Saving…' : 'Save diabetes screening'}
             </Button>
           ) : null}

--- a/apps/web/components/HypertensionForm.tsx
+++ b/apps/web/components/HypertensionForm.tsx
@@ -40,6 +40,7 @@ interface HypertensionFormProps {
     notes?: string | null;
   };
   onSaved?: () => void;
+  canEdit?: boolean;
   /** Optional ref to expose save for parent-driven save (e.g. on tab change) */
   saveRef?: React.MutableRefObject<(() => Promise<void>) | null>;
 }
@@ -49,6 +50,7 @@ export function HypertensionForm({
   encounterId,
   initialData,
   onSaved,
+  canEdit = true,
   saveRef,
 }: HypertensionFormProps) {
   const [classification, setClassification] = useState<string>(
@@ -61,6 +63,7 @@ export function HypertensionForm({
   const [error, setError] = useState<string | null>(null);
 
   const handleSave = useCallback(async () => {
+    if (!canEdit || saving) return;
     setSaving(true);
     setError(null);
     const assessmentId = generateId();
@@ -104,7 +107,17 @@ export function HypertensionForm({
     } finally {
       setSaving(false);
     }
-  }, [clinicId, encounterId, classification, suspected, confirmed, notes, onSaved]);
+  }, [
+    canEdit,
+    saving,
+    clinicId,
+    encounterId,
+    classification,
+    suspected,
+    confirmed,
+    notes,
+    onSaved,
+  ]);
 
   useEffect(() => {
     if (saveRef) saveRef.current = handleSave;
@@ -119,56 +132,63 @@ export function HypertensionForm({
         <h2 className="text-lg font-semibold">Hypertension Assessment</h2>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="space-y-2">
-          <Label htmlFor="classification">Classification</Label>
-          <Select value={classification} onValueChange={setClassification}>
-            <SelectTrigger>
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {CLASSIFICATIONS.map((c) => (
-                <SelectItem key={c} value={c}>
-                  {c}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="flex flex-wrap gap-6">
-          <div className="flex items-center space-x-2">
-            <Checkbox
-              id="suspected"
-              checked={suspected}
-              onCheckedChange={(v) => setSuspected(!!v)}
-            />
-            <Label htmlFor="suspected" className="cursor-pointer text-sm font-normal">
-              Suspected
-            </Label>
+        <fieldset disabled={!canEdit || saving} className="space-y-4 disabled:opacity-75">
+          <legend className="sr-only">Hypertension assessment details</legend>
+          <div className="space-y-2">
+            <Label htmlFor="classification">Classification</Label>
+            <Select value={classification} onValueChange={setClassification}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {CLASSIFICATIONS.map((c) => (
+                  <SelectItem key={c} value={c}>
+                    {c}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
-          <div className="flex items-center space-x-2">
-            <Checkbox
-              id="confirmed"
-              checked={confirmed}
-              onCheckedChange={(v) => setConfirmed(!!v)}
-            />
-            <Label htmlFor="confirmed" className="cursor-pointer text-sm font-normal">
-              Confirmed
-            </Label>
+          <div className="flex flex-wrap gap-6">
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="suspected"
+                checked={suspected}
+                onCheckedChange={(v) => setSuspected(!!v)}
+              />
+              <Label htmlFor="suspected" className="cursor-pointer text-sm font-normal">
+                Suspected
+              </Label>
+            </div>
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="confirmed"
+                checked={confirmed}
+                onCheckedChange={(v) => setConfirmed(!!v)}
+              />
+              <Label htmlFor="confirmed" className="cursor-pointer text-sm font-normal">
+                Confirmed
+              </Label>
+            </div>
           </div>
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="notes">Notes</Label>
-          <Input
-            id="notes"
-            value={notes}
-            onChange={(e) => setNotes(e.target.value)}
-            placeholder="Optional notes"
-          />
-        </div>
+          <div className="space-y-2">
+            <Label htmlFor="notes">Notes</Label>
+            <Input
+              id="notes"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="Optional notes"
+            />
+          </div>
+        </fieldset>
         {error && <p className="text-sm text-destructive">{error}</p>}
-        <Button onClick={handleSave} disabled={saving}>
-          {saving ? 'Saving…' : 'Save Assessment'}
-        </Button>
+        {canEdit ? (
+          <Button onClick={handleSave} disabled={saving}>
+            {saving ? 'Saving…' : 'Save Assessment'}
+          </Button>
+        ) : (
+          <p className="text-sm text-muted-foreground">This assessment is read-only.</p>
+        )}
       </CardContent>
     </Card>
   );

--- a/apps/web/components/patients/DiabetesHistoryPanel.tsx
+++ b/apps/web/components/patients/DiabetesHistoryPanel.tsx
@@ -1,0 +1,240 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { AlertTriangle, CalendarClock, Droplets, ExternalLink, UserRound } from 'lucide-react';
+import { DIABETES_SYMPTOM_LABELS, type DiabetesSymptom } from '@nkwapa/db';
+import { useAuth } from '@/lib/auth-context';
+import { apiFetch, readApiError } from '@/lib/api';
+import { db, type DiabetesScreeningRecord } from '@/lib/db';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { EmptyStateCard, InlineNotice } from '@/components/ops/OpsShared';
+
+interface DiabetesHistoryItem {
+  id: string;
+  clinicId: string;
+  patientId: string;
+  glucoseMgDl: number | null;
+  glucoseType: 'FASTING' | 'RANDOM' | 'UNKNOWN';
+  hba1cPercent: number | null;
+  symptoms: DiabetesSymptom[];
+  notes: string | null;
+  collectedAt: string;
+  author: { id: string; displayName: string } | null;
+  sourceEncounter: { id: string; createdAt: string; status: string };
+  legacySymptomsUnmapped: boolean;
+  isEditable: boolean;
+}
+
+function contextLabel(value: DiabetesHistoryItem['glucoseType']): string {
+  if (value === 'FASTING') return 'Fasting';
+  if (value === 'RANDOM') return 'Random';
+  return 'Unknown / not documented';
+}
+
+function fromLocal(
+  record: DiabetesScreeningRecord,
+  encounterStatus = 'DRAFT',
+): DiabetesHistoryItem {
+  return {
+    id: record.id,
+    clinicId: record.clinicId,
+    patientId: '',
+    glucoseMgDl: record.glucoseMgDl ?? null,
+    glucoseType: (record.glucoseType as DiabetesHistoryItem['glucoseType']) ?? 'UNKNOWN',
+    hba1cPercent: record.hba1cPercent ?? null,
+    symptoms: record.symptoms ?? [],
+    notes: record.notes ?? null,
+    collectedAt: record.collectedAt ?? record.createdAt ?? new Date().toISOString(),
+    author: record.authoredBy ?? null,
+    sourceEncounter: {
+      id: record.encounterId,
+      createdAt: record.createdAt ?? new Date().toISOString(),
+      status: record.encounterStatus ?? encounterStatus,
+    },
+    legacySymptomsUnmapped: record.legacySymptomsUnmapped ?? false,
+    isEditable: encounterStatus !== 'FINALIZED',
+  };
+}
+
+export function DiabetesHistoryPanel({
+  clinicId,
+  patientId,
+  currentEncounterId,
+}: {
+  clinicId: string;
+  patientId: string;
+  currentEncounterId?: string;
+}) {
+  const getToken = useAuth();
+  const [items, setItems] = useState<DiabetesHistoryItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await apiFetch(
+        `/clinics/${encodeURIComponent(clinicId)}/patients/${encodeURIComponent(patientId)}/diabetes-screenings?limit=100`,
+        { getToken, activeClinicId: clinicId },
+      );
+      if (!response.ok) throw await readApiError(response);
+      const payload = (await response.json()) as { items: DiabetesHistoryItem[] };
+      setItems(payload.items);
+    } catch (loadError) {
+      const encounters = await db.encounters.where('patientId').equals(patientId).toArray();
+      const statusByEncounter = new Map(
+        encounters.map((encounter) => [encounter.id, encounter.status]),
+      );
+      const encounterIds = new Set(
+        encounters
+          .filter((encounter) => encounter.clinicId === clinicId)
+          .map((encounter) => encounter.id),
+      );
+      const cached = (await db.diabetes_screenings.where('clinicId').equals(clinicId).toArray())
+        .filter((record) => encounterIds.has(record.encounterId))
+        .map((record) => fromLocal(record, statusByEncounter.get(record.encounterId)))
+        .sort(
+          (left, right) =>
+            new Date(right.collectedAt).getTime() - new Date(left.collectedAt).getTime(),
+        );
+      setItems(cached);
+      if (cached.length === 0) {
+        setError(
+          loadError instanceof Error ? loadError.message : 'Unable to load diabetes history.',
+        );
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [clinicId, getToken, patientId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const current = currentEncounterId
+    ? items.find((item) => item.sourceEncounter.id === currentEncounterId)
+    : undefined;
+  const history = currentEncounterId
+    ? items.filter((item) => item.sourceEncounter.id !== currentEncounterId)
+    : items;
+
+  const renderRecord = (item: DiabetesHistoryItem, currentRecord = false) => (
+    <li key={item.id} className="rounded-3xl border border-border/80 bg-background/75 p-4 sm:p-5">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0 space-y-3">
+          <div className="flex flex-wrap items-center gap-2">
+            {currentRecord ? <Badge>Current encounter</Badge> : null}
+            <Badge variant="outline">{contextLabel(item.glucoseType)}</Badge>
+            <Badge variant={item.sourceEncounter.status === 'FINALIZED' ? 'default' : 'secondary'}>
+              {item.sourceEncounter.status.replaceAll('_', ' ')}
+            </Badge>
+          </div>
+          <div className="flex flex-wrap gap-x-6 gap-y-2">
+            <p className="text-lg font-semibold">
+              {item.glucoseMgDl == null ? 'No glucose value' : `${item.glucoseMgDl} mg/dL`}
+            </p>
+            <p className="text-lg font-semibold">
+              {item.hba1cPercent == null ? 'No HbA1c value' : `HbA1c ${item.hba1cPercent}%`}
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-x-5 gap-y-2 text-sm text-muted-foreground">
+            <span className="inline-flex items-center gap-2">
+              <CalendarClock className="h-4 w-4" aria-hidden="true" />
+              <time dateTime={item.collectedAt}>{new Date(item.collectedAt).toLocaleString()}</time>
+            </span>
+            <span className="inline-flex items-center gap-2">
+              <UserRound className="h-4 w-4" aria-hidden="true" />
+              {item.author?.displayName ?? 'Author unavailable offline'}
+            </span>
+          </div>
+          {item.symptoms.length ? (
+            <div className="flex flex-wrap gap-2" aria-label="Recorded symptoms">
+              {item.symptoms.map((symptom) => (
+                <Badge key={symptom} variant="secondary">
+                  {DIABETES_SYMPTOM_LABELS[symptom]}
+                </Badge>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">No symptoms selected.</p>
+          )}
+          {item.notes ? (
+            <p className="whitespace-pre-wrap text-sm leading-6">{item.notes}</p>
+          ) : null}
+          {item.legacySymptomsUnmapped ? (
+            <InlineNotice tone="info">
+              <AlertTriangle className="h-4 w-4 shrink-0" aria-hidden="true" />
+              Some legacy symptom content could not be mapped. The original content is preserved.
+            </InlineNotice>
+          ) : null}
+        </div>
+        <Button asChild variant="outline" className="min-h-11 shrink-0 rounded-2xl">
+          <Link href={`/clinics/${clinicId}/encounters/${item.sourceEncounter.id}`}>
+            Open source visit <ExternalLink className="h-4 w-4" aria-hidden="true" />
+          </Link>
+        </Button>
+      </div>
+    </li>
+  );
+
+  return (
+    <Card className="rounded-[28px] border-border/80 bg-card/90 shadow-lg shadow-black/5">
+      <CardHeader className="flex-row items-start justify-between gap-4 space-y-0">
+        <div>
+          <h2 className="font-heading text-xl font-semibold">Longitudinal diabetes history</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Staff-recorded screenings remain linked to their source visits. Patient-entered portal
+            measurements are unchanged and stay in Trends.
+          </p>
+        </div>
+        <Droplets className="h-6 w-6 shrink-0 text-primary" aria-hidden="true" />
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {error ? <InlineNotice tone="error">{error}</InlineNotice> : null}
+        {loading ? (
+          <p role="status" className="text-sm text-muted-foreground">
+            Loading diabetes history…
+          </p>
+        ) : null}
+        {!loading && currentEncounterId ? (
+          <section aria-labelledby="current-diabetes-record" className="space-y-3">
+            <h3
+              id="current-diabetes-record"
+              className="text-sm font-semibold uppercase tracking-[0.16em] text-muted-foreground"
+            >
+              Current encounter
+            </h3>
+            {current ? (
+              <ul>{renderRecord(current, true)}</ul>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                No diabetes screening has been saved for this encounter.
+              </p>
+            )}
+          </section>
+        ) : null}
+        <section aria-labelledby="previous-diabetes-records" className="space-y-3">
+          <h3
+            id="previous-diabetes-records"
+            className="text-sm font-semibold uppercase tracking-[0.16em] text-muted-foreground"
+          >
+            {currentEncounterId ? 'Previous screenings' : 'Screening history'}
+          </h3>
+          {!loading && history.length === 0 ? (
+            <EmptyStateCard
+              title="No previous diabetes screenings"
+              description="A chronological history will appear after staff save screenings in encounters."
+            />
+          ) : (
+            <ol className="space-y-3">{history.map((item) => renderRecord(item))}</ol>
+          )}
+        </section>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/e2e/diabetes-screening.spec.js
+++ b/apps/web/e2e/diabetes-screening.spec.js
@@ -1,0 +1,118 @@
+const path = require('path');
+const { randomUUID } = require('crypto');
+const { test, expect } = require('@playwright/test');
+
+const authFile = path.join(__dirname, '..', 'playwright', '.auth', 'staff.json');
+
+test.use({ storageState: authFile });
+
+async function createPatient(page) {
+  const suffix = randomUUID().replaceAll('-', '').slice(0, 12);
+  await page.goto('/patients/new');
+  await page.getByLabel('First name *').fill('Diabetes');
+  await page.getByLabel('Last name *').fill(`E2E-${suffix}`);
+  await page.getByLabel('National ID *').fill(`E2E-DIABETES-${suffix}`);
+  await page.getByRole('button', { name: 'Create patient' }).click();
+  await page.waitForURL(/\/clinics\/[^/]+\/patients\/[^/]+$/, { timeout: 20_000 });
+  return page.url().split('/').at(-1);
+}
+
+async function createEncounter(page, patientId) {
+  const responsePromise = page.waitForResponse(
+    (response) =>
+      response.request().method() === 'POST' &&
+      /\/clinics\/[^/]+\/encounters$/.test(new URL(response.url()).pathname),
+  );
+  await page.goto(`/patients/${patientId}/encounters/new`);
+  const response = await responsePromise;
+  expect(response.ok()).toBeTruthy();
+  const encounter = await response.json();
+  await page.goto(`/encounters/${encounter.id}`);
+  await page.getByRole('tab', { name: 'Diabetes' }).click();
+  return encounter.id;
+}
+
+async function chooseContext(page, option) {
+  await page.getByLabel('Glucose context').click();
+  await page.getByRole('option', { name: option, exact: true }).click();
+}
+
+async function saveAndSync(page) {
+  const push = page.waitForResponse(
+    (response) =>
+      response.request().method() === 'POST' && new URL(response.url()).pathname === '/sync/push',
+  );
+  await page.getByRole('button', { name: 'Save diabetes screening' }).click();
+  expect((await push).ok()).toBeTruthy();
+}
+
+test('diabetes screening round-trips longitudinally, offline, read-only, and responsively', async ({
+  page,
+  context,
+}) => {
+  const patientId = await createPatient(page);
+  const firstEncounterId = await createEncounter(page, patientId);
+
+  await page.getByLabel('Glucose (mg/dL)').fill('601');
+  await page.getByRole('button', { name: 'Save diabetes screening' }).click();
+  await expect(page.getByText('Glucose must be a whole number from 0 to 600 mg/dL.')).toBeVisible();
+
+  await page.getByLabel('Glucose (mg/dL)').fill('126');
+  await chooseContext(page, 'Fasting');
+  await page.getByLabel('HbA1c (%)').fill('6.5');
+  await page.getByLabel('Polyuria').check();
+  await page.getByLabel('Clinical notes').fill('First encounter screening');
+  await saveAndSync(page);
+
+  await expect(page.getByRole('button', { name: 'Save diabetes screening' })).toBeEnabled();
+  await page.getByLabel('Glucose (mg/dL)').focus();
+  await page.keyboard.press('Tab');
+  await expect(page.getByLabel('Glucose context')).toBeFocused();
+
+  await page.getByRole('button', { name: 'Submit for Review' }).click();
+  await page.getByRole('button', { name: 'Mark Reviewed' }).click();
+  await page.getByRole('button', { name: 'Finalize' }).click();
+  await page.getByRole('tab', { name: 'Diabetes' }).click();
+  await expect(page.getByText('This screening is read-only.')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Save diabetes screening' })).toHaveCount(0);
+
+  const secondEncounterId = await createEncounter(page, patientId);
+  expect(secondEncounterId).not.toBe(firstEncounterId);
+  await page.getByLabel('Glucose (mg/dL)').fill('170');
+  await chooseContext(page, 'Unknown / not documented');
+  await page.getByLabel('Fatigue').check();
+  await page.getByLabel('Clinical notes').fill('Second encounter screening');
+  await saveAndSync(page);
+
+  await context.setOffline(true);
+  await page.getByLabel('Clinical notes').fill('Second encounter screening updated offline');
+  await page.getByRole('button', { name: 'Save diabetes screening' }).click();
+  await expect(
+    page.getByText('Diabetes screening saved on this device and pending sync.'),
+  ).toBeVisible();
+
+  const reconnectPush = page.waitForResponse(
+    (response) =>
+      response.request().method() === 'POST' && new URL(response.url()).pathname === '/sync/push',
+  );
+  await context.setOffline(false);
+  expect((await reconnectPush).ok()).toBeTruthy();
+
+  await page.goto(`/patients/${patientId}`);
+  await page.getByRole('tab', { name: 'Diabetes' }).click();
+  await expect(page.getByText('First encounter screening')).toBeVisible();
+  await expect(page.getByText('Second encounter screening updated offline')).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Open source visit' })).toHaveCount(2);
+
+  for (const viewport of [
+    { width: 375, height: 812 },
+    { width: 768, height: 1024 },
+    { width: 1024, height: 768 },
+    { width: 1440, height: 900 },
+  ]) {
+    await page.setViewportSize(viewport);
+    expect(
+      await page.evaluate(() => document.documentElement.scrollWidth > window.innerWidth + 1),
+    ).toBeFalsy();
+  }
+});

--- a/apps/web/lib/db-migrations.test.ts
+++ b/apps/web/lib/db-migrations.test.ts
@@ -1,4 +1,8 @@
-import { migrateLegacyPulse } from './db-migrations';
+import {
+  migrateLegacyDiabetesScreening,
+  migrateLegacyPulse,
+  type LegacyDiabetesScreeningRecord,
+} from './db-migrations';
 
 describe('Dexie clinical measurement migrations', () => {
   it('preserves a legacy heart rate as pulse bpm', () => {
@@ -15,5 +19,33 @@ describe('Dexie clinical measurement migrations', () => {
     migrateLegacyPulse(record);
 
     expect(record).toEqual({ pulseBpm: 70 });
+  });
+
+  it('structures recognized legacy diabetes symptoms and preserves collection context', () => {
+    const record: LegacyDiabetesScreeningRecord = {
+      symptomsJson: '["Polyuria","Blurred vision"]',
+      createdAt: '2026-08-10T10:00:00.000Z',
+    };
+
+    migrateLegacyDiabetesScreening(record);
+
+    expect(record).toEqual({
+      symptomsJson: '["Polyuria","Blurred vision"]',
+      symptoms: ['POLYURIA', 'BLURRED_VISION'],
+      legacySymptomsUnmapped: false,
+      createdAt: '2026-08-10T10:00:00.000Z',
+      collectedAt: '2026-08-10T10:00:00.000Z',
+    });
+  });
+
+  it('flags malformed legacy diabetes symptoms without deleting the raw value', () => {
+    const record: LegacyDiabetesScreeningRecord = { symptomsJson: '{not-json' };
+
+    migrateLegacyDiabetesScreening(record);
+
+    expect(record.symptomsJson).toBe('{not-json');
+    expect(record.symptoms).toEqual([]);
+    expect(record.legacySymptomsUnmapped).toBe(true);
+    expect(record.collectedAt).toEqual(expect.any(String));
   });
 });

--- a/apps/web/lib/db-migrations.ts
+++ b/apps/web/lib/db-migrations.ts
@@ -1,3 +1,5 @@
+import { parseLegacyDiabetesSymptoms, type DiabetesSymptom } from '@nkwapa/db/diabetes-screening';
+
 export interface LegacyPulseRecord {
   heartRate?: number;
   pulseBpm?: number;
@@ -9,4 +11,22 @@ export function migrateLegacyPulse(record: LegacyPulseRecord): void {
     record.pulseBpm = record.heartRate;
   }
   delete record.heartRate;
+}
+
+export interface LegacyDiabetesScreeningRecord {
+  symptoms?: DiabetesSymptom[];
+  symptomsJson?: string;
+  legacySymptomsUnmapped?: boolean;
+  collectedAt?: string;
+  createdAt?: string;
+}
+
+/** Mutates a cached diabetes row during the Dexie v6 upgrade. */
+export function migrateLegacyDiabetesScreening(record: LegacyDiabetesScreeningRecord): void {
+  if (!record.symptoms) {
+    const parsed = parseLegacyDiabetesSymptoms(record.symptomsJson);
+    record.symptoms = parsed.symptoms;
+    record.legacySymptomsUnmapped = parsed.hasUnmapped;
+  }
+  record.collectedAt ??= record.createdAt ?? new Date().toISOString();
 }

--- a/apps/web/lib/db-migrations.ts
+++ b/apps/web/lib/db-migrations.ts
@@ -1,4 +1,4 @@
-import { parseLegacyDiabetesSymptoms, type DiabetesSymptom } from '@nkwapa/db/diabetes-screening';
+import { parseLegacyDiabetesSymptoms, type DiabetesSymptom } from '@nkwapa/db';
 
 export interface LegacyPulseRecord {
   heartRate?: number;

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -83,7 +83,7 @@ export interface DiabetesScreeningRecord {
   glucoseMgDl?: number;
   glucoseType?: string;
   hba1cPercent?: number;
-  symptoms?: import('@nkwapa/db/diabetes-screening').DiabetesSymptom[];
+  symptoms?: import('@nkwapa/db').DiabetesSymptom[];
   symptomsJson?: string;
   legacySymptomsUnmapped?: boolean;
   notes?: string;

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -83,8 +83,14 @@ export interface DiabetesScreeningRecord {
   glucoseMgDl?: number;
   glucoseType?: string;
   hba1cPercent?: number;
+  symptoms?: import('@nkwapa/db/diabetes-screening').DiabetesSymptom[];
   symptomsJson?: string;
+  legacySymptomsUnmapped?: boolean;
   notes?: string;
+  collectedAt?: string;
+  authoredByUserId?: string;
+  authoredBy?: { id: string; displayName: string };
+  encounterStatus?: string;
   createdAt?: string;
   updatedAt?: string;
 }
@@ -336,6 +342,17 @@ export class NkwapaDb extends Dexie {
       patient_pharmacy_preferences:
         'id, clinicId, patientId, pharmacyRecordId, effectiveTo, updatedAt',
     });
+    this.version(6)
+      .stores({
+        diabetes_screenings: 'id, clinicId, encounterId, collectedAt, updatedAt',
+      })
+      .upgrade(async (transaction) => {
+        const { migrateLegacyDiabetesScreening } = await import('./db-migrations');
+        await transaction
+          .table<DiabetesScreeningRecord, string>('diabetes_screenings')
+          .toCollection()
+          .modify(migrateLegacyDiabetesScreening);
+      });
   }
 }
 

--- a/apps/web/lib/sync.test.ts
+++ b/apps/web/lib/sync.test.ts
@@ -1,0 +1,96 @@
+const emptyPull = {
+  cursor: 'cursor-1',
+  patients: [],
+  encounters: [],
+  vitals: [],
+  tobaccoScreenings: [],
+  diabetesScreenings: [],
+  hypertensionAssessments: [],
+  carePlans: [],
+  patientConsents: [],
+  prescriptions: [],
+  medicalHistoryRecords: [],
+  medicalHistoryRevisions: [],
+  patientMedicationRecords: [],
+  patientMedicationRevisions: [],
+  medicationReconciliationEvents: [],
+  patientPharmacyRecords: [],
+  patientPharmacyRevisions: [],
+  patientPharmacyPreferences: [],
+};
+
+const mutation = {
+  id: 'mutation-1',
+  clinicId: 'clinic-1',
+  entityType: 'diabetes_screening',
+  entityId: 'screening-1',
+  operation: 'UPSERT',
+  payloadJson: JSON.stringify({ encounterId: 'encounter-1' }),
+  idempotencyKey: 'idempotency-1',
+  createdAt: '2026-08-12T12:00:00.000Z',
+};
+
+jest.mock('./db', () => {
+  const put = jest.fn();
+  const mockSortBy = jest.fn().mockResolvedValueOnce([]).mockResolvedValueOnce([mutation]);
+  const table = { put };
+  return {
+    db: {
+      outbox: {
+        where: jest.fn(() => ({ equals: jest.fn(() => ({ sortBy: mockSortBy })) })),
+        delete: jest.fn(),
+      },
+      sync_state: { get: jest.fn(), put },
+      patients: table,
+      encounters: table,
+      vitals: table,
+      tobacco_screenings: table,
+      diabetes_screenings: table,
+      hypertension_assessments: table,
+      care_plans: table,
+      patient_consents: table,
+      prescriptions: table,
+      medical_history_records: table,
+      medical_history_revisions: table,
+      patient_medication_records: table,
+      patient_medication_revisions: table,
+      medication_reconciliation_events: table,
+      patient_pharmacy_records: table,
+      patient_pharmacy_revisions: table,
+      patient_pharmacy_preferences: table,
+    },
+  };
+});
+
+import { syncNow } from './sync';
+
+describe('sync coordinator', () => {
+  it('runs a follow-up pass when a mutation is queued during an active sync', async () => {
+    let resolveFirstPull!: (value: unknown) => void;
+    const firstPull = new Promise((resolve) => {
+      resolveFirstPull = resolve;
+    });
+    const fetchMock = jest
+      .fn()
+      .mockReturnValueOnce(firstPull)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ results: [{ id: mutation.id, status: 'APPLIED' }] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ...emptyPull, cursor: 'cursor-2' }),
+      });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const first = syncNow({ clinicId: mutation.clinicId });
+    const concurrent = syncNow({ clinicId: mutation.clinicId });
+    expect(concurrent).toBe(first);
+
+    resolveFirstPull({ ok: true, json: async () => emptyPull });
+
+    await expect(first).resolves.toEqual({ success: true });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[1]?.[0]).toContain('/sync/push');
+  });
+});

--- a/apps/web/lib/sync.ts
+++ b/apps/web/lib/sync.ts
@@ -11,6 +11,7 @@ export type SyncStatusListener = (status: SyncStatus, error?: string) => void;
 
 const listeners: Set<SyncStatusListener> = new Set();
 const inFlightByClinic = new Map<string, Promise<SyncResult>>();
+const rerunRequestedByClinic = new Set<string>();
 
 export function onSyncStatusChange(listener: SyncStatusListener): () => void {
   listeners.add(listener);
@@ -237,12 +238,30 @@ async function performSync(options: SyncNowOptions): Promise<SyncResult> {
   }
 }
 
-/** Coalesces concurrent retries so one clinic never replays the same outbox batch twice. */
+/**
+ * Coalesces concurrent retries without losing mutations queued during an active sync pass.
+ * A concurrent caller requests one follow-up pass after the current push/pull completes.
+ */
 export function syncNow(options: SyncNowOptions): Promise<SyncResult> {
   const inFlight = inFlightByClinic.get(options.clinicId);
-  if (inFlight) return inFlight;
+  if (inFlight) {
+    rerunRequestedByClinic.add(options.clinicId);
+    return inFlight;
+  }
 
-  const request = performSync(options).finally(() => {
+  const request = (async () => {
+    const conflicts: NonNullable<SyncResult['conflicts']> = [];
+    let result: SyncResult;
+
+    do {
+      rerunRequestedByClinic.delete(options.clinicId);
+      result = await performSync(options);
+      if (result.conflicts) conflicts.push(...result.conflicts);
+    } while (result.success && rerunRequestedByClinic.has(options.clinicId));
+
+    return conflicts.length ? { ...result, conflicts } : result;
+  })().finally(() => {
+    rerunRequestedByClinic.delete(options.clinicId);
     if (inFlightByClinic.get(options.clinicId) === request) {
       inFlightByClinic.delete(options.clinicId);
     }

--- a/docs/specs/00_INDEX.md
+++ b/docs/specs/00_INDEX.md
@@ -39,6 +39,7 @@ Use this file first when you need to answer one of these questions:
 | `docs/specs/06_PATIENTS_MODULE.md`                          | Current with follow-on work | Current patient registry, portal link/invite, and merge behavior               |
 | `docs/specs/07_MEDICAL_HISTORY_AND_ALLERGIES.md`            | Current                     | Longitudinal history, allergy safety, rollout, and release-gate contract       |
 | `docs/specs/08_MEDICATION_RECONCILIATION_AND_PHARMACIES.md` | Current                     | Reported medications, pharmacy history, offline conflicts, and rollout         |
+| `docs/specs/09_DIABETES_SCREENING.md`                       | Current                     | Diabetes record, compatibility, access, downstream, and release-gate contract  |
 | `docs/clinic-ops/26_RESEARCH_EXPORT_TRANSFORMS_V1.md`       | Current                     | Research export v1 compatibility and v2 pipeline contract                      |
 
 ---

--- a/docs/specs/09_DIABETES_SCREENING.md
+++ b/docs/specs/09_DIABETES_SCREENING.md
@@ -1,0 +1,51 @@
+# Dedicated Longitudinal Diabetes Screening
+
+## Scope
+
+Diabetes screening is a staff clinical workflow in encounter and patient-chart surfaces. It does
+not infer a diagnosis, change clinical thresholds, or expand patient-portal access or contribution.
+
+## Clinical record
+
+Each source encounter has at most one stable diabetes screening record containing:
+
+- glucose in mg/dL and an explicit `FASTING`, `RANDOM`, or `UNKNOWN` context;
+- HbA1c percentage;
+- structured Polyuria, Polydipsia, Weight loss, Blurred vision, and Fatigue symptoms;
+- multiline clinical notes and sample collection time;
+- author, source encounter, encounter status, and legacy-migration warning provenance.
+
+`UNKNOWN` remains a distinct context. Dashboard flags retain the approved fasting `>=126 mg/dL`
+and random `>=200 mg/dL` thresholds and never classify unknown-context measurements.
+
+## Compatibility and migration
+
+The migration backfills collection time from record creation and author from the source encounter
+creator. Recognized legacy `symptomsJson` values populate the structured symptom array. Raw legacy
+content remains preserved; malformed or unmapped content sets a staff-visible warning.
+
+New REST and sync writes use `symptoms`. Legacy sync clients may send `symptomsJson`, but a payload
+containing both contracts is rejected as ambiguous. Sync pull derives the deprecated JSON form for
+older deployed clients. Stable screening IDs, explicit null field clearing, and idempotency are
+preserved across online and offline writes.
+
+## Access and lifecycle
+
+- Staff reads require `SCREENING.READ` and clinic-scoped access.
+- Writes require `SCREENING.WRITE`, matching clinic and patient scope, and a non-finalized source
+  encounter.
+- Finalized records remain visible in read-only encounter tabs and patient history.
+- Every mutation records the current actor and an audit event.
+
+## Downstream behavior
+
+Glucose trends and research `recorded_at` use collection time. Research columns,
+de-identification, source encounter keys, patient self-reports, and patient-portal routes remain
+compatible. Patient-chart history is newest-first and links every staff screening to its visit.
+
+## Release verification
+
+The release gate covers migration compatibility, DTO and service validation, RBAC and clinic
+isolation, finalized-record enforcement, sync replay and conflicts, dashboard thresholds, trends,
+research exports, Dexie migration, accessible labels, keyboard navigation, offline round-trips,
+longitudinal history, and responsive widths at 375, 768, 1024, and 1440 pixels.

--- a/packages/db/index.ts
+++ b/packages/db/index.ts
@@ -15,3 +15,17 @@ export {
   toCelsius,
   type TemperatureUnit,
 } from './src/clinical-measurements';
+export {
+  DIABETES_GLUCOSE_TYPES,
+  DIABETES_SYMPTOMS,
+  DIABETES_SYMPTOM_LABELS,
+  DIABETES_GLUCOSE_MIN_MG_DL,
+  DIABETES_GLUCOSE_MAX_MG_DL,
+  DIABETES_HBA1C_MIN_PERCENT,
+  DIABETES_HBA1C_MAX_PERCENT,
+  parseLegacyDiabetesSymptoms,
+  serializeLegacyDiabetesSymptoms,
+  type DiabetesGlucoseType,
+  type DiabetesSymptom,
+  type ParsedLegacyDiabetesSymptoms,
+} from './src/diabetes-screening';

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -12,6 +12,10 @@
     "./clinical-measurements": {
       "types": "./dist/src/clinical-measurements.d.ts",
       "default": "./dist/src/clinical-measurements.js"
+    },
+    "./diabetes-screening": {
+      "types": "./dist/src/diabetes-screening.d.ts",
+      "default": "./dist/src/diabetes-screening.js"
     }
   },
   "scripts": {

--- a/packages/db/prisma/migrations/20260812000000_promote_diabetes_screening/migration.sql
+++ b/packages/db/prisma/migrations/20260812000000_promote_diabetes_screening/migration.sql
@@ -1,0 +1,99 @@
+CREATE TYPE "DiabetesSymptom" AS ENUM (
+  'POLYURIA',
+  'POLYDIPSIA',
+  'WEIGHT_LOSS',
+  'BLURRED_VISION',
+  'FATIGUE'
+);
+
+ALTER TABLE "DiabetesScreening"
+  ADD COLUMN "symptoms" "DiabetesSymptom"[] NOT NULL DEFAULT ARRAY[]::"DiabetesSymptom"[],
+  ADD COLUMN "legacySymptomsUnmapped" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN "collectedAt" TIMESTAMP(3),
+  ADD COLUMN "authoredByUserId" UUID;
+
+UPDATE "DiabetesScreening" screening
+SET
+  "collectedAt" = screening."createdAt",
+  "authoredByUserId" = encounter."createdByUserId"
+FROM "Encounter" encounter
+WHERE encounter."id" = screening."encounterId";
+
+DO $$
+DECLARE
+  screening_row RECORD;
+  parsed JSONB;
+  mapped "DiabetesSymptom"[];
+  source_count INTEGER;
+  mapped_count INTEGER;
+BEGIN
+  FOR screening_row IN
+    SELECT "id", "symptomsJson"
+    FROM "DiabetesScreening"
+    WHERE "symptomsJson" IS NOT NULL AND btrim("symptomsJson") <> ''
+  LOOP
+    BEGIN
+      parsed := screening_row."symptomsJson"::JSONB;
+      IF jsonb_typeof(parsed) <> 'array' THEN
+        UPDATE "DiabetesScreening"
+        SET "legacySymptomsUnmapped" = true
+        WHERE "id" = screening_row."id";
+        CONTINUE;
+      END IF;
+
+      SELECT
+        COUNT(*),
+        COALESCE(
+          ARRAY_AGG(DISTINCT mapped_value ORDER BY mapped_value)
+            FILTER (WHERE mapped_value IS NOT NULL),
+          ARRAY[]::"DiabetesSymptom"[]
+        ),
+        COUNT(mapped_value)
+      INTO source_count, mapped, mapped_count
+      FROM (
+        SELECT CASE value
+          WHEN 'Polyuria' THEN 'POLYURIA'::"DiabetesSymptom"
+          WHEN 'POLYURIA' THEN 'POLYURIA'::"DiabetesSymptom"
+          WHEN 'Polydipsia' THEN 'POLYDIPSIA'::"DiabetesSymptom"
+          WHEN 'POLYDIPSIA' THEN 'POLYDIPSIA'::"DiabetesSymptom"
+          WHEN 'Weight loss' THEN 'WEIGHT_LOSS'::"DiabetesSymptom"
+          WHEN 'WEIGHT_LOSS' THEN 'WEIGHT_LOSS'::"DiabetesSymptom"
+          WHEN 'Blurred vision' THEN 'BLURRED_VISION'::"DiabetesSymptom"
+          WHEN 'BLURRED_VISION' THEN 'BLURRED_VISION'::"DiabetesSymptom"
+          WHEN 'Fatigue' THEN 'FATIGUE'::"DiabetesSymptom"
+          WHEN 'FATIGUE' THEN 'FATIGUE'::"DiabetesSymptom"
+          ELSE NULL
+        END AS mapped_value
+        FROM jsonb_array_elements_text(parsed) AS item(value)
+      ) values_to_map;
+
+      UPDATE "DiabetesScreening"
+      SET
+        "symptoms" = mapped,
+        "legacySymptomsUnmapped" = source_count <> mapped_count
+      WHERE "id" = screening_row."id";
+    EXCEPTION WHEN OTHERS THEN
+      UPDATE "DiabetesScreening"
+      SET "legacySymptomsUnmapped" = true
+      WHERE "id" = screening_row."id";
+    END;
+  END LOOP;
+END $$;
+
+ALTER TABLE "DiabetesScreening"
+  ALTER COLUMN "collectedAt" SET NOT NULL,
+  ALTER COLUMN "collectedAt" SET DEFAULT CURRENT_TIMESTAMP,
+  ALTER COLUMN "authoredByUserId" SET NOT NULL;
+
+ALTER TABLE "DiabetesScreening"
+  ADD CONSTRAINT "DiabetesScreening_glucose_range_check"
+    CHECK ("glucoseMgDl" IS NULL OR ("glucoseMgDl" >= 0 AND "glucoseMgDl" <= 600)),
+  ADD CONSTRAINT "DiabetesScreening_hba1c_range_check"
+    CHECK ("hba1cPercent" IS NULL OR ("hba1cPercent" >= 0 AND "hba1cPercent" <= 100)),
+  ADD CONSTRAINT "DiabetesScreening_authoredByUserId_fkey"
+    FOREIGN KEY ("authoredByUserId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+CREATE INDEX "DiabetesScreening_clinicId_collectedAt_idx"
+  ON "DiabetesScreening"("clinicId", "collectedAt");
+CREATE INDEX "DiabetesScreening_authoredByUserId_collectedAt_idx"
+  ON "DiabetesScreening"("authoredByUserId", "collectedAt");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -75,6 +75,14 @@ enum GlucoseType {
   UNKNOWN
 }
 
+enum DiabetesSymptom {
+  POLYURIA
+  POLYDIPSIA
+  WEIGHT_LOSS
+  BLURRED_VISION
+  FATIGUE
+}
+
 enum PatientSelfReportType {
   FOLLOW_UP_UPDATE
   HOME_BP
@@ -391,6 +399,7 @@ model User {
   setPharmacyPreferences        PatientPharmacyPreference[]     @relation("PatientPharmacyPreferenceSetBy")
   endedPharmacyPreferences      PatientPharmacyPreference[]     @relation("PatientPharmacyPreferenceEndedBy")
   reviewedTobaccoScreenings     TobaccoScreening[]              @relation("TobaccoScreeningReviewedBy")
+  authoredDiabetesScreenings    DiabetesScreening[]             @relation("DiabetesScreeningAuthoredBy")
 
   @@index([isActive])
 }
@@ -679,17 +688,25 @@ model DiabetesScreening {
   glucoseType  GlucoseType @default(UNKNOWN)
   hba1cPercent Float?
 
-  symptomsJson String? @db.Text // store JSON string (or move to Json type if preferred)
+  symptoms               DiabetesSymptom[] @default([])
+  symptomsJson           String?           @db.Text
+  legacySymptomsUnmapped Boolean           @default(false)
 
   notes String? @db.Text
+
+  collectedAt     DateTime @default(now())
+  authoredByUserId String   @db.Uuid
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  encounter Encounter @relation(fields: [encounterId], references: [id], onDelete: Cascade)
-  clinic    Clinic    @relation(fields: [clinicId], references: [id], onDelete: Cascade)
+  encounter  Encounter @relation(fields: [encounterId], references: [id], onDelete: Cascade)
+  clinic     Clinic    @relation(fields: [clinicId], references: [id], onDelete: Cascade)
+  authoredBy User      @relation("DiabetesScreeningAuthoredBy", fields: [authoredByUserId], references: [id])
 
   @@index([clinicId, updatedAt])
+  @@index([clinicId, collectedAt])
+  @@index([authoredByUserId, collectedAt])
 }
 
 model HypertensionAssessment {

--- a/packages/db/src/diabetes-migration.integration.spec.ts
+++ b/packages/db/src/diabetes-migration.integration.spec.ts
@@ -1,0 +1,140 @@
+import { readFile, readdir } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { Client } from 'pg';
+
+const TARGET_MIGRATION = '20260812000000_promote_diabetes_screening';
+const describeMigration =
+  process.env.RUN_DIABETES_MIGRATION_TESTS === '1' ? describe : describe.skip;
+
+function databaseUrl(source: string, database: string): string {
+  const url = new URL(source);
+  url.pathname = `/${database}`;
+  return url.toString();
+}
+
+describeMigration('diabetes screening legacy database migration', () => {
+  jest.setTimeout(120_000);
+
+  it('preserves legacy symptoms, backfills provenance, and enforces measurement bounds', async () => {
+    const sourceUrl = process.env.DATABASE_URL;
+    if (!sourceUrl) throw new Error('DATABASE_URL is required for migration integration tests');
+
+    const database = `nkwapa_diabetes_${process.pid}_${Date.now()}`;
+    const admin = new Client({ connectionString: databaseUrl(sourceUrl, 'postgres') });
+    const target = new Client({ connectionString: databaseUrl(sourceUrl, database) });
+
+    await admin.connect();
+    try {
+      await admin.query(`CREATE DATABASE "${database}"`);
+      await target.connect();
+      try {
+        const migrationsRoot = resolve(__dirname, '../prisma/migrations');
+        const migrationNames = (await readdir(migrationsRoot))
+          .filter((name) => /^\d/.test(name))
+          .sort();
+        const targetIndex = migrationNames.indexOf(TARGET_MIGRATION);
+        expect(targetIndex).toBeGreaterThan(0);
+
+        for (const migrationName of migrationNames.slice(0, targetIndex)) {
+          const sql = await readFile(
+            resolve(migrationsRoot, migrationName, 'migration.sql'),
+            'utf8',
+          );
+          await target.query(sql);
+        }
+
+        await target.query(`
+          INSERT INTO "Clinic" (
+            "id", "name", "organizationId", "timezone", "locationCode", "updatedAt"
+          ) SELECT
+            '10000000-0000-4000-8000-000000000001', 'Diabetes Migration Clinic', "id",
+            'Africa/Accra', 'diabetes-migration', CURRENT_TIMESTAMP
+          FROM "Organization" WHERE "slug" = 'default';
+
+          INSERT INTO "User" (
+            "id", "keycloakSub", "displayName", "firstName", "lastName", "updatedAt"
+          ) VALUES (
+            '10000000-0000-4000-8000-000000000002', 'diabetes-migration-user',
+            'Migration Author', 'Migration', 'Author', CURRENT_TIMESTAMP
+          );
+
+          INSERT INTO "Patient" (
+            "id", "patientCode", "primaryClinicId", "firstName", "lastName",
+            "nationalIdType", "nationalIdCiphertext", "nationalIdHash", "updatedAt"
+          ) VALUES (
+            '10000000-0000-4000-8000-000000000003', 'NKP-DIABETES-1',
+            '10000000-0000-4000-8000-000000000001', 'Legacy', 'Diabetes',
+            'OTHER', 'encrypted', 'diabetes-migration-hash', CURRENT_TIMESTAMP
+          );
+
+          INSERT INTO "Encounter" (
+            "id", "clinicId", "patientId", "createdByUserId", "createdAt", "updatedAt"
+          ) VALUES
+            ('10000000-0000-4000-8000-000000000010', '10000000-0000-4000-8000-000000000001', '10000000-0000-4000-8000-000000000003', '10000000-0000-4000-8000-000000000002', '2026-08-01T10:00:00Z', CURRENT_TIMESTAMP),
+            ('10000000-0000-4000-8000-000000000011', '10000000-0000-4000-8000-000000000001', '10000000-0000-4000-8000-000000000003', '10000000-0000-4000-8000-000000000002', '2026-08-02T10:00:00Z', CURRENT_TIMESTAMP),
+            ('10000000-0000-4000-8000-000000000012', '10000000-0000-4000-8000-000000000001', '10000000-0000-4000-8000-000000000003', '10000000-0000-4000-8000-000000000002', '2026-08-03T10:00:00Z', CURRENT_TIMESTAMP);
+
+          INSERT INTO "DiabetesScreening" (
+            "id", "clinicId", "encounterId", "symptomsJson", "createdAt", "updatedAt"
+          ) VALUES
+            ('10000000-0000-4000-8000-000000000020', '10000000-0000-4000-8000-000000000001', '10000000-0000-4000-8000-000000000010', '["Polyuria","Fatigue"]', '2026-08-01T10:05:00Z', CURRENT_TIMESTAMP),
+            ('10000000-0000-4000-8000-000000000021', '10000000-0000-4000-8000-000000000001', '10000000-0000-4000-8000-000000000011', '{broken', '2026-08-02T10:05:00Z', CURRENT_TIMESTAMP),
+            ('10000000-0000-4000-8000-000000000022', '10000000-0000-4000-8000-000000000001', '10000000-0000-4000-8000-000000000012', '["Polydipsia","Other"]', '2026-08-03T10:05:00Z', CURRENT_TIMESTAMP);
+        `);
+
+        const migrationSql = await readFile(
+          resolve(migrationsRoot, TARGET_MIGRATION, 'migration.sql'),
+          'utf8',
+        );
+        await target.query(migrationSql);
+
+        const rows = await target.query<{
+          id: string;
+          symptoms: string;
+          legacySymptomsUnmapped: boolean;
+          collectedAt: Date;
+          createdAt: Date;
+          authoredByUserId: string;
+          symptomsJson: string;
+        }>(`
+          SELECT "id", "symptoms"::TEXT AS symptoms, "legacySymptomsUnmapped", "collectedAt", "createdAt",
+                 "authoredByUserId", "symptomsJson"
+          FROM "DiabetesScreening" ORDER BY "id"
+        `);
+
+        expect(rows.rows[0]).toMatchObject({
+          symptoms: '{POLYURIA,FATIGUE}',
+          legacySymptomsUnmapped: false,
+          authoredByUserId: '10000000-0000-4000-8000-000000000002',
+          symptomsJson: '["Polyuria","Fatigue"]',
+        });
+        expect(rows.rows[0]?.collectedAt.toISOString()).toBe(rows.rows[0]?.createdAt.toISOString());
+        expect(rows.rows[1]).toMatchObject({ symptoms: '{}', legacySymptomsUnmapped: true });
+        expect(rows.rows[2]).toMatchObject({
+          symptoms: '{POLYDIPSIA}',
+          legacySymptomsUnmapped: true,
+        });
+
+        await expect(
+          target.query('UPDATE "DiabetesScreening" SET "glucoseMgDl" = 601 WHERE "id" = $1', [
+            '10000000-0000-4000-8000-000000000020',
+          ]),
+        ).rejects.toMatchObject({ code: '23514' });
+        await expect(
+          target.query('UPDATE "DiabetesScreening" SET "hba1cPercent" = 101 WHERE "id" = $1', [
+            '10000000-0000-4000-8000-000000000020',
+          ]),
+        ).rejects.toMatchObject({ code: '23514' });
+      } finally {
+        await target.end().catch(() => undefined);
+      }
+    } finally {
+      await admin.query(
+        'SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1',
+        [database],
+      );
+      await admin.query(`DROP DATABASE IF EXISTS "${database}"`);
+      await admin.end();
+    }
+  });
+});

--- a/packages/db/src/diabetes-migration.spec.ts
+++ b/packages/db/src/diabetes-migration.spec.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('diabetes screening migration', () => {
+  const migration = readFileSync(
+    resolve(
+      __dirname,
+      '../prisma/migrations/20260812000000_promote_diabetes_screening/migration.sql',
+    ),
+    'utf8',
+  );
+
+  it('adds structured symptoms and clinical provenance while retaining legacy JSON', () => {
+    expect(migration).toContain('CREATE TYPE "DiabetesSymptom"');
+    expect(migration).toContain('ADD COLUMN "symptoms"');
+    expect(migration).not.toContain('DROP COLUMN "symptomsJson"');
+    expect(migration).toContain('"legacySymptomsUnmapped"');
+    expect(migration).toContain('"collectedAt" = screening."createdAt"');
+    expect(migration).toContain('"authoredByUserId" = encounter."createdByUserId"');
+  });
+
+  it('maps every supported legacy label and catches malformed JSON', () => {
+    for (const label of ['Polyuria', 'Polydipsia', 'Weight loss', 'Blurred vision', 'Fatigue']) {
+      expect(migration).toContain(`WHEN '${label}'`);
+    }
+    expect(migration).toContain('EXCEPTION WHEN OTHERS');
+  });
+
+  it('adds bounds, provenance indexes, and the author foreign key', () => {
+    expect(migration).toContain('"DiabetesScreening_glucose_range_check"');
+    expect(migration).toContain('"DiabetesScreening_hba1c_range_check"');
+    expect(migration).toContain('"DiabetesScreening_clinicId_collectedAt_idx"');
+    expect(migration).toContain('"DiabetesScreening_authoredByUserId_fkey"');
+  });
+});

--- a/packages/db/src/diabetes-screening.spec.ts
+++ b/packages/db/src/diabetes-screening.spec.ts
@@ -1,0 +1,23 @@
+import { parseLegacyDiabetesSymptoms, serializeLegacyDiabetesSymptoms } from './diabetes-screening';
+
+describe('diabetes screening shared contract', () => {
+  it('maps legacy display labels and canonical values without duplicates', () => {
+    expect(parseLegacyDiabetesSymptoms('["Polyuria","POLYURIA","Weight loss"]')).toEqual({
+      symptoms: ['POLYURIA', 'WEIGHT_LOSS'],
+      hasUnmapped: false,
+    });
+  });
+
+  it.each(['{broken', '{"Polyuria":true}', '["Polyuria","Other"]'])(
+    'flags unmapped legacy input %s',
+    (input) => {
+      expect(parseLegacyDiabetesSymptoms(input).hasUnmapped).toBe(true);
+    },
+  );
+
+  it('serializes canonical symptoms for legacy clients', () => {
+    expect(serializeLegacyDiabetesSymptoms(['POLYDIPSIA', 'FATIGUE'])).toBe(
+      '["Polydipsia","Fatigue"]',
+    );
+  });
+});

--- a/packages/db/src/diabetes-screening.ts
+++ b/packages/db/src/diabetes-screening.ts
@@ -1,0 +1,62 @@
+export const DIABETES_GLUCOSE_TYPES = ['FASTING', 'RANDOM', 'UNKNOWN'] as const;
+export type DiabetesGlucoseType = (typeof DIABETES_GLUCOSE_TYPES)[number];
+
+export const DIABETES_SYMPTOMS = [
+  'POLYURIA',
+  'POLYDIPSIA',
+  'WEIGHT_LOSS',
+  'BLURRED_VISION',
+  'FATIGUE',
+] as const;
+export type DiabetesSymptom = (typeof DIABETES_SYMPTOMS)[number];
+
+export const DIABETES_SYMPTOM_LABELS: Record<DiabetesSymptom, string> = {
+  POLYURIA: 'Polyuria',
+  POLYDIPSIA: 'Polydipsia',
+  WEIGHT_LOSS: 'Weight loss',
+  BLURRED_VISION: 'Blurred vision',
+  FATIGUE: 'Fatigue',
+};
+
+export const DIABETES_GLUCOSE_MIN_MG_DL = 0;
+export const DIABETES_GLUCOSE_MAX_MG_DL = 600;
+export const DIABETES_HBA1C_MIN_PERCENT = 0;
+export const DIABETES_HBA1C_MAX_PERCENT = 100;
+
+const LEGACY_SYMPTOM_LOOKUP = new Map<string, DiabetesSymptom>([
+  ...DIABETES_SYMPTOMS.map((symptom) => [symptom, symptom] as const),
+  ...DIABETES_SYMPTOMS.map((symptom) => [DIABETES_SYMPTOM_LABELS[symptom], symptom] as const),
+]);
+
+export interface ParsedLegacyDiabetesSymptoms {
+  symptoms: DiabetesSymptom[];
+  hasUnmapped: boolean;
+}
+
+export function parseLegacyDiabetesSymptoms(value: unknown): ParsedLegacyDiabetesSymptoms {
+  if (value == null || value === '') return { symptoms: [], hasUnmapped: false };
+
+  let parsed: unknown = value;
+  if (typeof value === 'string') {
+    try {
+      parsed = JSON.parse(value) as unknown;
+    } catch {
+      return { symptoms: [], hasUnmapped: true };
+    }
+  }
+
+  if (!Array.isArray(parsed)) return { symptoms: [], hasUnmapped: true };
+
+  const symptoms = new Set<DiabetesSymptom>();
+  let hasUnmapped = false;
+  for (const item of parsed) {
+    const symptom = typeof item === 'string' ? LEGACY_SYMPTOM_LOOKUP.get(item) : undefined;
+    if (symptom) symptoms.add(symptom);
+    else hasUnmapped = true;
+  }
+  return { symptoms: [...symptoms], hasUnmapped };
+}
+
+export function serializeLegacyDiabetesSymptoms(symptoms: readonly DiabetesSymptom[]): string {
+  return JSON.stringify(symptoms.map((symptom) => DIABETES_SYMPTOM_LABELS[symptom]));
+}


### PR DESCRIPTION
## Summary

Promotes diabetes screening from the generic Screening workflow into dedicated, longitudinal Diabetes tabs across encounters and staff patient charts.

Closes #59.

## What changed

### Database and shared clinical contract

- Added a canonical shared diabetes contract for:
  - `FASTING`, `RANDOM`, and `UNKNOWN` glucose context
  - Polyuria
  - Polydipsia
  - Weight loss
  - Blurred vision
  - Fatigue
- Extended diabetes records with:
  - structured symptoms
  - collection time
  - author provenance
  - legacy migration-warning state
  - collection-time indexes
- Backfilled collection time from record creation time.
- Backfilled author from the source encounter creator.
- Migrated recognized legacy `symptomsJson` values while preserving the original raw data.
- Flagged malformed or unmapped legacy symptom content for staff review.
- Added database constraints for glucose `0–600 mg/dL` and HbA1c `0–100%`.
- Upgraded Dexie records to structured symptoms and stable screening IDs.

### API and authorization

Added:

- `GET /clinics/:clinicId/patients/:patientId/diabetes-screenings`
- `PUT /clinics/:clinicId/encounters/:encounterId/diabetes-screening`

The shared diabetes domain service now provides:

- structured validation for glucose context, glucose, HbA1c, symptoms, notes, and timestamps
- collection timestamps limited to five minutes in the future
- explicit-null field clearing
- stable record upserts
- current-actor author attribution
- mutation auditing
- clinic and patient isolation
- finalized-encounter enforcement
- source encounter links, status, author, migration warnings, and editability context

Reads require clinic-scoped `SCREENING.READ`. Writes require `SCREENING.WRITE`. Finalized encounters are immutable.

### Offline sync and compatibility

- Routed diabetes replay through the shared domain service.
- Added idempotent structured symptom replay.
- Preserved clinic isolation, RBAC, audit behavior, and finalized-record enforcement during sync.
- Added a legacy `symptomsJson` compatibility adapter.
- Rejects ambiguous payloads containing both `symptoms` and `symptomsJson`.
- Sync pull derives the deprecated JSON representation for older deployed clients.
- Added a follow-up sync pass when mutations arrive during an active sync, preventing newly queued offline work from being stranded.
- Diabetes saves now sync immediately when online and accurately report synced or pending state.

### Trends, dashboards, and research exports

- Glucose trends and research `recorded_at` now use collection time.
- Preserved patient self-reports and patient-portal behavior.
- Centralized diabetes dashboard filtering.
- Preserved the existing thresholds:
  - fasting glucose `>=126 mg/dL`
  - random glucose `>=200 mg/dL`
- Explicitly excludes `UNKNOWN` context from fasting and random flags.
- Preserved research columns, de-identification, source encounter keys, and export compatibility.

### Clinical UI and UX

- Renamed Screening to Diabetes across encounter navigation, headings, actions, help text, and save-before-switch behavior.
- Added dedicated Diabetes tabs to both role-aware staff patient-chart routes.
- Added a shared longitudinal history panel.
- Separates the current encounter from previous screenings.
- Shows:
  - glucose value, unit, and context
  - HbA1c percentage
  - collection time
  - structured symptoms
  - multiline notes
  - author
  - source encounter link and status
  - legacy migration warnings
- Labels contexts as:
  - Fasting
  - Random
  - Unknown / not documented
- Clearly explains that unknown context is not interpreted as fasting or random.
- Keeps finalized clinical tabs visible in read-only mode.
- Corrected Hypertension and Care Plan finalized-state controls for consistent read-only behavior.
- Added accessible labels, semantic timestamps/statuses, visible focus, 44-pixel targets, keyboard operation, horizontal tab scrolling, and responsive layouts.

### Patient portal

No patient-portal routes, exposure, or contribution capabilities were added or expanded.

No diabetes diagnosis is inferred and no clinical thresholds were changed.

## Migration notes

The migration is backward compatible:

- existing raw `symptomsJson` content is retained
- recognized legacy values populate structured symptoms
- malformed and unknown values remain available for audit review
- collection time falls back to record creation time
- author falls back to the source encounter creator

A successful canonical rewrite clears the staff warning without deleting the original legacy evidence.

## Testing

Passed:

- 380 unit tests with coverage
- PostgreSQL diabetes migration integration test
- 16 Docker-backed Playwright tests
- DTO and service validation
- RBAC, clinic isolation, and finalized-record tests
- structured and legacy sync replay tests
- idempotency and sync-race regression tests
- dashboard, trend, self-report, and research-export regressions
- Dexie migration tests
- online and offline symptom/note round-trips
- two-encounter longitudinal history
- keyboard navigation
- finalized read-only behavior
- responsive overflow checks at 375, 768, 1024, and 1440 pixels
- formatting, lint, typechecks, secret scanning, dependency audits, and production builds

Dependency audits reported 0 vulnerabilities.