### PR TITLE
Patient records/add residential location and location filters

### DIFF
--- a/apps/api/src/clinics/clinics-patients.controller.ts
+++ b/apps/api/src/clinics/clinics-patients.controller.ts
@@ -91,6 +91,12 @@ export class ClinicsPatientsController {
       {
         cursor: query.cursor,
         limit: query.limit,
+        location: {
+          residentialRegion: query.residentialRegion,
+          residentialDistrict: query.residentialDistrict,
+          residentialCommunity: query.residentialCommunity,
+          residentialLocationStatus: query.residentialLocationStatus,
+        },
       },
     );
   }

--- a/apps/api/src/common/ghana-location.validator.ts
+++ b/apps/api/src/common/ghana-location.validator.ts
@@ -1,0 +1,57 @@
+import { isDistrictInRegion } from '@nkwapa/db';
+import { GhanaRegion } from '@prisma/client';
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+
+interface ResidentialLocationShape {
+  residentialRegion?: GhanaRegion | null;
+  residentialDistrict?: string | null;
+}
+
+/**
+ * Cross-field constraint: a residential district is only valid when it belongs
+ * to the sibling `residentialRegion`. An absent district is always valid (the
+ * district is optional even when a region is recorded).
+ */
+@ValidatorConstraint({ name: 'isDistrictInRegion', async: false })
+export class IsDistrictInRegionConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown, args: ValidationArguments): boolean {
+    if (value == null || value === '') {
+      return true;
+    }
+    if (typeof value !== 'string') {
+      return false;
+    }
+    const { residentialRegion } = args.object as ResidentialLocationShape;
+    if (!residentialRegion) {
+      return false;
+    }
+    return isDistrictInRegion(residentialRegion, value);
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    const { residentialRegion } = args.object as ResidentialLocationShape;
+    if (!residentialRegion) {
+      return 'residentialDistrict requires a residentialRegion';
+    }
+    return 'residentialDistrict must be a district within the selected region';
+  }
+}
+
+/** Validates that `residentialDistrict` belongs to `residentialRegion`. */
+export function IsDistrictInRegion(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      constraints: [],
+      validator: IsDistrictInRegionConstraint,
+    });
+  };
+}

--- a/apps/api/src/patients/dto/create-patient-body.dto.ts
+++ b/apps/api/src/patients/dto/create-patient-body.dto.ts
@@ -2,9 +2,10 @@ import { NationalIdType, Sex } from '@prisma/client';
 import { IsDateString, IsEmail, IsEnum, IsOptional, IsString, MaxLength } from 'class-validator';
 import { IsAllowedEmailDomain } from '../../common/email-policy';
 import { ToNormalizedEmail, ToSanitizedString } from '../../common/validation';
+import { ResidentialLocationDto } from './residential-location.dto';
 
 /** Body DTO for POST /clinics/:clinicId/patients; primaryClinicId from route. */
-export class CreatePatientBodyDto {
+export class CreatePatientBodyDto extends ResidentialLocationDto {
   @ToSanitizedString({ maxLength: 120 })
   @IsString()
   @MaxLength(120)

--- a/apps/api/src/patients/dto/create-patient.dto.ts
+++ b/apps/api/src/patients/dto/create-patient.dto.ts
@@ -1,4 +1,4 @@
-import { NationalIdType, Sex } from '@prisma/client';
+import { GhanaRegion, NationalIdType, PatientLocationStatus, Sex } from '@prisma/client';
 
 /** DTO for creating patient; primaryClinicId comes from route param. */
 export interface CreatePatientDto {
@@ -12,4 +12,10 @@ export interface CreatePatientDto {
   nationalIdType: NationalIdType;
   nationalId: string; // plaintext, encrypted/hashed by service
   createdByUserId?: string;
+  // Residential location (see ResidentialLocationDto); resolved by service.
+  residentialLocationStatus?: PatientLocationStatus;
+  residentialRegion?: GhanaRegion;
+  residentialDistrict?: string;
+  residentialCommunity?: string;
+  residentialAddressNote?: string;
 }

--- a/apps/api/src/patients/dto/list-patient-registry.query.dto.ts
+++ b/apps/api/src/patients/dto/list-patient-registry.query.dto.ts
@@ -1,10 +1,27 @@
-import { IsInt, IsOptional, Max, Min } from 'class-validator';
+import { GhanaRegion, PatientLocationStatus } from '@prisma/client';
+import { IsEnum, IsInt, IsOptional, Max, Min } from 'class-validator';
 import { ToCursor, ToOptionalNumber, ToSanitizedString } from '../../common/validation';
 
 export class ListPatientRegistryQueryDto {
   @IsOptional()
   @ToSanitizedString({ maxLength: 120 })
   q?: string;
+
+  @IsOptional()
+  @IsEnum(GhanaRegion)
+  residentialRegion?: GhanaRegion;
+
+  @IsOptional()
+  @ToSanitizedString({ maxLength: 120 })
+  residentialDistrict?: string;
+
+  @IsOptional()
+  @ToSanitizedString({ maxLength: 120 })
+  residentialCommunity?: string;
+
+  @IsOptional()
+  @IsEnum(PatientLocationStatus)
+  residentialLocationStatus?: PatientLocationStatus;
 
   @IsOptional()
   @ToOptionalNumber()

--- a/apps/api/src/patients/dto/residential-location.dto.spec.ts
+++ b/apps/api/src/patients/dto/residential-location.dto.spec.ts
@@ -1,0 +1,97 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { CreatePatientBodyDto } from './create-patient-body.dto';
+import { UpdatePatientBodyDto } from './update-patient-body.dto';
+
+const BASE_CREATE = {
+  firstName: 'Ama',
+  lastName: 'Mensah',
+  nationalIdType: 'NATIONAL_ID',
+  nationalId: 'GHA-123456789-0',
+};
+
+describe('residential location DTO validation', () => {
+  it('accepts a fully recorded location and trims free-text fields', async () => {
+    const dto = plainToInstance(CreatePatientBodyDto, {
+      ...BASE_CREATE,
+      residentialLocationStatus: 'RECORDED',
+      residentialRegion: 'GREATER_ACCRA',
+      residentialDistrict: 'Accra Metropolitan',
+      residentialCommunity: '  Osu  ',
+      residentialAddressNote: '  Near the market  ',
+    });
+
+    await expect(validate(dto)).resolves.toHaveLength(0);
+    expect(dto.residentialCommunity).toBe('Osu');
+    expect(dto.residentialAddressNote).toBe('Near the market');
+  });
+
+  it('accepts an omitted location (defaults handled by the service)', async () => {
+    const dto = plainToInstance(CreatePatientBodyDto, { ...BASE_CREATE });
+    await expect(validate(dto)).resolves.toHaveLength(0);
+    expect(dto.residentialRegion).toBeUndefined();
+  });
+
+  it('accepts a deliberate UNKNOWN status without granular fields', async () => {
+    const dto = plainToInstance(UpdatePatientBodyDto, {
+      residentialLocationStatus: 'UNKNOWN',
+    });
+    await expect(validate(dto)).resolves.toHaveLength(0);
+  });
+
+  it('rejects a district that does not belong to the region', async () => {
+    const dto = plainToInstance(CreatePatientBodyDto, {
+      ...BASE_CREATE,
+      residentialRegion: 'GREATER_ACCRA',
+      residentialDistrict: 'Kumasi Metropolitan',
+    });
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'residentialDistrict')).toBe(true);
+  });
+
+  it('rejects a district provided without a region', async () => {
+    const dto = plainToInstance(CreatePatientBodyDto, {
+      ...BASE_CREATE,
+      residentialDistrict: 'Accra Metropolitan',
+    });
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'residentialDistrict')).toBe(true);
+  });
+
+  it('accepts a region without a district (partial input)', async () => {
+    const dto = plainToInstance(CreatePatientBodyDto, {
+      ...BASE_CREATE,
+      residentialRegion: 'ASHANTI',
+    });
+    await expect(validate(dto)).resolves.toHaveLength(0);
+  });
+
+  it('rejects an unknown region enum value', async () => {
+    const dto = plainToInstance(CreatePatientBodyDto, {
+      ...BASE_CREATE,
+      residentialRegion: 'ATLANTIS',
+    });
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'residentialRegion')).toBe(true);
+  });
+
+  it('normalizes an over-length community down to the limit', async () => {
+    const dto = plainToInstance(CreatePatientBodyDto, {
+      ...BASE_CREATE,
+      residentialRegion: 'ASHANTI',
+      residentialCommunity: 'x'.repeat(121),
+    });
+    await expect(validate(dto)).resolves.toHaveLength(0);
+    expect(dto.residentialCommunity).toHaveLength(120);
+  });
+
+  it('truncates and preserves newlines in the address note', async () => {
+    const dto = plainToInstance(CreatePatientBodyDto, {
+      ...BASE_CREATE,
+      residentialAddressNote: `Line one\nLine two${' '.repeat(5)}`,
+    });
+    await expect(validate(dto)).resolves.toHaveLength(0);
+    expect(dto.residentialAddressNote).toBe('Line one\nLine two');
+  });
+});

--- a/apps/api/src/patients/dto/residential-location.dto.ts
+++ b/apps/api/src/patients/dto/residential-location.dto.ts
@@ -1,0 +1,40 @@
+import { GhanaRegion, PatientLocationStatus } from '@prisma/client';
+import { IsEnum, IsOptional, IsString, MaxLength } from 'class-validator';
+import { IsDistrictInRegion } from '../../common/ghana-location.validator';
+import { ToSanitizedString } from '../../common/validation';
+
+/**
+ * Residential location fields shared by patient create and update DTOs.
+ *
+ * All fields are optional at the transport layer; the service enforces the
+ * status invariant (RECORDED requires a region; UNKNOWN/NOT_RECORDED clear the
+ * granular fields). District membership is validated against its region here.
+ */
+export class ResidentialLocationDto {
+  @IsOptional()
+  @IsEnum(PatientLocationStatus)
+  residentialLocationStatus?: PatientLocationStatus;
+
+  @IsOptional()
+  @IsEnum(GhanaRegion)
+  residentialRegion?: GhanaRegion;
+
+  @IsOptional()
+  @ToSanitizedString({ maxLength: 120 })
+  @IsString()
+  @MaxLength(120)
+  @IsDistrictInRegion()
+  residentialDistrict?: string;
+
+  @IsOptional()
+  @ToSanitizedString({ maxLength: 120 })
+  @IsString()
+  @MaxLength(120)
+  residentialCommunity?: string;
+
+  @IsOptional()
+  @ToSanitizedString({ maxLength: 280, preserveNewlines: true })
+  @IsString()
+  @MaxLength(280)
+  residentialAddressNote?: string;
+}

--- a/apps/api/src/patients/dto/update-patient-body.dto.ts
+++ b/apps/api/src/patients/dto/update-patient-body.dto.ts
@@ -2,9 +2,10 @@ import { Sex } from '@prisma/client';
 import { IsDateString, IsEmail, IsEnum, IsOptional, IsString, MaxLength } from 'class-validator';
 import { IsAllowedEmailDomain } from '../../common/email-policy';
 import { ToNormalizedEmail, ToSanitizedString } from '../../common/validation';
+import { ResidentialLocationDto } from './residential-location.dto';
 
 /** Body DTO for PATCH /clinics/:clinicId/patients/:patientId. National ID is immutable. */
-export class UpdatePatientBodyDto {
+export class UpdatePatientBodyDto extends ResidentialLocationDto {
   @IsOptional()
   @ToSanitizedString({ maxLength: 120 })
   @IsString()

--- a/apps/api/src/patients/patient.repository.spec.ts
+++ b/apps/api/src/patients/patient.repository.spec.ts
@@ -1,0 +1,67 @@
+import { PatientRepository } from './patient.repository';
+import { PrismaService } from '../prisma/prisma.service';
+
+describe('PatientRepository - residential location filters', () => {
+  let findMany: jest.Mock;
+  let repository: PatientRepository;
+
+  beforeEach(() => {
+    findMany = jest.fn().mockResolvedValue([]);
+    const prisma = { patient: { findMany } } as unknown as PrismaService;
+    repository = new PatientRepository(prisma);
+  });
+
+  function whereOf(): Record<string, unknown> {
+    return findMany.mock.calls[0][0].where as Record<string, unknown>;
+  }
+
+  it('always scopes to the clinic even with location filters (cross-clinic isolation)', async () => {
+    await repository.findMany({
+      primaryClinicId: 'clinic-1',
+      residentialRegion: 'GREATER_ACCRA',
+    });
+
+    const where = whereOf();
+    expect(where.primaryClinicId).toBe('clinic-1');
+    expect(where.residentialRegion).toBe('GREATER_ACCRA');
+    // Location filters must be AND-ed, never expressed as an OR that could widen scope.
+    expect(where.OR).toBeUndefined();
+  });
+
+  it('applies region and status as equality filters', async () => {
+    await repository.findMany({
+      primaryClinicId: 'clinic-1',
+      residentialRegion: 'ASHANTI',
+      residentialLocationStatus: 'UNKNOWN',
+    });
+
+    const where = whereOf();
+    expect(where.residentialRegion).toBe('ASHANTI');
+    expect(where.residentialLocationStatus).toBe('UNKNOWN');
+  });
+
+  it('applies district and community as case-insensitive contains filters', async () => {
+    await repository.findMany({
+      primaryClinicId: 'clinic-1',
+      residentialDistrict: ' Bekwai ',
+      residentialCommunity: 'osu',
+    });
+
+    const where = whereOf();
+    expect(where.residentialDistrict).toEqual({ contains: 'Bekwai', mode: 'insensitive' });
+    expect(where.residentialCommunity).toEqual({ contains: 'osu', mode: 'insensitive' });
+  });
+
+  it('keeps location filters alongside a text search, still clinic-scoped', async () => {
+    await repository.findMany({
+      primaryClinicId: 'clinic-1',
+      search: 'Ama',
+      residentialRegion: 'VOLTA',
+    });
+
+    const where = whereOf();
+    expect(where.primaryClinicId).toBe('clinic-1');
+    expect(where.residentialRegion).toBe('VOLTA');
+    expect(Array.isArray(where.OR)).toBe(true);
+  });
+});

--- a/apps/api/src/patients/patient.repository.ts
+++ b/apps/api/src/patients/patient.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { Patient, Prisma } from '@prisma/client';
+import { GhanaRegion, Patient, PatientLocationStatus, Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 
 export interface PatientFindManyFilters {
@@ -7,6 +7,11 @@ export interface PatientFindManyFilters {
   search?: string;
   /** When q matches phone pattern, service sets normalized E.164 for exact match. */
   phoneE164?: string;
+  /** Residential location filters, AND-ed within the clinic scope. */
+  residentialRegion?: GhanaRegion;
+  residentialDistrict?: string;
+  residentialCommunity?: string;
+  residentialLocationStatus?: PatientLocationStatus;
   cursor?: string;
   skip?: number;
   take?: number;
@@ -98,6 +103,26 @@ export class PatientRepository {
     }
     if (!filters.includeMerged) {
       where.mergedIntoPatientId = null;
+    }
+    // Residential location filters are AND-ed with the clinic scope above so
+    // they can only ever narrow results, never widen them across clinics.
+    if (filters.residentialRegion) {
+      where.residentialRegion = filters.residentialRegion;
+    }
+    if (filters.residentialLocationStatus) {
+      where.residentialLocationStatus = filters.residentialLocationStatus;
+    }
+    if (filters.residentialDistrict) {
+      where.residentialDistrict = {
+        contains: filters.residentialDistrict.trim(),
+        mode: 'insensitive',
+      };
+    }
+    if (filters.residentialCommunity) {
+      where.residentialCommunity = {
+        contains: filters.residentialCommunity.trim(),
+        mode: 'insensitive',
+      };
     }
     if (filters.search || filters.phoneE164) {
       const orConditions: Prisma.PatientWhereInput[] = [];

--- a/apps/api/src/patients/patient.service.spec.ts
+++ b/apps/api/src/patients/patient.service.spec.ts
@@ -27,6 +27,11 @@ const mockPatient: Patient = {
   mergedIntoPatientId: null,
   mergedAt: null,
   mergedByUserId: null,
+  residentialLocationStatus: 'NOT_RECORDED',
+  residentialRegion: null,
+  residentialDistrict: null,
+  residentialCommunity: null,
+  residentialAddressNote: null,
   createdAt: new Date(),
   updatedAt: new Date(),
 };
@@ -251,5 +256,173 @@ describe('PatientService - update', () => {
     expect(updateCall).not.toHaveProperty('nationalIdCiphertext');
     expect(updateCall).not.toHaveProperty('nationalIdHash');
     expect(updateCall).not.toHaveProperty('nationalIdLast4');
+  });
+
+  it('does not touch residential location when no location field is provided', async () => {
+    await service.update(
+      'patient-1',
+      { firstName: 'Jane' },
+      { clinicId: 'clinic-1', actorUserId: 'user-1' },
+    );
+
+    const updateCall = mockRepoUpdate.mock.calls[0][1];
+    expect(updateCall).not.toHaveProperty('residentialRegion');
+    expect(updateCall).not.toHaveProperty('residentialLocationStatus');
+  });
+
+  it('resolves a recorded location block on update', async () => {
+    await service.update(
+      'patient-1',
+      {
+        residentialRegion: 'GREATER_ACCRA',
+        residentialDistrict: 'accra metropolitan',
+        residentialCommunity: '  Osu  ',
+      },
+      { clinicId: 'clinic-1', actorUserId: 'user-1' },
+    );
+
+    expect(mockRepoUpdate).toHaveBeenCalledWith(
+      'patient-1',
+      expect.objectContaining({
+        residentialLocationStatus: 'RECORDED',
+        residentialRegion: 'GREATER_ACCRA',
+        residentialDistrict: 'Accra Metropolitan',
+        residentialCommunity: 'Osu',
+      }),
+    );
+  });
+
+  it('clears granular fields when location status is UNKNOWN', async () => {
+    await service.update(
+      'patient-1',
+      {
+        residentialLocationStatus: 'UNKNOWN',
+        residentialRegion: 'ASHANTI',
+        residentialCommunity: 'Bantama',
+      },
+      { clinicId: 'clinic-1', actorUserId: 'user-1' },
+    );
+
+    expect(mockRepoUpdate).toHaveBeenCalledWith(
+      'patient-1',
+      expect.objectContaining({
+        residentialLocationStatus: 'UNKNOWN',
+        residentialRegion: null,
+        residentialDistrict: null,
+        residentialCommunity: null,
+        residentialAddressNote: null,
+      }),
+    );
+  });
+});
+
+describe('PatientService - create persists resolved location', () => {
+  let service: PatientService;
+  let txCreate: jest.Mock;
+
+  beforeAll(() => {
+    // National ID encryption requires a 32-byte key; deterministic for tests.
+    process.env.NATIONAL_ID_ENCRYPTION_KEY = 'a'.repeat(64);
+  });
+
+  beforeEach(async () => {
+    txCreate = jest.fn().mockResolvedValue(mockPatient);
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PatientService,
+        {
+          provide: PatientRepository,
+          useValue: { findByNationalIdHash: jest.fn().mockResolvedValue(null) },
+        },
+        {
+          provide: PrismaService,
+          useValue: {
+            $transaction: jest.fn((cb) =>
+              cb({
+                patientCodeSequence: {
+                  upsert: jest.fn().mockResolvedValue({ year: 2025, lastNumber: 1 }),
+                },
+                patient: { create: txCreate },
+              }),
+            ),
+          },
+        },
+        { provide: AuditService, useValue: { logWrite: jest.fn().mockResolvedValue(undefined) } },
+        { provide: EncounterService, useValue: { listByPatient: jest.fn() } },
+        { provide: ConsentService, useValue: { getConsentStatusForClinic: jest.fn() } },
+      ],
+    }).compile();
+    service = module.get(PatientService);
+  });
+
+  it('writes a resolved RECORDED location with a canonical district', async () => {
+    await service.create({
+      primaryClinicId: 'clinic-1',
+      firstName: 'Ama',
+      lastName: 'Mensah',
+      nationalIdType: 'NATIONAL_ID',
+      nationalId: 'GHA-1',
+      residentialRegion: 'GREATER_ACCRA',
+      residentialDistrict: 'accra metropolitan',
+    });
+
+    const data = txCreate.mock.calls[0][0].data;
+    expect(data.residentialLocationStatus).toBe('RECORDED');
+    expect(data.residentialRegion).toBe('GREATER_ACCRA');
+    expect(data.residentialDistrict).toBe('Accra Metropolitan');
+  });
+
+  it('defaults to NOT_RECORDED with no fabricated location', async () => {
+    await service.create({
+      primaryClinicId: 'clinic-1',
+      firstName: 'Kofi',
+      lastName: 'Owusu',
+      nationalIdType: 'NATIONAL_ID',
+      nationalId: 'GHA-2',
+    });
+
+    const data = txCreate.mock.calls[0][0].data;
+    expect(data.residentialLocationStatus).toBe('NOT_RECORDED');
+    expect(data.residentialRegion).toBeNull();
+  });
+});
+
+describe('PatientService - resolveResidentialLocation invariant', () => {
+  const service = new PatientService(
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+  );
+
+  it('infers NOT_RECORDED with null fields when nothing is supplied', () => {
+    expect(service.resolveResidentialLocation({})).toEqual({
+      residentialLocationStatus: 'NOT_RECORDED',
+      residentialRegion: null,
+      residentialDistrict: null,
+      residentialCommunity: null,
+      residentialAddressNote: null,
+    });
+  });
+
+  it('infers RECORDED when a region is present', () => {
+    const resolved = service.resolveResidentialLocation({ residentialRegion: 'VOLTA' });
+    expect(resolved.residentialLocationStatus).toBe('RECORDED');
+    expect(resolved.residentialRegion).toBe('VOLTA');
+  });
+
+  it('drops a district that does not belong to the region', () => {
+    const resolved = service.resolveResidentialLocation({
+      residentialRegion: 'GREATER_ACCRA',
+      residentialDistrict: 'Kumasi Metropolitan',
+    });
+    expect(resolved.residentialDistrict).toBeNull();
+  });
+
+  it('rejects RECORDED without a region', () => {
+    expect(() =>
+      service.resolveResidentialLocation({ residentialLocationStatus: 'RECORDED' }),
+    ).toThrow();
   });
 });

--- a/apps/api/src/patients/patient.service.ts
+++ b/apps/api/src/patients/patient.service.ts
@@ -1,12 +1,11 @@
-import { BadRequestException, ConflictException, Injectable } from '@nestjs/common';
-import { Encounter, GhanaRegion, Patient, PatientLocationStatus } from '@prisma/client';
+import { ConflictException, Injectable } from '@nestjs/common';
+import { Encounter, Patient } from '@prisma/client';
 import { EncounterService } from '../encounters/encounter.service';
 import { ConsentService } from '../consents/consent.service';
 import {
   encryptNationalId,
   hashNationalId,
   nationalIdLast4,
-  normalizeDistrict,
   normalizePhoneToE164,
 } from '@nkwapa/db';
 import { PrismaService } from '../prisma/prisma.service';
@@ -14,37 +13,18 @@ import { AuditService } from '../audit/audit.service';
 import { PatientRepository, PatientFindManyFilters } from './patient.repository';
 import { CreatePatientDto } from './dto/create-patient.dto';
 import { UpdatePatientBodyDto } from './dto/update-patient-body.dto';
+import {
+  hasResidentialLocationInput,
+  ResidentialLocationFilters,
+  ResidentialLocationInput,
+  ResolvedResidentialLocation,
+  resolveResidentialLocation,
+} from './residential-location.util';
 
 export interface AuditContext {
   clinicId: string;
   actorUserId: string;
   requestId?: string;
-}
-
-/** Raw residential location fields as supplied by create/update DTOs. */
-export interface ResidentialLocationInput {
-  residentialLocationStatus?: PatientLocationStatus;
-  residentialRegion?: GhanaRegion;
-  residentialDistrict?: string;
-  residentialCommunity?: string;
-  residentialAddressNote?: string;
-}
-
-/** Resolved residential location, ready to persist. */
-export interface ResolvedResidentialLocation {
-  residentialLocationStatus: PatientLocationStatus;
-  residentialRegion: GhanaRegion | null;
-  residentialDistrict: string | null;
-  residentialCommunity: string | null;
-  residentialAddressNote: string | null;
-}
-
-/** Optional residential location filters for the registry, within clinic scope. */
-export interface ResidentialLocationFilters {
-  residentialRegion?: GhanaRegion;
-  residentialDistrict?: string;
-  residentialCommunity?: string;
-  residentialLocationStatus?: PatientLocationStatus;
 }
 
 export interface ExistingPatientSummary {
@@ -334,13 +314,7 @@ export class PatientService {
     // Residential location is resolved as a coherent block: when any location
     // field is supplied, re-apply the status invariant across all of them so a
     // partial edit can never leave region/status inconsistent.
-    const hasLocationInput =
-      dto.residentialLocationStatus !== undefined ||
-      dto.residentialRegion !== undefined ||
-      dto.residentialDistrict !== undefined ||
-      dto.residentialCommunity !== undefined ||
-      dto.residentialAddressNote !== undefined;
-    if (hasLocationInput) {
+    if (hasResidentialLocationInput(dto)) {
       Object.assign(data, this.resolveResidentialLocation(dto));
     }
 
@@ -366,42 +340,9 @@ export class PatientService {
     return this.patientRepository.findMany(filters);
   }
 
-  /**
-   * Enforce the deliberate residential-location invariant so a missing location
-   * is never ambiguous blank text:
-   * - RECORDED requires a region (district is normalized to its canonical name);
-   * - UNKNOWN / NOT_RECORDED clear every granular field;
-   * - an omitted status is inferred: RECORDED when a region is present,
-   *   otherwise NOT_RECORDED.
-   */
+  /** Enforce the deliberate residential-location invariant. See the util. */
   resolveResidentialLocation(input: ResidentialLocationInput): ResolvedResidentialLocation {
-    const region = input.residentialRegion ?? null;
-    const status: PatientLocationStatus =
-      input.residentialLocationStatus ?? (region ? 'RECORDED' : 'NOT_RECORDED');
-
-    if (status !== 'RECORDED') {
-      return {
-        residentialLocationStatus: status,
-        residentialRegion: null,
-        residentialDistrict: null,
-        residentialCommunity: null,
-        residentialAddressNote: null,
-      };
-    }
-
-    if (!region) {
-      throw new BadRequestException(
-        'residentialRegion is required when residentialLocationStatus is RECORDED',
-      );
-    }
-
-    return {
-      residentialLocationStatus: 'RECORDED',
-      residentialRegion: region,
-      residentialDistrict: normalizeDistrict(region, input.residentialDistrict),
-      residentialCommunity: input.residentialCommunity?.trim() || null,
-      residentialAddressNote: input.residentialAddressNote?.trim() || null,
-    };
+    return resolveResidentialLocation(input);
   }
 
   private toRegistryItem(patient: Patient): PatientRegistryItem {

--- a/apps/api/src/patients/patient.service.ts
+++ b/apps/api/src/patients/patient.service.ts
@@ -1,11 +1,12 @@
-import { ConflictException, Injectable } from '@nestjs/common';
-import { Encounter, Patient } from '@prisma/client';
+import { BadRequestException, ConflictException, Injectable } from '@nestjs/common';
+import { Encounter, GhanaRegion, Patient, PatientLocationStatus } from '@prisma/client';
 import { EncounterService } from '../encounters/encounter.service';
 import { ConsentService } from '../consents/consent.service';
 import {
   encryptNationalId,
   hashNationalId,
   nationalIdLast4,
+  normalizeDistrict,
   normalizePhoneToE164,
 } from '@nkwapa/db';
 import { PrismaService } from '../prisma/prisma.service';
@@ -18,6 +19,32 @@ export interface AuditContext {
   clinicId: string;
   actorUserId: string;
   requestId?: string;
+}
+
+/** Raw residential location fields as supplied by create/update DTOs. */
+export interface ResidentialLocationInput {
+  residentialLocationStatus?: PatientLocationStatus;
+  residentialRegion?: GhanaRegion;
+  residentialDistrict?: string;
+  residentialCommunity?: string;
+  residentialAddressNote?: string;
+}
+
+/** Resolved residential location, ready to persist. */
+export interface ResolvedResidentialLocation {
+  residentialLocationStatus: PatientLocationStatus;
+  residentialRegion: GhanaRegion | null;
+  residentialDistrict: string | null;
+  residentialCommunity: string | null;
+  residentialAddressNote: string | null;
+}
+
+/** Optional residential location filters for the registry, within clinic scope. */
+export interface ResidentialLocationFilters {
+  residentialRegion?: GhanaRegion;
+  residentialDistrict?: string;
+  residentialCommunity?: string;
+  residentialLocationStatus?: PatientLocationStatus;
 }
 
 export interface ExistingPatientSummary {
@@ -90,6 +117,7 @@ export class PatientService {
     const phoneE164 = dto.phoneE164
       ? (normalizePhoneToE164(dto.phoneE164, 'GH') ?? dto.phoneE164)
       : null;
+    const location = this.resolveResidentialLocation(dto);
 
     const year = new Date().getFullYear();
     const patient = await this.prisma.$transaction(async (tx) => {
@@ -114,6 +142,7 @@ export class PatientService {
           nationalIdHash: hash,
           nationalIdLast4: nationalIdLast4(dto.nationalId),
           createdByUserId: dto.createdByUserId,
+          ...location,
         },
       });
     });
@@ -166,7 +195,7 @@ export class PatientService {
     q = '',
     page = 1,
     pageSize = 25,
-    options?: { cursor?: string; limit?: number },
+    options?: { cursor?: string; limit?: number; location?: ResidentialLocationFilters },
   ): Promise<PatientRegistryPage> {
     const normalizedPage = Number.isFinite(page) && page > 0 ? Math.floor(page) : 1;
     const normalizedPageSize = Math.min(
@@ -189,6 +218,10 @@ export class PatientService {
       cursor: options?.cursor,
       skip: options?.cursor ? undefined : (normalizedPage - 1) * normalizedPageSize,
       take: options?.cursor ? normalizedLimit : normalizedPageSize,
+      residentialRegion: options?.location?.residentialRegion,
+      residentialDistrict: options?.location?.residentialDistrict,
+      residentialCommunity: options?.location?.residentialCommunity,
+      residentialLocationStatus: options?.location?.residentialLocationStatus,
     };
 
     if (trimmed) {
@@ -298,6 +331,19 @@ export class PatientService {
         : null;
     }
 
+    // Residential location is resolved as a coherent block: when any location
+    // field is supplied, re-apply the status invariant across all of them so a
+    // partial edit can never leave region/status inconsistent.
+    const hasLocationInput =
+      dto.residentialLocationStatus !== undefined ||
+      dto.residentialRegion !== undefined ||
+      dto.residentialDistrict !== undefined ||
+      dto.residentialCommunity !== undefined ||
+      dto.residentialAddressNote !== undefined;
+    if (hasLocationInput) {
+      Object.assign(data, this.resolveResidentialLocation(dto));
+    }
+
     const updated = await this.patientRepository.update(id, data);
 
     if (auditContext) {
@@ -318,6 +364,44 @@ export class PatientService {
 
   async findMany(filters: PatientFindManyFilters): Promise<Patient[]> {
     return this.patientRepository.findMany(filters);
+  }
+
+  /**
+   * Enforce the deliberate residential-location invariant so a missing location
+   * is never ambiguous blank text:
+   * - RECORDED requires a region (district is normalized to its canonical name);
+   * - UNKNOWN / NOT_RECORDED clear every granular field;
+   * - an omitted status is inferred: RECORDED when a region is present,
+   *   otherwise NOT_RECORDED.
+   */
+  resolveResidentialLocation(input: ResidentialLocationInput): ResolvedResidentialLocation {
+    const region = input.residentialRegion ?? null;
+    const status: PatientLocationStatus =
+      input.residentialLocationStatus ?? (region ? 'RECORDED' : 'NOT_RECORDED');
+
+    if (status !== 'RECORDED') {
+      return {
+        residentialLocationStatus: status,
+        residentialRegion: null,
+        residentialDistrict: null,
+        residentialCommunity: null,
+        residentialAddressNote: null,
+      };
+    }
+
+    if (!region) {
+      throw new BadRequestException(
+        'residentialRegion is required when residentialLocationStatus is RECORDED',
+      );
+    }
+
+    return {
+      residentialLocationStatus: 'RECORDED',
+      residentialRegion: region,
+      residentialDistrict: normalizeDistrict(region, input.residentialDistrict),
+      residentialCommunity: input.residentialCommunity?.trim() || null,
+      residentialAddressNote: input.residentialAddressNote?.trim() || null,
+    };
   }
 
   private toRegistryItem(patient: Patient): PatientRegistryItem {

--- a/apps/api/src/patients/residential-location.util.ts
+++ b/apps/api/src/patients/residential-location.util.ts
@@ -1,0 +1,81 @@
+import { BadRequestException } from '@nestjs/common';
+import { normalizeDistrict } from '@nkwapa/db';
+import { GhanaRegion, PatientLocationStatus } from '@prisma/client';
+
+/** Raw residential location fields as supplied by create/update/sync payloads. */
+export interface ResidentialLocationInput {
+  residentialLocationStatus?: PatientLocationStatus;
+  residentialRegion?: GhanaRegion;
+  residentialDistrict?: string;
+  residentialCommunity?: string;
+  residentialAddressNote?: string;
+}
+
+/** Resolved residential location, ready to persist. */
+export interface ResolvedResidentialLocation {
+  residentialLocationStatus: PatientLocationStatus;
+  residentialRegion: GhanaRegion | null;
+  residentialDistrict: string | null;
+  residentialCommunity: string | null;
+  residentialAddressNote: string | null;
+}
+
+/** Optional residential location filters for the registry, within clinic scope. */
+export interface ResidentialLocationFilters {
+  residentialRegion?: GhanaRegion;
+  residentialDistrict?: string;
+  residentialCommunity?: string;
+  residentialLocationStatus?: PatientLocationStatus;
+}
+
+/**
+ * Enforce the deliberate residential-location invariant so a missing location is
+ * never ambiguous blank text. Shared by the patient service and the offline
+ * sync path so both persist an identical, consistent shape:
+ * - RECORDED requires a region (district is normalized to its canonical name);
+ * - UNKNOWN / NOT_RECORDED clear every granular field;
+ * - an omitted status is inferred: RECORDED when a region is present, otherwise
+ *   NOT_RECORDED.
+ */
+export function resolveResidentialLocation(
+  input: ResidentialLocationInput,
+): ResolvedResidentialLocation {
+  const region = input.residentialRegion ?? null;
+  const status: PatientLocationStatus =
+    input.residentialLocationStatus ?? (region ? 'RECORDED' : 'NOT_RECORDED');
+
+  if (status !== 'RECORDED') {
+    return {
+      residentialLocationStatus: status,
+      residentialRegion: null,
+      residentialDistrict: null,
+      residentialCommunity: null,
+      residentialAddressNote: null,
+    };
+  }
+
+  if (!region) {
+    throw new BadRequestException(
+      'residentialRegion is required when residentialLocationStatus is RECORDED',
+    );
+  }
+
+  return {
+    residentialLocationStatus: 'RECORDED',
+    residentialRegion: region,
+    residentialDistrict: normalizeDistrict(region, input.residentialDistrict),
+    residentialCommunity: input.residentialCommunity?.trim() || null,
+    residentialAddressNote: input.residentialAddressNote?.trim() || null,
+  };
+}
+
+/** True when a DTO/payload carries any residential location field. */
+export function hasResidentialLocationInput(input: ResidentialLocationInput): boolean {
+  return (
+    input.residentialLocationStatus !== undefined ||
+    input.residentialRegion !== undefined ||
+    input.residentialDistrict !== undefined ||
+    input.residentialCommunity !== undefined ||
+    input.residentialAddressNote !== undefined
+  );
+}

--- a/apps/api/src/research/research-policy.ts
+++ b/apps/api/src/research/research-policy.ts
@@ -2,7 +2,8 @@ import { createHash } from 'crypto';
 
 export const RESEARCH_EXPORT_QUEUE_NAME = 'research-exports';
 export const RESEARCH_POLICY_VERSION = 'research-export-v1';
-export const RESEARCH_DATASET_VERSION = 3;
+// v4 adds a coarse residential_region column to research_subjects.csv.
+export const RESEARCH_DATASET_VERSION = 4;
 export const RESEARCH_TIMESTAMP_ROUNDING_MINUTES = 15;
 export const RESEARCH_FILE_FORMAT = 'zip';
 

--- a/apps/api/src/research/research-transform.service.spec.ts
+++ b/apps/api/src/research/research-transform.service.spec.ts
@@ -65,7 +65,7 @@ describe('ResearchTransformService', () => {
         'research_revocations.csv',
       ]),
     );
-    expect(result.manifest.datasetVersion).toBe(3);
+    expect(result.manifest.datasetVersion).toBe(4);
     expect(fs.existsSync(result.artifactPath)).toBe(true);
   });
 
@@ -268,11 +268,18 @@ describe('ResearchTransformService', () => {
         id: 'patient-1',
         dob: new Date('1990-05-15T00:00:00.000Z'),
         sex: 'MALE',
+        residentialLocationStatus: 'RECORDED',
+        residentialRegion: 'GREATER_ACCRA',
+        residentialDistrict: 'Accra Metropolitan',
+        residentialCommunity: 'SecretCommunityName',
+        residentialAddressNote: 'SecretAddressNote',
       },
       {
         id: 'patient-2',
         dob: new Date('1982-01-10T00:00:00.000Z'),
         sex: 'FEMALE',
+        residentialLocationStatus: 'UNKNOWN',
+        residentialRegion: null,
       },
     ]);
     prisma.medicalHistoryRevision.findMany.mockResolvedValue([
@@ -326,10 +333,16 @@ describe('ResearchTransformService', () => {
     );
 
     expect(result.recordCount).toBeGreaterThan(0);
-    expect(result.manifest.datasetVersion).toBe(3);
+    expect(result.manifest.datasetVersion).toBe(4);
     expect(subjectsCsv?.content).toContain('research_patient_key');
     expect(subjectsCsv?.content).toContain('1990');
     expect(subjectsCsv?.content).not.toContain('Witness');
+    // Coarse region only; granular residence must never leak into exports.
+    expect(subjectsCsv?.content).toContain('residential_region');
+    expect(subjectsCsv?.content).toContain('GREATER_ACCRA');
+    expect(subjectsCsv?.content).not.toContain('Accra Metropolitan');
+    expect(subjectsCsv?.content).not.toContain('SecretCommunityName');
+    expect(subjectsCsv?.content).not.toContain('SecretAddressNote');
     expect(measurementsCsv?.content).toContain('126');
     expect(measurementsCsv?.content).toContain('102');
     expect(measurementsCsv?.content).not.toContain('Do not leak');

--- a/apps/api/src/research/research-transform.service.ts
+++ b/apps/api/src/research/research-transform.service.ts
@@ -20,6 +20,9 @@ const SUBJECT_HEADERS = [
   'research_clinic_key',
   'sex',
   'birth_year',
+  // Coarse geography only. District, community and the free-text address note
+  // are deliberately excluded from research exports as re-identifying.
+  'residential_region',
   'latest_consent_status',
 ];
 
@@ -388,6 +391,8 @@ export class ResearchTransformService {
               id: true,
               dob: true,
               sex: true,
+              residentialLocationStatus: true,
+              residentialRegion: true,
             },
           });
 
@@ -405,6 +410,11 @@ export class ResearchTransformService {
         research_clinic_key: clinicKey,
         sex: patient?.sex ?? 'UNKNOWN',
         birth_year: this.deIdService.birthYear(patient?.dob ?? null),
+        // Region only, and only when deliberately recorded.
+        residential_region:
+          patient?.residentialLocationStatus === 'RECORDED' && patient.residentialRegion
+            ? patient.residentialRegion
+            : '',
         latest_consent_status: currentConsent
           ? 'GRANTED'
           : latestRevocation

--- a/apps/api/src/sync/sync.service.spec.ts
+++ b/apps/api/src/sync/sync.service.spec.ts
@@ -332,6 +332,80 @@ describe('SyncService', () => {
     });
   });
 
+  describe('patient UPSERT - residential location', () => {
+    beforeAll(() => {
+      process.env.NATIONAL_ID_ENCRYPTION_KEY = 'a'.repeat(64);
+    });
+
+    it('resolves and persists a recorded location on upsert', async () => {
+      const mutations: SyncMutationDto[] = [
+        {
+          id: 'mut-loc-1',
+          entityType: 'patient',
+          entityId: 'patient-loc-1',
+          operation: 'UPSERT',
+          clinicId: 'clinic-1',
+          payloadJson: {
+            patientCode: 'NKP-2025-000123',
+            nationalId: '1234567890',
+            primaryClinicId: 'clinic-1',
+            firstName: 'Ama',
+            lastName: 'Mensah',
+            residentialRegion: 'GREATER_ACCRA',
+            residentialDistrict: 'accra metropolitan',
+            residentialCommunity: 'Osu',
+          },
+          idempotencyKey: 'idem-loc-1',
+        },
+      ];
+
+      await service.applyMutations('clinic-1', mockUser as never, mutations);
+
+      expect(prisma.patient.upsert).toHaveBeenCalledTimes(1);
+      const args = (prisma.patient.upsert as jest.Mock).mock.calls[0][0];
+      expect(args.create).toEqual(
+        expect.objectContaining({
+          residentialLocationStatus: 'RECORDED',
+          residentialRegion: 'GREATER_ACCRA',
+          residentialDistrict: 'Accra Metropolitan',
+          residentialCommunity: 'Osu',
+        }),
+      );
+      expect(args.update).toEqual(
+        expect.objectContaining({
+          residentialLocationStatus: 'RECORDED',
+          residentialRegion: 'GREATER_ACCRA',
+        }),
+      );
+    });
+
+    it('defaults to NOT_RECORDED when a synced patient carries no location', async () => {
+      const mutations: SyncMutationDto[] = [
+        {
+          id: 'mut-loc-2',
+          entityType: 'patient',
+          entityId: 'patient-loc-2',
+          operation: 'UPSERT',
+          clinicId: 'clinic-1',
+          payloadJson: {
+            patientCode: 'NKP-2025-000124',
+            nationalId: '1234567891',
+            primaryClinicId: 'clinic-1',
+            firstName: 'Kofi',
+            lastName: 'Owusu',
+          },
+          idempotencyKey: 'idem-loc-2',
+        },
+      ];
+
+      await service.applyMutations('clinic-1', mockUser as never, mutations);
+
+      const args = (prisma.patient.upsert as jest.Mock).mock.calls[0][0];
+      expect(args.create.residentialLocationStatus).toBe('NOT_RECORDED');
+      expect(args.create.residentialRegion).toBeNull();
+    });
+  });
+
   describe('encounter UPSERT - CONFLICT_FINALIZED', () => {
     it('returns CONFLICT with CONFLICT_FINALIZED when encounter is FINALIZED', async () => {
       (encounterRepo.findById as jest.Mock).mockResolvedValue({

--- a/apps/api/src/sync/sync.service.ts
+++ b/apps/api/src/sync/sync.service.ts
@@ -9,8 +9,10 @@ import {
   SyncOperation,
   SyncMutationStatus,
   EncounterStatus,
+  GhanaRegion,
   HypertensionClassification,
   NationalIdType,
+  PatientLocationStatus,
   Sex,
   UserRole,
   MedicalHistoryCategory,
@@ -26,6 +28,7 @@ import {
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
 import { PatientRepository } from '../patients/patient.repository';
+import { resolveResidentialLocation } from '../patients/residential-location.util';
 import { EncounterRepository } from '../encounters/encounter.repository';
 import { SyncMutationDto, SYNC_OPERATION } from './dto/sync-mutation.dto';
 import { SyncMutationResultDto, SYNC_MUTATION_RESULT_STATUS } from './dto/sync-push-response.dto';
@@ -375,6 +378,18 @@ export class SyncService {
     const rawPhone = (payload.phoneE164 as string) ?? (payload.phone as string) ?? null;
     const phoneE164 = rawPhone ? (normalizePhoneToE164(rawPhone, 'GH') ?? null) : null;
 
+    // Residential location is resolved through the shared invariant so an
+    // offline-synced patient stores the same consistent shape as a REST write.
+    const location = resolveResidentialLocation({
+      residentialLocationStatus: payload.residentialLocationStatus as
+        | PatientLocationStatus
+        | undefined,
+      residentialRegion: payload.residentialRegion as GhanaRegion | undefined,
+      residentialDistrict: payload.residentialDistrict as string | undefined,
+      residentialCommunity: payload.residentialCommunity as string | undefined,
+      residentialAddressNote: payload.residentialAddressNote as string | undefined,
+    });
+
     const before = existingById ? JSON.stringify(existingById) : null;
     const patient = await this.prisma.patient.upsert({
       where: { id: mut.entityId },
@@ -393,6 +408,7 @@ export class SyncService {
         nationalIdHash: hash,
         nationalIdLast4: nationalIdLast4(nationalId),
         createdBy: createdByUserId ? { connect: { id: createdByUserId } } : undefined,
+        ...location,
       },
       update: {
         patientCode,
@@ -402,6 +418,7 @@ export class SyncService {
         sex: (payload.sex as Sex) ?? 'UNKNOWN',
         phoneE164,
         email: (payload.email as string) ?? null,
+        ...location,
       },
     });
 

--- a/apps/web/app/(workspace)/clinics/[clinicId]/patients/[patientId]/edit/page.tsx
+++ b/apps/web/app/(workspace)/clinics/[clinicId]/patients/[patientId]/edit/page.tsx
@@ -25,6 +25,14 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { ArrowLeft, FilePenLine, ShieldCheck, UserRoundPen } from 'lucide-react';
+import { ResidentialLocationFields } from '@/components/patients/ResidentialLocationFields';
+import {
+  emptyResidentialLocation,
+  toResidentialLocationPayload,
+  toResidentialLocationValue,
+  type PatientLocationStatus,
+  type ResidentialLocationValue,
+} from '@/lib/residential-location';
 
 interface PatientData {
   id: string;
@@ -36,6 +44,11 @@ interface PatientData {
   phoneE164?: string | null;
   email?: string | null;
   nationalIdLast4?: string | null;
+  residentialLocationStatus?: PatientLocationStatus | string | null;
+  residentialRegion?: string | null;
+  residentialDistrict?: string | null;
+  residentialCommunity?: string | null;
+  residentialAddressNote?: string | null;
 }
 
 export default function EditPatientPage() {
@@ -59,6 +72,7 @@ export default function EditPatientPage() {
   const [sex, setSex] = useState('UNKNOWN');
   const [phoneE164, setPhoneE164] = useState('');
   const [email, setEmail] = useState('');
+  const [location, setLocation] = useState<ResidentialLocationValue>(emptyResidentialLocation());
 
   const fetchPatient = useCallback(async () => {
     setLoading(true);
@@ -85,6 +99,11 @@ export default function EditPatientPage() {
             phoneE164: local.phoneE164,
             email: local.email,
             nationalIdLast4: local.nationalIdLast4,
+            residentialLocationStatus: local.residentialLocationStatus,
+            residentialRegion: local.residentialRegion,
+            residentialDistrict: local.residentialDistrict,
+            residentialCommunity: local.residentialCommunity,
+            residentialAddressNote: local.residentialAddressNote,
           });
         } else {
           setError('Patient not found');
@@ -105,6 +124,7 @@ export default function EditPatientPage() {
     setSex(p.sex);
     setPhoneE164(p.phoneE164 ?? '');
     setEmail(p.email ?? '');
+    setLocation(toResidentialLocationValue(p));
   }
 
   useEffect(() => {
@@ -125,6 +145,20 @@ export default function EditPatientPage() {
     if (sex !== patient.sex) body.sex = sex;
     if (phoneE164 !== (patient.phoneE164 ?? '')) body.phoneE164 = phoneE164;
     if (email !== (patient.email ?? '')) body.email = email;
+
+    // Residential location is diffed and sent as a coherent block; the server
+    // re-applies the status invariant.
+    const locationPayload = toResidentialLocationPayload(location);
+    const currentStatus = patient.residentialLocationStatus ?? 'NOT_RECORDED';
+    const locationChanged =
+      locationPayload.residentialLocationStatus !== currentStatus ||
+      (locationPayload.residentialRegion ?? null) !== (patient.residentialRegion ?? null) ||
+      (locationPayload.residentialDistrict ?? null) !== (patient.residentialDistrict ?? null) ||
+      (locationPayload.residentialCommunity ?? null) !== (patient.residentialCommunity ?? null) ||
+      (locationPayload.residentialAddressNote ?? null) !== (patient.residentialAddressNote ?? null);
+    if (locationChanged) {
+      Object.assign(body, locationPayload);
+    }
 
     if (Object.keys(body).length === 0) {
       router.push(`/clinics/${clinicId}/patients/${patientId}`);
@@ -307,6 +341,8 @@ export default function EditPatientPage() {
             </div>
           </div>
         </FormSectionCard>
+
+        <ResidentialLocationFields value={location} onChange={setLocation} />
 
         <Card className="rounded-[28px] border-border/80 bg-card/90 shadow-lg shadow-black/5">
           <CardHeader className="space-y-2">

--- a/apps/web/app/(workspace)/clinics/[clinicId]/patients/[patientId]/page.tsx
+++ b/apps/web/app/(workspace)/clinics/[clinicId]/patients/[patientId]/page.tsx
@@ -31,6 +31,7 @@ import { PatientTrendsPanel } from '@/components/patients/PatientTrendsPanel';
 import { MedicalHistoryPanel } from '@/components/patients/MedicalHistoryPanel';
 import { MedicationReconciliationPanel } from '@/components/patients/MedicationReconciliationPanel';
 import { DiabetesHistoryPanel } from '@/components/patients/DiabetesHistoryPanel';
+import { ResidentialLocationSummary } from '@/components/patients/ResidentialLocationSummary';
 import { PatientClinicalNotesPanel } from '@/components/clinical-notes/PatientClinicalNotesPanel';
 import { isWebFeatureEnabled } from '@/lib/feature-flags';
 import { EmptyStateCard, InlineNotice } from '@/components/ops/OpsShared';
@@ -66,6 +67,11 @@ interface PatientWithEncounters {
     phoneE164?: string | null;
     email?: string | null;
     nationalIdLast4?: string | null;
+    residentialLocationStatus?: string | null;
+    residentialRegion?: string | null;
+    residentialDistrict?: string | null;
+    residentialCommunity?: string | null;
+    residentialAddressNote?: string | null;
   };
   portalAccess?: {
     status: 'LINKED' | 'INVITED' | 'UNLINKED' | 'MERGED';
@@ -767,51 +773,55 @@ export default function PatientDetailPage() {
 
         <TabsContent value="overview">
           <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
-            <Card className="rounded-[28px] border-border/80 bg-card/90 shadow-lg shadow-black/5">
-              <CardHeader>
-                <h2 className="text-lg font-semibold">Patient details</h2>
-              </CardHeader>
-              <CardContent className="grid gap-4 sm:grid-cols-2">
-                <div className="rounded-3xl border border-border/80 bg-background/75 p-4">
-                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-                    Patient code
-                  </p>
-                  <p className="mt-2 font-mono text-lg font-semibold text-foreground">
-                    {patient.patientCode}
-                  </p>
-                </div>
-                <div className="rounded-3xl border border-border/80 bg-background/75 p-4">
-                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-                    Contact
-                  </p>
-                  <p className="mt-2 text-sm text-foreground">
-                    {patient.phoneE164 || 'No phone on file'}
-                  </p>
-                </div>
-                <div className="rounded-3xl border border-border/80 bg-background/75 p-4">
-                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-                    Date of birth
-                  </p>
-                  <p className="mt-2 text-sm text-foreground">
-                    {patient.dob ? new Date(patient.dob).toLocaleDateString() : 'Not recorded'}
-                  </p>
-                </div>
-                <div className="rounded-3xl border border-border/80 bg-background/75 p-4">
-                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-                    Sex
-                  </p>
-                  <p className="mt-2 text-sm text-foreground">{patient.sex}</p>
-                </div>
-                {patient.nationalIdLast4 ? (
-                  <div className="rounded-3xl border border-border/80 bg-background/75 p-4 sm:col-span-2">
+            <div className="space-y-4">
+              <Card className="rounded-[28px] border-border/80 bg-card/90 shadow-lg shadow-black/5">
+                <CardHeader>
+                  <h2 className="text-lg font-semibold">Patient details</h2>
+                </CardHeader>
+                <CardContent className="grid gap-4 sm:grid-cols-2">
+                  <div className="rounded-3xl border border-border/80 bg-background/75 p-4">
                     <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-                      National ID
+                      Patient code
                     </p>
-                    <p className="mt-2 text-sm text-foreground">...{patient.nationalIdLast4}</p>
+                    <p className="mt-2 font-mono text-lg font-semibold text-foreground">
+                      {patient.patientCode}
+                    </p>
                   </div>
-                ) : null}
-              </CardContent>
-            </Card>
+                  <div className="rounded-3xl border border-border/80 bg-background/75 p-4">
+                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+                      Contact
+                    </p>
+                    <p className="mt-2 text-sm text-foreground">
+                      {patient.phoneE164 || 'No phone on file'}
+                    </p>
+                  </div>
+                  <div className="rounded-3xl border border-border/80 bg-background/75 p-4">
+                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+                      Date of birth
+                    </p>
+                    <p className="mt-2 text-sm text-foreground">
+                      {patient.dob ? new Date(patient.dob).toLocaleDateString() : 'Not recorded'}
+                    </p>
+                  </div>
+                  <div className="rounded-3xl border border-border/80 bg-background/75 p-4">
+                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+                      Sex
+                    </p>
+                    <p className="mt-2 text-sm text-foreground">{patient.sex}</p>
+                  </div>
+                  {patient.nationalIdLast4 ? (
+                    <div className="rounded-3xl border border-border/80 bg-background/75 p-4 sm:col-span-2">
+                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+                        National ID
+                      </p>
+                      <p className="mt-2 text-sm text-foreground">...{patient.nationalIdLast4}</p>
+                    </div>
+                  ) : null}
+                </CardContent>
+              </Card>
+
+              <ResidentialLocationSummary patient={patient} />
+            </div>
 
             <div className="space-y-4">
               {canLinkPortal ? (

--- a/apps/web/app/(workspace)/clinics/[clinicId]/patients/page.tsx
+++ b/apps/web/app/(workspace)/clinics/[clinicId]/patients/page.tsx
@@ -18,6 +18,13 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Input } from '@/components/ui/input';
 import { EmptyStateCard, InlineNotice } from '@/components/ops/OpsShared';
 import { dataGridSx } from '@/lib/datagrid-theme';
+import { ActiveFilterSummary } from '@/components/app-shell/ActiveFilterSummary';
+import {
+  EMPTY_LOCATION_FILTER,
+  ResidentialLocationFilters,
+  type ResidentialLocationFilterValue,
+} from '@/components/patients/ResidentialLocationFilters';
+import { GHANA_REGION_LABELS, PATIENT_LOCATION_STATUS_LABELS } from '@/lib/residential-location';
 
 interface PatientSummary {
   id: string;
@@ -45,6 +52,8 @@ export default function ClinicPatientsPage() {
   const canCreateOpsCheckIn = hasPermission(perms, 'OPS.CHECKIN.CREATE');
 
   const [q, setQ] = useState('');
+  const [locationFilter, setLocationFilter] =
+    useState<ResidentialLocationFilterValue>(EMPTY_LOCATION_FILTER);
   const [results, setResults] = useState<PatientSummary[]>([]);
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(10);
@@ -62,8 +71,19 @@ export default function ClinicPatientsPage() {
     setError(null);
 
     try {
+      const query = new URLSearchParams({
+        page: String(page + 1),
+        pageSize: String(pageSize),
+      });
+      if (q.trim()) query.set('q', q.trim());
+      if (locationFilter.region) query.set('residentialRegion', locationFilter.region);
+      if (locationFilter.district) query.set('residentialDistrict', locationFilter.district);
+      if (locationFilter.community.trim())
+        query.set('residentialCommunity', locationFilter.community.trim());
+      if (locationFilter.status) query.set('residentialLocationStatus', locationFilter.status);
+
       const response = await apiFetch(
-        `/clinics/${encodeURIComponent(clinicId)}/patients?page=${page + 1}&pageSize=${pageSize}&q=${encodeURIComponent(q)}`,
+        `/clinics/${encodeURIComponent(clinicId)}/patients?${query.toString()}`,
         { getToken, activeClinicId: clinicId },
       );
       if (!response.ok) {
@@ -80,18 +100,16 @@ export default function ClinicPatientsPage() {
     } finally {
       setLoading(false);
     }
-  }, [clinicId, getToken, page, pageSize, q]);
+  }, [clinicId, getToken, page, pageSize, q, locationFilter]);
 
   useEffect(() => {
-    const timeoutId = window.setTimeout(
-      () => {
-        void search();
-      },
-      q.trim() ? 300 : 0,
-    );
+    const debounce = q.trim() || locationFilter.community.trim() ? 300 : 0;
+    const timeoutId = window.setTimeout(() => {
+      void search();
+    }, debounce);
 
     return () => window.clearTimeout(timeoutId);
-  }, [q, search]);
+  }, [q, locationFilter.community, search]);
 
   const handleCheckIn = async (patient: PatientSummary) => {
     if (!clinicId || !getToken) {
@@ -229,7 +247,7 @@ export default function ClinicPatientsPage() {
               Results update as you type and stay scoped to the active clinic.
             </CardDescription>
           </CardHeader>
-          <CardContent>
+          <CardContent className="space-y-4">
             <Input
               type="search"
               value={q}
@@ -240,6 +258,36 @@ export default function ClinicPatientsPage() {
               placeholder="Search by name, patient code, phone, or national ID last 4"
               className="w-full md:max-w-xl"
             />
+            <div className="space-y-3 border-t border-border/70 pt-4">
+              <p className="text-sm font-medium text-foreground">Residential location filters</p>
+              <ResidentialLocationFilters
+                value={locationFilter}
+                onChange={(next) => {
+                  setLocationFilter(next);
+                  setPage(0);
+                }}
+              />
+              <ActiveFilterSummary
+                items={[
+                  { label: 'Query', value: q.trim() || null },
+                  {
+                    label: 'Region',
+                    value: locationFilter.region
+                      ? GHANA_REGION_LABELS[locationFilter.region]
+                      : null,
+                  },
+                  { label: 'District', value: locationFilter.district || null },
+                  { label: 'Community', value: locationFilter.community.trim() || null },
+                  {
+                    label: 'Location status',
+                    value: locationFilter.status
+                      ? PATIENT_LOCATION_STATUS_LABELS[locationFilter.status]
+                      : null,
+                  },
+                ]}
+                emptyLabel="Browsing the full clinic registry"
+              />
+            </div>
           </CardContent>
         </Card>
 

--- a/apps/web/app/(workspace)/patients/[patientId]/page.tsx
+++ b/apps/web/app/(workspace)/patients/[patientId]/page.tsx
@@ -21,6 +21,7 @@ import { PatientTrendsPanel } from '@/components/patients/PatientTrendsPanel';
 import { MedicalHistoryPanel } from '@/components/patients/MedicalHistoryPanel';
 import { MedicationReconciliationPanel } from '@/components/patients/MedicationReconciliationPanel';
 import { DiabetesHistoryPanel } from '@/components/patients/DiabetesHistoryPanel';
+import { ResidentialLocationSummary } from '@/components/patients/ResidentialLocationSummary';
 import { isWebFeatureEnabled } from '@/lib/feature-flags';
 
 interface ConsentStatusItem {
@@ -39,6 +40,11 @@ interface PatientWithEncounters {
     sex: string;
     phoneE164?: string | null;
     nationalIdLast4?: string | null;
+    residentialLocationStatus?: string | null;
+    residentialRegion?: string | null;
+    residentialDistrict?: string | null;
+    residentialCommunity?: string | null;
+    residentialAddressNote?: string | null;
   };
   resolvedFromPatientId?: string | null;
   recentEncounters: Array<{
@@ -380,31 +386,34 @@ export default function PatientDetailPage() {
             </TabsList>
           </div>
           <TabsContent value="overview">
-            <Card>
-              <CardHeader>
-                <h2 className="text-lg font-semibold">Patient Details</h2>
-              </CardHeader>
-              <CardContent className="space-y-2">
-                <p>
-                  <span className="font-medium">Patient Code:</span>{' '}
-                  <span className="font-mono">{patient.patientCode}</span>
-                </p>
-                {patient.phoneE164 && (
+            <div className="grid gap-4 xl:grid-cols-2">
+              <Card>
+                <CardHeader>
+                  <h2 className="text-lg font-semibold">Patient Details</h2>
+                </CardHeader>
+                <CardContent className="space-y-2">
                   <p>
-                    <span className="font-medium">Phone:</span> {patient.phoneE164}
+                    <span className="font-medium">Patient Code:</span>{' '}
+                    <span className="font-mono">{patient.patientCode}</span>
                   </p>
-                )}
-                {patient.dob && (
+                  {patient.phoneE164 && (
+                    <p>
+                      <span className="font-medium">Phone:</span> {patient.phoneE164}
+                    </p>
+                  )}
+                  {patient.dob && (
+                    <p>
+                      <span className="font-medium">DOB:</span>{' '}
+                      {new Date(patient.dob).toLocaleDateString()}
+                    </p>
+                  )}
                   <p>
-                    <span className="font-medium">DOB:</span>{' '}
-                    {new Date(patient.dob).toLocaleDateString()}
+                    <span className="font-medium">Sex:</span> {patient.sex}
                   </p>
-                )}
-                <p>
-                  <span className="font-medium">Sex:</span> {patient.sex}
-                </p>
-              </CardContent>
-            </Card>
+                </CardContent>
+              </Card>
+              <ResidentialLocationSummary patient={patient} />
+            </div>
           </TabsContent>
           <TabsContent value="trends">
             <PatientTrendsPanel patientId={patientId} clinicId={clinicId} />

--- a/apps/web/app/(workspace)/patients/page.tsx
+++ b/apps/web/app/(workspace)/patients/page.tsx
@@ -22,6 +22,12 @@ import { dataGridSx } from '@/lib/datagrid-theme';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { ProgressiveHelp } from '@/components/ui/progressive-help';
 import { EmptyStateCard, InlineNotice } from '@/components/ops/OpsShared';
+import {
+  EMPTY_LOCATION_FILTER,
+  ResidentialLocationFilters,
+  type ResidentialLocationFilterValue,
+} from '@/components/patients/ResidentialLocationFilters';
+import { GHANA_REGION_LABELS, PATIENT_LOCATION_STATUS_LABELS } from '@/lib/residential-location';
 
 interface PatientSummary {
   id: string;
@@ -49,6 +55,8 @@ export default function PatientsPage() {
   const canCreateOpsCheckIn = hasPermission(perms, 'OPS.CHECKIN.CREATE');
 
   const [q, setQ] = useState('');
+  const [locationFilter, setLocationFilter] =
+    useState<ResidentialLocationFilterValue>(EMPTY_LOCATION_FILTER);
   const [results, setResults] = useState<PatientSummary[]>([]);
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(10);
@@ -62,8 +70,19 @@ export default function PatientsPage() {
     setLoading(true);
     setError(null);
     try {
+      const query = new URLSearchParams({
+        page: String(page + 1),
+        pageSize: String(pageSize),
+      });
+      if (q.trim()) query.set('q', q.trim());
+      if (locationFilter.region) query.set('residentialRegion', locationFilter.region);
+      if (locationFilter.district) query.set('residentialDistrict', locationFilter.district);
+      if (locationFilter.community.trim())
+        query.set('residentialCommunity', locationFilter.community.trim());
+      if (locationFilter.status) query.set('residentialLocationStatus', locationFilter.status);
+
       const res = await apiFetch(
-        `/clinics/${encodeURIComponent(clinicId)}/patients?page=${page + 1}&pageSize=${pageSize}&q=${encodeURIComponent(q)}`,
+        `/clinics/${encodeURIComponent(clinicId)}/patients?${query.toString()}`,
         { getToken, activeClinicId: clinicId },
       );
       if (!res.ok) throw new Error(await readApiError(res));
@@ -77,17 +96,15 @@ export default function PatientsPage() {
     } finally {
       setLoading(false);
     }
-  }, [clinicId, getToken, page, pageSize, q]);
+  }, [clinicId, getToken, page, pageSize, q, locationFilter]);
 
   useEffect(() => {
-    const t = setTimeout(
-      () => {
-        search();
-      },
-      q.trim() ? 300 : 0,
-    );
+    const debounce = q.trim() || locationFilter.community.trim() ? 300 : 0;
+    const t = setTimeout(() => {
+      search();
+    }, debounce);
     return () => clearTimeout(t);
-  }, [q, search]);
+  }, [q, locationFilter.community, search]);
 
   const handleCheckIn = async (patient: PatientSummary) => {
     if (!clinicId || !getToken) return;
@@ -240,10 +257,32 @@ export default function PatientsPage() {
               placeholder="Search by name, patient code, phone, or national ID last 4"
               className="w-full md:max-w-xl"
             />
+            <div className="space-y-3 border-t border-border/70 pt-4">
+              <p className="text-sm font-medium text-foreground">Residential location filters</p>
+              <ResidentialLocationFilters
+                value={locationFilter}
+                onChange={(next) => {
+                  setLocationFilter(next);
+                  setPage(0);
+                }}
+              />
+            </div>
             <ActiveFilterSummary
               items={[
                 { label: 'Query', value: q.trim() || null },
                 { label: 'Page', value: page > 0 ? page + 1 : null },
+                {
+                  label: 'Region',
+                  value: locationFilter.region ? GHANA_REGION_LABELS[locationFilter.region] : null,
+                },
+                { label: 'District', value: locationFilter.district || null },
+                { label: 'Community', value: locationFilter.community.trim() || null },
+                {
+                  label: 'Location status',
+                  value: locationFilter.status
+                    ? PATIENT_LOCATION_STATUS_LABELS[locationFilter.status]
+                    : null,
+                },
               ]}
               emptyLabel="Browsing the full clinic registry"
             />

--- a/apps/web/components/patients/RegisterPatientScreen.tsx
+++ b/apps/web/components/patients/RegisterPatientScreen.tsx
@@ -30,6 +30,12 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { InlineNotice } from '@/components/ops/OpsShared';
+import { ResidentialLocationFields } from '@/components/patients/ResidentialLocationFields';
+import {
+  emptyResidentialLocation,
+  toResidentialLocationPayload,
+  type ResidentialLocationValue,
+} from '@/lib/residential-location';
 
 interface CreatePatientBody {
   firstName: string;
@@ -72,6 +78,7 @@ export function RegisterPatientScreen({
     nationalIdType: 'OTHER',
     nationalId: '',
   });
+  const [location, setLocation] = useState<ResidentialLocationValue>(emptyResidentialLocation());
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [conflictPatient, setConflictPatient] = useState<ExistingPatient | null>(null);
@@ -87,11 +94,12 @@ export function RegisterPatientScreen({
     setConflictPatient(null);
 
     try {
-      const body: CreatePatientBody = {
+      const body = {
         ...form,
         dob: form.dob || undefined,
         phoneE164: form.phoneE164 || undefined,
         email: form.email || undefined,
+        ...toResidentialLocationPayload(location),
       };
 
       const response = await apiFetch(`/clinics/${encodeURIComponent(clinicId)}/patients`, {
@@ -302,6 +310,8 @@ export function RegisterPatientScreen({
                 </div>
               </div>
             </FormSectionCard>
+
+            <ResidentialLocationFields value={location} onChange={setLocation} />
 
             <FormSectionCard
               title="National ID"

--- a/apps/web/components/patients/ResidentialLocationFields.tsx
+++ b/apps/web/components/patients/ResidentialLocationFields.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { MapPin } from 'lucide-react';
+import { FormSectionCard } from '@/components/app-shell/FormSectionCard';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  districtsForRegion,
+  PATIENT_LOCATION_STATUS_LABELS,
+  PATIENT_LOCATION_STATUS_OPTIONS,
+  REGION_OPTIONS,
+  type GhanaRegion,
+  type PatientLocationStatus,
+  type ResidentialLocationValue,
+} from '@/lib/residential-location';
+
+/**
+ * Reusable "Residential location" form section used by both the register and
+ * edit patient screens. It is deliberately separate from the primary clinic:
+ * this records where the patient lives, not where they receive care. No GPS.
+ *
+ * The control enforces the same status invariant as the API: granular fields
+ * are only editable when the status is RECORDED, and switching away from
+ * RECORDED clears them so a missing location is never ambiguous blank text.
+ */
+export function ResidentialLocationFields({
+  value,
+  onChange,
+  idPrefix = 'residential',
+}: {
+  value: ResidentialLocationValue;
+  onChange: (next: ResidentialLocationValue) => void;
+  idPrefix?: string;
+}) {
+  const isRecorded = value.residentialLocationStatus === 'RECORDED';
+  const districts = districtsForRegion(value.residentialRegion);
+
+  const setStatus = (status: PatientLocationStatus) => {
+    if (status === 'RECORDED') {
+      onChange({ ...value, residentialLocationStatus: status });
+      return;
+    }
+    // Deliberate unknown / not-recorded clears granular fields.
+    onChange({
+      residentialLocationStatus: status,
+      residentialRegion: '',
+      residentialDistrict: '',
+      residentialCommunity: '',
+      residentialAddressNote: '',
+    });
+  };
+
+  const setRegion = (region: GhanaRegion) => {
+    // Changing region invalidates any previously chosen district.
+    onChange({ ...value, residentialRegion: region, residentialDistrict: '' });
+  };
+
+  return (
+    <FormSectionCard
+      title="Residential location"
+      description="Where the patient lives. This is separate from their primary clinic and never uses GPS."
+      hint="Record region, district and community when known. Choose “Unknown” if you asked and the patient does not know, or leave it “Not recorded” until you can capture it."
+    >
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor={`${idPrefix}-status`}>Location status</Label>
+          <Select value={value.residentialLocationStatus} onValueChange={setStatus}>
+            <SelectTrigger id={`${idPrefix}-status`}>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {PATIENT_LOCATION_STATUS_OPTIONS.map((status) => (
+                <SelectItem key={status} value={status}>
+                  {PATIENT_LOCATION_STATUS_LABELS[status]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor={`${idPrefix}-region`}>Region</Label>
+          <Select
+            value={value.residentialRegion || undefined}
+            onValueChange={(region) => setRegion(region as GhanaRegion)}
+            disabled={!isRecorded}
+          >
+            <SelectTrigger id={`${idPrefix}-region`}>
+              <SelectValue placeholder={isRecorded ? 'Select a region' : '—'} />
+            </SelectTrigger>
+            <SelectContent>
+              {REGION_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor={`${idPrefix}-district`}>District</Label>
+          <Select
+            value={value.residentialDistrict || undefined}
+            onValueChange={(district) => onChange({ ...value, residentialDistrict: district })}
+            disabled={!isRecorded || !value.residentialRegion}
+          >
+            <SelectTrigger id={`${idPrefix}-district`}>
+              <SelectValue
+                placeholder={
+                  value.residentialRegion ? 'Select a district' : 'Choose a region first'
+                }
+              />
+            </SelectTrigger>
+            <SelectContent>
+              {districts.map((district) => (
+                <SelectItem key={district} value={district}>
+                  {district}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor={`${idPrefix}-community`}>Community / town</Label>
+          <Input
+            id={`${idPrefix}-community`}
+            value={value.residentialCommunity}
+            disabled={!isRecorded}
+            maxLength={120}
+            placeholder={isRecorded ? 'e.g. Osu' : ''}
+            onChange={(event) => onChange({ ...value, residentialCommunity: event.target.value })}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor={`${idPrefix}-note`}>Address note (optional)</Label>
+        <Textarea
+          id={`${idPrefix}-note`}
+          value={value.residentialAddressNote}
+          disabled={!isRecorded}
+          maxLength={280}
+          rows={2}
+          placeholder={
+            isRecorded ? 'Landmark or directions — no need for a full postal address.' : ''
+          }
+          onChange={(event) => onChange({ ...value, residentialAddressNote: event.target.value })}
+        />
+        <p className="flex items-center gap-1 text-xs text-muted-foreground">
+          <MapPin className="h-3 w-3" aria-hidden />
+          Residence only — do not enter GPS coordinates or a clinic location.
+        </p>
+      </div>
+    </FormSectionCard>
+  );
+}

--- a/apps/web/components/patients/ResidentialLocationFilters.tsx
+++ b/apps/web/components/patients/ResidentialLocationFilters.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  districtsForRegion,
+  PATIENT_LOCATION_STATUS_LABELS,
+  PATIENT_LOCATION_STATUS_OPTIONS,
+  REGION_OPTIONS,
+  type GhanaRegion,
+  type PatientLocationStatus,
+} from '@/lib/residential-location';
+
+export interface ResidentialLocationFilterValue {
+  region: GhanaRegion | '';
+  district: string;
+  community: string;
+  status: PatientLocationStatus | '';
+}
+
+export const EMPTY_LOCATION_FILTER: ResidentialLocationFilterValue = {
+  region: '',
+  district: '',
+  community: '',
+  status: '',
+};
+
+const ALL = '__all__';
+
+/**
+ * Registry filter controls for residential location. Filtering only narrows
+ * results inside the caller's clinic scope — it never crosses clinics.
+ */
+export function ResidentialLocationFilters({
+  value,
+  onChange,
+}: {
+  value: ResidentialLocationFilterValue;
+  onChange: (next: ResidentialLocationFilterValue) => void;
+}) {
+  const districts = districtsForRegion(value.region);
+
+  return (
+    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="space-y-2">
+        <Label htmlFor="filter-region">Region</Label>
+        <Select
+          value={value.region || ALL}
+          onValueChange={(next) =>
+            onChange({
+              ...value,
+              region: next === ALL ? '' : (next as GhanaRegion),
+              // Region change invalidates the district filter.
+              district: '',
+            })
+          }
+        >
+          <SelectTrigger id="filter-region">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL}>All regions</SelectItem>
+            {REGION_OPTIONS.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="filter-district">District</Label>
+        <Select
+          value={value.district || ALL}
+          onValueChange={(next) => onChange({ ...value, district: next === ALL ? '' : next })}
+          disabled={!value.region}
+        >
+          <SelectTrigger id="filter-district">
+            <SelectValue placeholder={value.region ? 'All districts' : 'Choose a region first'} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL}>All districts</SelectItem>
+            {districts.map((district) => (
+              <SelectItem key={district} value={district}>
+                {district}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="filter-community">Community</Label>
+        <Input
+          id="filter-community"
+          type="search"
+          placeholder="Search community"
+          value={value.community}
+          onChange={(event) => onChange({ ...value, community: event.target.value })}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="filter-location-status">Location status</Label>
+        <Select
+          value={value.status || ALL}
+          onValueChange={(next) =>
+            onChange({ ...value, status: next === ALL ? '' : (next as PatientLocationStatus) })
+          }
+        >
+          <SelectTrigger id="filter-location-status">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL}>Any status</SelectItem>
+            {PATIENT_LOCATION_STATUS_OPTIONS.map((status) => (
+              <SelectItem key={status} value={status}>
+                {PATIENT_LOCATION_STATUS_LABELS[status]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/patients/ResidentialLocationSummary.tsx
+++ b/apps/web/components/patients/ResidentialLocationSummary.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { Home, MapPin } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { describeResidentialLocation } from '@/lib/residential-location';
+import type { GhanaRegion, PatientLocationStatus } from '@/lib/residential-location';
+
+interface PatientLocationFields {
+  residentialLocationStatus?: PatientLocationStatus | string | null;
+  residentialRegion?: GhanaRegion | string | null;
+  residentialDistrict?: string | null;
+  residentialCommunity?: string | null;
+  residentialAddressNote?: string | null;
+}
+
+function Tile({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-3xl border border-border/80 bg-background/75 p-4">
+      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+        {label}
+      </p>
+      <p className="mt-2 text-sm text-foreground">{value}</p>
+    </div>
+  );
+}
+
+/**
+ * Read-only residential location for the patient detail Overview. Deliberately
+ * labelled and styled apart from the primary clinic so residence is never
+ * mistaken for the care site.
+ */
+export function ResidentialLocationSummary({ patient }: { patient: PatientLocationFields }) {
+  const location = describeResidentialLocation(patient);
+
+  return (
+    <Card className="rounded-[28px] border-border/80 bg-card/90 shadow-lg shadow-black/5">
+      <CardHeader>
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <Home className="h-4 w-4 text-muted-foreground" aria-hidden />
+            <h2 className="text-lg font-semibold">Residential location</h2>
+          </div>
+          <Badge variant={location.isRecorded ? 'default' : 'outline'}>
+            {location.statusLabel}
+          </Badge>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          Where the patient lives — separate from their primary clinic.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {location.isRecorded ? (
+          <>
+            <div className="flex items-start gap-2 rounded-3xl border border-border/80 bg-background/75 p-4">
+              <MapPin className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+              <p className="text-sm font-medium text-foreground">{location.summary}</p>
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <Tile label="Region" value={location.regionLabel ?? 'Not recorded'} />
+              <Tile label="District" value={location.district ?? 'Not recorded'} />
+              <Tile label="Community" value={location.community ?? 'Not recorded'} />
+              {location.addressNote ? (
+                <div className="rounded-3xl border border-border/80 bg-background/75 p-4 sm:col-span-2">
+                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+                    Address note
+                  </p>
+                  <p className="mt-2 whitespace-pre-line text-sm text-foreground">
+                    {location.addressNote}
+                  </p>
+                </div>
+              ) : null}
+            </div>
+          </>
+        ) : (
+          <div className="rounded-3xl border border-dashed border-border/80 bg-background/60 p-4 text-sm text-muted-foreground">
+            {location.status === 'UNKNOWN'
+              ? 'The patient was asked and their residential location is not known.'
+              : 'No residential location has been recorded yet. Edit the patient to add one.'}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/e2e/diabetes-screening.spec.js
+++ b/apps/web/e2e/diabetes-screening.spec.js
@@ -91,9 +91,14 @@ test('diabetes screening round-trips longitudinally, offline, read-only, and res
     page.getByText('Diabetes screening saved on this device and pending sync.'),
   ).toBeVisible();
 
+  // Wait for the specific push that carries the offline edit, not just the
+  // first push after reconnect: an unrelated/empty sync can resolve early and
+  // race the reload below, leaving the read to see stale server data.
   const reconnectPush = page.waitForResponse(
     (response) =>
-      response.request().method() === 'POST' && new URL(response.url()).pathname === '/sync/push',
+      response.request().method() === 'POST' &&
+      new URL(response.url()).pathname === '/sync/push' &&
+      (response.request().postData() ?? '').includes('Second encounter screening updated offline'),
   );
   await context.setOffline(false);
   expect((await reconnectPush).ok()).toBeTruthy();

--- a/apps/web/e2e/patient-residential-location.spec.js
+++ b/apps/web/e2e/patient-residential-location.spec.js
@@ -71,7 +71,5 @@ test('represents an unknown residential location deliberately', async ({ page })
   await page.waitForURL(/\/clinics\/[^/]+\/patients\/[^/]+$/, { timeout: 20_000 });
 
   await expect(page.getByRole('heading', { name: 'Residential location' })).toBeVisible();
-  await expect(
-    page.getByText(/residential location is not known/i),
-  ).toBeVisible();
+  await expect(page.getByText(/residential location is not known/i)).toBeVisible();
 });

--- a/apps/web/e2e/patient-residential-location.spec.js
+++ b/apps/web/e2e/patient-residential-location.spec.js
@@ -39,10 +39,13 @@ test('records a residential location, distinguishes it from the clinic, and filt
   const clinicId = page.url().match(/\/clinics\/([^/]+)\//)[1];
 
   // Registry: filter by region and confirm the active-filter chip + result.
+  // The registry renders both a mobile card list and the desktop DataGrid in
+  // the DOM (breakpoint-hidden via CSS); target the grid cell the default
+  // desktop viewport actually shows to avoid a strict-mode double match.
   await page.goto(`/clinics/${clinicId}/patients`);
   await chooseSelect(page, 'Region', 'Greater Accra');
   await expect(page.getByText('Region: Greater Accra')).toBeVisible();
-  await expect(page.getByText(lastName)).toBeVisible();
+  await expect(page.getByRole('gridcell', { name: lastName })).toBeVisible();
 
   // No horizontal overflow across breakpoints.
   for (const viewport of [

--- a/apps/web/e2e/patient-residential-location.spec.js
+++ b/apps/web/e2e/patient-residential-location.spec.js
@@ -1,0 +1,77 @@
+const path = require('path');
+const { randomUUID } = require('crypto');
+const { test, expect } = require('@playwright/test');
+
+const authFile = path.join(__dirname, '..', 'playwright', '.auth', 'staff.json');
+
+test.use({ storageState: authFile });
+
+async function chooseSelect(page, label, option) {
+  await page.getByLabel(label, { exact: true }).click();
+  await page.getByRole('option', { name: option, exact: true }).click();
+}
+
+test('records a residential location, distinguishes it from the clinic, and filters the registry', async ({
+  page,
+}) => {
+  const suffix = randomUUID().replaceAll('-', '').slice(0, 12);
+  const lastName = `Residence-${suffix}`;
+
+  await page.goto('/patients/new');
+  await page.getByLabel('First name *').fill('Location');
+  await page.getByLabel('Last name *').fill(lastName);
+  await page.getByLabel('National ID *').fill(`E2E-LOC-${suffix}`);
+
+  // Region/district are disabled until the location is deliberately recorded.
+  await expect(page.getByLabel('Region', { exact: true })).toBeDisabled();
+  await chooseSelect(page, 'Location status', 'Recorded');
+  await chooseSelect(page, 'Region', 'Greater Accra');
+  await chooseSelect(page, 'District', 'Accra Metropolitan');
+  await page.getByLabel('Community / town').fill('Osu');
+
+  await page.getByRole('button', { name: 'Create patient' }).click();
+  await page.waitForURL(/\/clinics\/[^/]+\/patients\/[^/]+$/, { timeout: 20_000 });
+
+  // Detail page: residential location is present and clearly separated.
+  await expect(page.getByRole('heading', { name: 'Residential location' })).toBeVisible();
+  await expect(page.getByText('Osu, Accra Metropolitan, Greater Accra')).toBeVisible();
+
+  const clinicId = page.url().match(/\/clinics\/([^/]+)\//)[1];
+
+  // Registry: filter by region and confirm the active-filter chip + result.
+  await page.goto(`/clinics/${clinicId}/patients`);
+  await chooseSelect(page, 'Region', 'Greater Accra');
+  await expect(page.getByText('Region: Greater Accra')).toBeVisible();
+  await expect(page.getByText(lastName)).toBeVisible();
+
+  // No horizontal overflow across breakpoints.
+  for (const viewport of [
+    { width: 375, height: 812 },
+    { width: 768, height: 1024 },
+    { width: 1440, height: 900 },
+  ]) {
+    await page.setViewportSize(viewport);
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth > window.innerWidth + 1,
+    );
+    expect(overflow).toBeFalsy();
+  }
+});
+
+test('represents an unknown residential location deliberately', async ({ page }) => {
+  const suffix = randomUUID().replaceAll('-', '').slice(0, 12);
+
+  await page.goto('/patients/new');
+  await page.getByLabel('First name *').fill('Unknown');
+  await page.getByLabel('Last name *').fill(`Location-${suffix}`);
+  await page.getByLabel('National ID *').fill(`E2E-UNK-${suffix}`);
+  await chooseSelect(page, 'Location status', 'Unknown');
+
+  await page.getByRole('button', { name: 'Create patient' }).click();
+  await page.waitForURL(/\/clinics\/[^/]+\/patients\/[^/]+$/, { timeout: 20_000 });
+
+  await expect(page.getByRole('heading', { name: 'Residential location' })).toBeVisible();
+  await expect(
+    page.getByText(/residential location is not known/i),
+  ).toBeVisible();
+});

--- a/apps/web/lib/db.test.ts
+++ b/apps/web/lib/db.test.ts
@@ -20,4 +20,10 @@ describe('NkwapaDb longitudinal clinical schema', () => {
       ]),
     );
   });
+
+  it('indexes the residential region on the patients store for offline filtering', () => {
+    const patients = db.tables.find((table) => table.name === 'patients');
+    const indexNames = patients?.schema.indexes.map((index) => index.name) ?? [];
+    expect(indexNames).toContain('residentialRegion');
+  });
 });

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -15,6 +15,12 @@ export interface PatientRecord {
   nationalIdCiphertext?: string;
   nationalIdHash?: string;
   nationalIdLast4?: string;
+  // Residential location (see @nkwapa/db residential-location helpers).
+  residentialLocationStatus?: string;
+  residentialRegion?: string | null;
+  residentialDistrict?: string | null;
+  residentialCommunity?: string | null;
+  residentialAddressNote?: string | null;
   createdByUserId?: string;
   createdAt?: string;
   updatedAt?: string;
@@ -353,6 +359,11 @@ export class NkwapaDb extends Dexie {
           .toCollection()
           .modify(migrateLegacyDiabetesScreening);
       });
+    // v7 indexes the residential region for offline registry filtering. New
+    // non-indexed location fields need no migration; existing rows resync.
+    this.version(7).stores({
+      patients: 'id, primaryClinicId, updatedAt, nationalIdHash, residentialRegion',
+    });
   }
 }
 

--- a/apps/web/lib/residential-location.test.ts
+++ b/apps/web/lib/residential-location.test.ts
@@ -1,0 +1,78 @@
+import {
+  describeResidentialLocation,
+  districtsForRegion,
+  emptyResidentialLocation,
+  toResidentialLocationPayload,
+  toResidentialLocationValue,
+} from './residential-location';
+
+describe('residential location web helpers', () => {
+  it('defaults to a deliberately not-recorded location', () => {
+    expect(emptyResidentialLocation().residentialLocationStatus).toBe('NOT_RECORDED');
+  });
+
+  it('lists districts for a region and nothing without one', () => {
+    expect(districtsForRegion('GREATER_ACCRA')).toContain('Accra Metropolitan');
+    expect(districtsForRegion('')).toEqual([]);
+  });
+
+  it('strips granular fields from the payload when not recorded', () => {
+    const payload = toResidentialLocationPayload({
+      residentialLocationStatus: 'UNKNOWN',
+      residentialRegion: 'ASHANTI',
+      residentialDistrict: 'Bekwai',
+      residentialCommunity: 'Somewhere',
+      residentialAddressNote: 'note',
+    });
+    expect(payload).toEqual({
+      residentialLocationStatus: 'UNKNOWN',
+      residentialRegion: null,
+      residentialDistrict: null,
+      residentialCommunity: null,
+      residentialAddressNote: null,
+    });
+  });
+
+  it('trims and forwards recorded fields', () => {
+    const payload = toResidentialLocationPayload({
+      residentialLocationStatus: 'RECORDED',
+      residentialRegion: 'GREATER_ACCRA',
+      residentialDistrict: 'Accra Metropolitan',
+      residentialCommunity: '  Osu  ',
+      residentialAddressNote: '',
+    });
+    expect(payload.residentialRegion).toBe('GREATER_ACCRA');
+    expect(payload.residentialCommunity).toBe('Osu');
+    expect(payload.residentialAddressNote).toBeNull();
+  });
+
+  it('round-trips a patient record into edit-form state', () => {
+    const value = toResidentialLocationValue({
+      residentialLocationStatus: 'RECORDED',
+      residentialRegion: 'VOLTA',
+      residentialDistrict: 'Ho Municipal',
+      residentialCommunity: null,
+      residentialAddressNote: null,
+    });
+    expect(value.residentialRegion).toBe('VOLTA');
+    expect(value.residentialDistrict).toBe('Ho Municipal');
+    expect(value.residentialCommunity).toBe('');
+  });
+
+  it('describes a recorded location as a readable summary', () => {
+    const described = describeResidentialLocation({
+      residentialLocationStatus: 'RECORDED',
+      residentialRegion: 'GREATER_ACCRA',
+      residentialDistrict: 'Accra Metropolitan',
+      residentialCommunity: 'Osu',
+    });
+    expect(described.isRecorded).toBe(true);
+    expect(described.summary).toBe('Osu, Accra Metropolitan, Greater Accra');
+  });
+
+  it('describes an unknown location by its status only', () => {
+    const described = describeResidentialLocation({ residentialLocationStatus: 'UNKNOWN' });
+    expect(described.isRecorded).toBe(false);
+    expect(described.summary).toBe('Unknown');
+  });
+});

--- a/apps/web/lib/residential-location.ts
+++ b/apps/web/lib/residential-location.ts
@@ -1,0 +1,158 @@
+import {
+  GHANA_DISTRICTS_BY_REGION,
+  GHANA_REGION_LABELS,
+  GHANA_REGIONS,
+  PATIENT_LOCATION_STATUS_LABELS,
+} from '@nkwapa/db';
+import type { GhanaRegion, PatientLocationStatus } from '@prisma/client';
+
+export {
+  GHANA_DISTRICTS_BY_REGION,
+  GHANA_REGION_LABELS,
+  GHANA_REGIONS,
+  PATIENT_LOCATION_STATUS_LABELS,
+};
+export type { GhanaRegion, PatientLocationStatus };
+
+/** Form/edit state for a patient's residential location. */
+export interface ResidentialLocationValue {
+  residentialLocationStatus: PatientLocationStatus;
+  residentialRegion: GhanaRegion | '';
+  residentialDistrict: string;
+  residentialCommunity: string;
+  residentialAddressNote: string;
+}
+
+/** Status options in the order staff should read them. */
+export const PATIENT_LOCATION_STATUS_OPTIONS: PatientLocationStatus[] = [
+  'RECORDED',
+  'UNKNOWN',
+  'NOT_RECORDED',
+];
+
+/** A blank, deliberately not-recorded location for new intake forms. */
+export function emptyResidentialLocation(): ResidentialLocationValue {
+  return {
+    residentialLocationStatus: 'NOT_RECORDED',
+    residentialRegion: '',
+    residentialDistrict: '',
+    residentialCommunity: '',
+    residentialAddressNote: '',
+  };
+}
+
+/** Districts available for a region (empty when no region is selected). */
+export function districtsForRegion(region: GhanaRegion | ''): string[] {
+  return region ? GHANA_DISTRICTS_BY_REGION[region] : [];
+}
+
+type PatientLocationFields = {
+  residentialLocationStatus?: PatientLocationStatus | string | null;
+  residentialRegion?: GhanaRegion | string | null;
+  residentialDistrict?: string | null;
+  residentialCommunity?: string | null;
+  residentialAddressNote?: string | null;
+};
+
+/** Hydrate edit-form state from a loaded patient record. */
+export function toResidentialLocationValue(
+  patient: PatientLocationFields | null | undefined,
+): ResidentialLocationValue {
+  if (!patient) {
+    return emptyResidentialLocation();
+  }
+  return {
+    residentialLocationStatus:
+      (patient.residentialLocationStatus as PatientLocationStatus) ?? 'NOT_RECORDED',
+    residentialRegion: (patient.residentialRegion as GhanaRegion) ?? '',
+    residentialDistrict: patient.residentialDistrict ?? '',
+    residentialCommunity: patient.residentialCommunity ?? '',
+    residentialAddressNote: patient.residentialAddressNote ?? '',
+  };
+}
+
+/**
+ * Normalize form state into an API payload. Mirrors the server invariant so the
+ * request is already coherent: only RECORDED carries granular fields.
+ */
+export function toResidentialLocationPayload(value: ResidentialLocationValue): {
+  residentialLocationStatus: PatientLocationStatus;
+  residentialRegion: GhanaRegion | null;
+  residentialDistrict: string | null;
+  residentialCommunity: string | null;
+  residentialAddressNote: string | null;
+} {
+  if (value.residentialLocationStatus !== 'RECORDED') {
+    return {
+      residentialLocationStatus: value.residentialLocationStatus,
+      residentialRegion: null,
+      residentialDistrict: null,
+      residentialCommunity: null,
+      residentialAddressNote: null,
+    };
+  }
+  return {
+    residentialLocationStatus: 'RECORDED',
+    residentialRegion: value.residentialRegion || null,
+    residentialDistrict: value.residentialDistrict.trim() || null,
+    residentialCommunity: value.residentialCommunity.trim() || null,
+    residentialAddressNote: value.residentialAddressNote.trim() || null,
+  };
+}
+
+export interface ResidentialLocationDescription {
+  status: PatientLocationStatus;
+  statusLabel: string;
+  isRecorded: boolean;
+  regionLabel: string | null;
+  district: string | null;
+  community: string | null;
+  addressNote: string | null;
+  /** One-line summary, e.g. "Osu, Accra Metropolitan, Greater Accra". */
+  summary: string;
+}
+
+/** Build a display-ready description for the patient detail page. */
+export function describeResidentialLocation(
+  patient: PatientLocationFields | null | undefined,
+): ResidentialLocationDescription {
+  const status = (patient?.residentialLocationStatus as PatientLocationStatus) ?? 'NOT_RECORDED';
+  const statusLabel = PATIENT_LOCATION_STATUS_LABELS[status] ?? 'Not recorded';
+
+  if (status !== 'RECORDED') {
+    return {
+      status,
+      statusLabel,
+      isRecorded: false,
+      regionLabel: null,
+      district: null,
+      community: null,
+      addressNote: null,
+      summary: statusLabel,
+    };
+  }
+
+  const region = patient?.residentialRegion as GhanaRegion | undefined;
+  const regionLabel = region ? (GHANA_REGION_LABELS[region] ?? null) : null;
+  const district = patient?.residentialDistrict?.trim() || null;
+  const community = patient?.residentialCommunity?.trim() || null;
+  const addressNote = patient?.residentialAddressNote?.trim() || null;
+
+  const summary = [community, district, regionLabel].filter(Boolean).join(', ') || statusLabel;
+
+  return {
+    status,
+    statusLabel,
+    isRecorded: true,
+    regionLabel,
+    district,
+    community,
+    addressNote,
+    summary,
+  };
+}
+
+export const REGION_OPTIONS = GHANA_REGIONS.map((region) => ({
+  value: region,
+  label: GHANA_REGION_LABELS[region],
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -9660,10 +9660,20 @@
       }
     },
     "node_modules/deepmerge-ts": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
-      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-8.0.1.tgz",
+      "integrity": "sha512-szCXE7YLCvLKR9bFPJcvsezOShdalctSvrgN/LM/QGUEPZQajwjmsMObZ6/DuANT5lxzM/wtO8Feubwdkz8myA==",
       "devOptional": true,
+      "funding": [
+        {
+          "type": "ko-fi",
+          "url": "https://ko-fi.com/rebeccastevens"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/deepmerge-ts"
+        }
+      ],
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16.0.0"
@@ -16370,7 +16380,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -19062,18 +19071,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/tmpl": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16380,6 +16380,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -19071,6 +19072,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/tmpl": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
       "js-yaml": "5.2.3",
       "yaml": "1.10.3"
     },
+    "deepmerge-ts": "8.0.1",
     "effect": "3.20.0",
     "engine.io": {
       "ws": "8.21.0"

--- a/packages/db/index.ts
+++ b/packages/db/index.ts
@@ -36,3 +36,12 @@ export {
   CLINICAL_NOTE_STATUS,
   type ClinicalNoteStatusValue,
 } from './src/clinical-notes';
+export {
+  GHANA_REGIONS,
+  GHANA_REGION_LABELS,
+  GHANA_DISTRICTS_BY_REGION,
+  PATIENT_LOCATION_STATUS_LABELS,
+  isGhanaRegion,
+  isDistrictInRegion,
+  normalizeDistrict,
+} from './src/ghana-locations';

--- a/packages/db/prisma/migrations/20260819120000_add_patient_residential_location/migration.sql
+++ b/packages/db/prisma/migrations/20260819120000_add_patient_residential_location/migration.sql
@@ -1,0 +1,40 @@
+-- CreateEnum
+CREATE TYPE "GhanaRegion" AS ENUM (
+  'AHAFO',
+  'ASHANTI',
+  'BONO',
+  'BONO_EAST',
+  'CENTRAL',
+  'EASTERN',
+  'GREATER_ACCRA',
+  'NORTH_EAST',
+  'NORTHERN',
+  'OTI',
+  'SAVANNAH',
+  'UPPER_EAST',
+  'UPPER_WEST',
+  'VOLTA',
+  'WESTERN',
+  'WESTERN_NORTH'
+);
+
+-- CreateEnum
+CREATE TYPE "PatientLocationStatus" AS ENUM ('RECORDED', 'UNKNOWN', 'NOT_RECORDED');
+
+-- AlterTable
+-- Existing patients backfill to NOT_RECORDED (never captured, no fabricated
+-- location). Region/district/community/address-note stay NULL until recorded.
+ALTER TABLE "Patient"
+  ADD COLUMN "residentialLocationStatus" "PatientLocationStatus" NOT NULL DEFAULT 'NOT_RECORDED',
+  ADD COLUMN "residentialRegion" "GhanaRegion",
+  ADD COLUMN "residentialDistrict" VARCHAR(120),
+  ADD COLUMN "residentialCommunity" VARCHAR(120),
+  ADD COLUMN "residentialAddressNote" VARCHAR(280);
+
+-- CreateIndex
+CREATE INDEX "Patient_primaryClinicId_residentialRegion_idx"
+  ON "Patient"("primaryClinicId", "residentialRegion");
+
+-- CreateIndex
+CREATE INDEX "Patient_primaryClinicId_residentialLocationStatus_idx"
+  ON "Patient"("primaryClinicId", "residentialLocationStatus");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -15,6 +15,38 @@ enum Sex {
   UNKNOWN
 }
 
+// Ghana's 16 administrative regions. Used for a patient's residential
+// location, which is deliberately kept separate from their primary clinic.
+enum GhanaRegion {
+  AHAFO
+  ASHANTI
+  BONO
+  BONO_EAST
+  CENTRAL
+  EASTERN
+  GREATER_ACCRA
+  NORTH_EAST
+  NORTHERN
+  OTI
+  SAVANNAH
+  UPPER_EAST
+  UPPER_WEST
+  VOLTA
+  WESTERN
+  WESTERN_NORTH
+}
+
+// Deliberate capture state for a patient's residential location so that a
+// missing location is never ambiguous blank text.
+// - RECORDED: staff captured a residential location (region required).
+// - UNKNOWN: staff asked but the location is not known.
+// - NOT_RECORDED: never captured (default for migrated/new patients).
+enum PatientLocationStatus {
+  RECORDED
+  UNKNOWN
+  NOT_RECORDED
+}
+
 enum UserRole {
   SYSTEM_ADMIN
   DIRECTOR
@@ -454,6 +486,14 @@ model Patient {
   nationalIdHash       String         @unique @db.VarChar(128) // SHA-256 hex or base64url
   nationalIdLast4      String?        @db.VarChar(8)
 
+  // Residential/community location. Distinct from primaryClinicId (care site)
+  // and Clinic.locationCode. Privacy-conscious: no GPS/lat/long in v1.
+  residentialLocationStatus PatientLocationStatus @default(NOT_RECORDED)
+  residentialRegion         GhanaRegion?
+  residentialDistrict       String?               @db.VarChar(120)
+  residentialCommunity      String?               @db.VarChar(120)
+  residentialAddressNote    String?               @db.VarChar(280)
+
   createdByUserId     String?   @db.Uuid
   portalUserId        String?   @unique @db.Uuid
   mergedIntoPatientId String?   @db.Uuid
@@ -495,6 +535,8 @@ model Patient {
   @@index([phoneE164])
   @@index([updatedAt])
   @@index([primaryClinicId, updatedAt, id])
+  @@index([primaryClinicId, residentialRegion])
+  @@index([primaryClinicId, residentialLocationStatus])
 }
 
 model PatientConsent {

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -8,7 +8,15 @@
  * for clinic maintenance or data repair scripts.
  */
 import 'dotenv/config';
-import { PrismaClient, UserRole, Sex, NationalIdType, EncounterStatus } from '@prisma/client';
+import {
+  PrismaClient,
+  UserRole,
+  Sex,
+  NationalIdType,
+  EncounterStatus,
+  GhanaRegion,
+  PatientLocationStatus,
+} from '@prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';
 import {
   encryptNationalId,
@@ -198,6 +206,12 @@ async function main() {
             nationalIdHash: hashNationalId(nationalIdPlain),
             nationalIdLast4: nationalIdLast4(nationalIdPlain),
             createdByUserId: user.id,
+            // Demonstrates a deliberately recorded residential location. Other
+            // patients default to NOT_RECORDED (the safe migration state).
+            residentialLocationStatus: PatientLocationStatus.RECORDED,
+            residentialRegion: GhanaRegion.GREATER_ACCRA,
+            residentialDistrict: 'Accra Metropolitan',
+            residentialCommunity: 'Osu',
           },
         });
         await prisma.encounter.create({

--- a/packages/db/src/ghana-locations.spec.ts
+++ b/packages/db/src/ghana-locations.spec.ts
@@ -1,0 +1,47 @@
+import {
+  GHANA_DISTRICTS_BY_REGION,
+  GHANA_REGIONS,
+  GHANA_REGION_LABELS,
+  isDistrictInRegion,
+  isGhanaRegion,
+  normalizeDistrict,
+} from './ghana-locations';
+
+describe('ghana-locations reference data', () => {
+  it('covers all 16 regions with labels and district lists', () => {
+    expect(GHANA_REGIONS).toHaveLength(16);
+    for (const region of GHANA_REGIONS) {
+      expect(GHANA_REGION_LABELS[region]).toBeTruthy();
+      expect(GHANA_DISTRICTS_BY_REGION[region].length).toBeGreaterThan(0);
+    }
+  });
+
+  it('has no duplicate districts within a region', () => {
+    for (const region of GHANA_REGIONS) {
+      const districts = GHANA_DISTRICTS_BY_REGION[region];
+      expect(new Set(districts).size).toBe(districts.length);
+    }
+  });
+
+  it('validates region enum membership', () => {
+    expect(isGhanaRegion('GREATER_ACCRA')).toBe(true);
+    expect(isGhanaRegion('ATLANTIS')).toBe(false);
+    expect(isGhanaRegion(undefined)).toBe(false);
+  });
+
+  it('normalizes a district case-insensitively to its canonical spelling', () => {
+    expect(normalizeDistrict('GREATER_ACCRA', 'accra metropolitan')).toBe('Accra Metropolitan');
+    expect(normalizeDistrict('ASHANTI', '  Kumasi Metropolitan  ')).toBe('Kumasi Metropolitan');
+  });
+
+  it('rejects a district that does not belong to the region', () => {
+    expect(isDistrictInRegion('GREATER_ACCRA', 'Kumasi Metropolitan')).toBe(false);
+    expect(normalizeDistrict('GREATER_ACCRA', 'Kumasi Metropolitan')).toBeNull();
+  });
+
+  it('treats empty/absent input as no district', () => {
+    expect(normalizeDistrict('ASHANTI', '')).toBeNull();
+    expect(normalizeDistrict(null, 'Bekwai')).toBeNull();
+    expect(isDistrictInRegion('ASHANTI', undefined)).toBe(false);
+  });
+});

--- a/packages/db/src/ghana-locations.ts
+++ b/packages/db/src/ghana-locations.ts
@@ -1,0 +1,390 @@
+import type { GhanaRegion, PatientLocationStatus } from '@prisma/client';
+
+/**
+ * Shared reference data for a patient's residential location.
+ *
+ * This is the single source of truth consumed by the API (DTO validation +
+ * service normalization) and the web app (region/district dropdowns), so the
+ * two layers can never drift. It is intentionally free of any GPS/coordinate
+ * concept — v1 captures administrative geography only.
+ */
+
+/** Ghana's 16 administrative regions, in a stable display order. */
+export const GHANA_REGIONS: GhanaRegion[] = [
+  'AHAFO',
+  'ASHANTI',
+  'BONO',
+  'BONO_EAST',
+  'CENTRAL',
+  'EASTERN',
+  'GREATER_ACCRA',
+  'NORTH_EAST',
+  'NORTHERN',
+  'OTI',
+  'SAVANNAH',
+  'UPPER_EAST',
+  'UPPER_WEST',
+  'VOLTA',
+  'WESTERN',
+  'WESTERN_NORTH',
+];
+
+/** Human-readable labels for each region. */
+export const GHANA_REGION_LABELS: Record<GhanaRegion, string> = {
+  AHAFO: 'Ahafo',
+  ASHANTI: 'Ashanti',
+  BONO: 'Bono',
+  BONO_EAST: 'Bono East',
+  CENTRAL: 'Central',
+  EASTERN: 'Eastern',
+  GREATER_ACCRA: 'Greater Accra',
+  NORTH_EAST: 'North East',
+  NORTHERN: 'Northern',
+  OTI: 'Oti',
+  SAVANNAH: 'Savannah',
+  UPPER_EAST: 'Upper East',
+  UPPER_WEST: 'Upper West',
+  VOLTA: 'Volta',
+  WESTERN: 'Western',
+  WESTERN_NORTH: 'Western North',
+};
+
+/** Human-readable labels for the deliberate capture state. */
+export const PATIENT_LOCATION_STATUS_LABELS: Record<PatientLocationStatus, string> = {
+  RECORDED: 'Recorded',
+  UNKNOWN: 'Unknown',
+  NOT_RECORDED: 'Not recorded',
+};
+
+/**
+ * Metropolitan / Municipal / District assemblies (MMDAs) per region.
+ *
+ * Used to drive the dependent district dropdown and to validate that a captured
+ * district belongs to its region. Names are stored/compared case-insensitively
+ * (see {@link normalizeDistrict}) so that assembly-suffix casing does not cause
+ * spurious validation failures.
+ */
+export const GHANA_DISTRICTS_BY_REGION: Record<GhanaRegion, string[]> = {
+  AHAFO: [
+    'Asunafo North',
+    'Asunafo South',
+    'Asutifi North',
+    'Asutifi South',
+    'Tano North',
+    'Tano South',
+  ],
+  ASHANTI: [
+    'Adansi Asokwa',
+    'Adansi North',
+    'Adansi South',
+    'Afigya Kwabre North',
+    'Afigya Kwabre South',
+    'Ahafo Ano North',
+    'Ahafo Ano South East',
+    'Ahafo Ano South West',
+    'Amansie Central',
+    'Amansie South',
+    'Amansie West',
+    'Asante Akim Central',
+    'Asante Akim North',
+    'Asante Akim South',
+    'Asokore Mampong',
+    'Asokwa',
+    'Atwima Kwanwoma',
+    'Atwima Mponua',
+    'Atwima Nwabiagya',
+    'Atwima Nwabiagya North',
+    'Bekwai',
+    'Bosome Freho',
+    'Bosomtwe',
+    'Ejisu',
+    'Ejura Sekyedumase',
+    'Juaben',
+    'Kumasi Metropolitan',
+    'Kwabre East',
+    'Kwadaso',
+    'Mampong',
+    'Obuasi East',
+    'Obuasi Municipal',
+    'Offinso Municipal',
+    'Offinso North',
+    'Oforikrom',
+    'Old Tafo',
+    'Sekyere Afram Plains',
+    'Sekyere Central',
+    'Sekyere East',
+    'Sekyere Kumawu',
+    'Sekyere South',
+    'Suame',
+  ],
+  BONO: [
+    'Banda',
+    'Berekum East',
+    'Berekum West',
+    'Dormaa Central',
+    'Dormaa East',
+    'Dormaa West',
+    'Jaman North',
+    'Jaman South',
+    'Sunyani Municipal',
+    'Sunyani West',
+    'Tain',
+    'Wenchi',
+  ],
+  BONO_EAST: [
+    'Atebubu Amantin',
+    'Kintampo North',
+    'Kintampo South',
+    'Nkoranza North',
+    'Nkoranza South',
+    'Pru East',
+    'Pru West',
+    'Sene East',
+    'Sene West',
+    'Techiman Municipal',
+    'Techiman North',
+  ],
+  CENTRAL: [
+    'Abura Asebu Kwamankese',
+    'Agona East',
+    'Agona West',
+    'Ajumako Enyan Essiam',
+    'Asikuma Odoben Brakwa',
+    'Assin Central',
+    'Assin North',
+    'Assin South',
+    'Awutu Senya East',
+    'Awutu Senya West',
+    'Cape Coast Metropolitan',
+    'Effutu',
+    'Ekumfi',
+    'Gomoa Central',
+    'Gomoa East',
+    'Gomoa West',
+    'Komenda Edina Eguafo Abirem',
+    'Mfantsiman',
+    'Twifo Atti Morkwa',
+    'Twifo Hemang Lower Denkyira',
+    'Upper Denkyira East',
+    'Upper Denkyira West',
+  ],
+  EASTERN: [
+    'Abuakwa North',
+    'Abuakwa South',
+    'Achiase',
+    'Akuapem North',
+    'Akuapem South',
+    'Akyemansa',
+    'Asene Manso Akroso',
+    'Asuogyaman',
+    'Atiwa East',
+    'Atiwa West',
+    'Ayensuano',
+    'Birim Central',
+    'Birim North',
+    'Birim South',
+    'Denkyembour',
+    'Fanteakwa North',
+    'Fanteakwa South',
+    'Kwaebibirem',
+    'Kwahu Afram Plains North',
+    'Kwahu Afram Plains South',
+    'Kwahu East',
+    'Kwahu South',
+    'Kwahu West',
+    'Lower Manya Krobo',
+    'New Juaben North',
+    'New Juaben South',
+    'Nsawam Adoagyiri',
+    'Okere',
+    'Suhum',
+    'Upper Manya Krobo',
+    'Upper West Akim',
+    'West Akim',
+    'Yilo Krobo',
+  ],
+  GREATER_ACCRA: [
+    'Accra Metropolitan',
+    'Ada East',
+    'Ada West',
+    'Adentan',
+    'Ashaiman',
+    'Ayawaso Central',
+    'Ayawaso East',
+    'Ayawaso North',
+    'Ayawaso West',
+    'Ga Central',
+    'Ga East',
+    'Ga North',
+    'Ga South',
+    'Ga West',
+    'Korle Klottey',
+    'Kpone Katamanso',
+    'Krowor',
+    'La Dade Kotopon',
+    'La Nkwantanang Madina',
+    'Ledzokuku',
+    'Ningo Prampram',
+    'Okaikwei North',
+    'Shai Osudoku',
+    'Tema Metropolitan',
+    'Tema West',
+    'Weija Gbawe',
+  ],
+  NORTH_EAST: [
+    'Bunkpurugu Nakpanduri',
+    'Chereponi',
+    'East Mamprusi',
+    'Mamprugu Moagduri',
+    'West Mamprusi',
+    'Yunyoo Nasuan',
+  ],
+  NORTHERN: [
+    'Gushegu',
+    'Karaga',
+    'Kpandai',
+    'Kumbungu',
+    'Mion',
+    'Nanton',
+    'Nanumba North',
+    'Nanumba South',
+    'Saboba',
+    'Sagnarigu',
+    'Savelugu',
+    'Tamale Metropolitan',
+    'Tatale Sanguli',
+    'Tolon',
+    'Yendi',
+    'Zabzugu',
+  ],
+  OTI: [
+    'Biakoye',
+    'Jasikan',
+    'Kadjebi',
+    'Krachi East',
+    'Krachi Nchumuru',
+    'Krachi West',
+    'Nkwanta North',
+    'Nkwanta South',
+    'Guan',
+  ],
+  SAVANNAH: [
+    'Bole',
+    'Central Gonja',
+    'East Gonja',
+    'North East Gonja',
+    'North Gonja',
+    'Sawla Tuna Kalba',
+    'West Gonja',
+  ],
+  UPPER_EAST: [
+    'Bawku Municipal',
+    'Bawku West',
+    'Binduri',
+    'Bolgatanga Municipal',
+    'Bolgatanga East',
+    'Bongo',
+    'Builsa North',
+    'Builsa South',
+    'Garu',
+    'Kassena Nankana Municipal',
+    'Kassena Nankana West',
+    'Nabdam',
+    'Pusiga',
+    'Talensi',
+    'Tempane',
+  ],
+  UPPER_WEST: [
+    'Daffiama Bussie Issa',
+    'Jirapa',
+    'Lambussie Karni',
+    'Lawra',
+    'Nadowli Kaleo',
+    'Nandom',
+    'Sissala East',
+    'Sissala West',
+    'Wa East',
+    'Wa Municipal',
+    'Wa West',
+  ],
+  VOLTA: [
+    'Adaklu',
+    'Afadzato South',
+    'Agotime Ziope',
+    'Akatsi North',
+    'Akatsi South',
+    'Anloga',
+    'Central Tongu',
+    'Ho Municipal',
+    'Ho West',
+    'Hohoe Municipal',
+    'Keta Municipal',
+    'Ketu North',
+    'Ketu South',
+    'Kpando',
+    'North Dayi',
+    'North Tongu',
+    'South Dayi',
+    'South Tongu',
+  ],
+  WESTERN: [
+    'Ahanta West',
+    'Amenfi Central',
+    'Amenfi East',
+    'Amenfi West',
+    'Effia Kwesimintsim',
+    'Ellembelle',
+    'Jomoro',
+    'Mpohor',
+    'Nzema East',
+    'Prestea Huni Valley',
+    'Sekondi Takoradi Metropolitan',
+    'Shama',
+    'Tarkwa Nsuaem',
+    'Wassa East',
+  ],
+  WESTERN_NORTH: [
+    'Aowin',
+    'Bia East',
+    'Bia West',
+    'Bibiani Anhwiaso Bekwai',
+    'Bodi',
+    'Juaboso',
+    'Sefwi Akontombra',
+    'Sefwi Wiawso',
+    'Suaman',
+  ],
+};
+
+/** Type guard for a valid region enum value. */
+export function isGhanaRegion(value: unknown): value is GhanaRegion {
+  return typeof value === 'string' && (GHANA_REGIONS as string[]).includes(value);
+}
+
+/**
+ * Case-insensitively resolve a district string to its canonical spelling within
+ * a region. Returns the canonical name if the district belongs to the region,
+ * otherwise `null`.
+ */
+export function normalizeDistrict(
+  region: GhanaRegion | null | undefined,
+  district: string | null | undefined,
+): string | null {
+  if (!region || !district) {
+    return null;
+  }
+  const target = district.trim().toLowerCase();
+  if (!target) {
+    return null;
+  }
+  const match = GHANA_DISTRICTS_BY_REGION[region].find((name) => name.toLowerCase() === target);
+  return match ?? null;
+}
+
+/** True when `district` is a known MMDA within `region`. */
+export function isDistrictInRegion(
+  region: GhanaRegion | null | undefined,
+  district: string | null | undefined,
+): boolean {
+  return normalizeDistrict(region, district) !== null;
+}

--- a/packages/db/src/patient-residential-location-schema.spec.ts
+++ b/packages/db/src/patient-residential-location-schema.spec.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('patient residential location migration', () => {
+  const migration = readFileSync(
+    resolve(
+      __dirname,
+      '../prisma/migrations/20260819120000_add_patient_residential_location/migration.sql',
+    ),
+    'utf8',
+  );
+
+  it('creates the region and deliberate-status enums', () => {
+    expect(migration).toContain('CREATE TYPE "GhanaRegion" AS ENUM');
+    expect(migration).toContain("'GREATER_ACCRA'");
+    expect(migration).toContain("'WESTERN_NORTH'");
+    expect(migration).toContain(
+      "CREATE TYPE \"PatientLocationStatus\" AS ENUM ('RECORDED', 'UNKNOWN', 'NOT_RECORDED')",
+    );
+  });
+
+  it('adds residential columns keeping location separate from primary clinic', () => {
+    expect(migration).toContain('ALTER TABLE "Patient"');
+    expect(migration).toContain('"residentialLocationStatus" "PatientLocationStatus"');
+    expect(migration).toContain('"residentialRegion" "GhanaRegion"');
+    expect(migration).toContain('"residentialDistrict" VARCHAR(120)');
+    expect(migration).toContain('"residentialCommunity" VARCHAR(120)');
+    expect(migration).toContain('"residentialAddressNote" VARCHAR(280)');
+  });
+
+  it('backfills existing patients to NOT_RECORDED without fabricating a location', () => {
+    expect(migration).toContain("NOT NULL DEFAULT 'NOT_RECORDED'");
+    // Region/district/community/address-note must remain nullable (no default).
+    expect(migration).not.toMatch(/"residentialRegion"[^\n]*DEFAULT/);
+  });
+
+  it('indexes location filters within the clinic scope', () => {
+    expect(migration).toContain('CREATE INDEX "Patient_primaryClinicId_residentialRegion_idx"');
+    expect(migration).toContain(
+      'CREATE INDEX "Patient_primaryClinicId_residentialLocationStatus_idx"',
+    );
+  });
+});


### PR DESCRIPTION
Closes #64.

Summary

Patients had only a primary clinic (their care site). This PR adds a privacy-conscious residential/community location — where the patient actually lives — that is deliberately kept separate from primaryClinicId and Clinic.locationCode, and lets staff filter/group the clinic registry by those location dimensions.

Key properties:

- Structured, no GPS. Region is a DB enum (Ghana's 16 regions), district is validated against a region→district reference map, community and an optional address note are free text. No latitude/longitude/coordinates in v1.
- Deliberate unknown state. A PatientLocationStatus (RECORDED | UNKNOWN | NOT_RECORDED) makes a missing location explicit rather than ambiguous blank text. Existing patients migrate to NOT_RECORDED with no fabricated location.
- Clinic-scoped filtering. The registry can filter by region, district, community, and location status, always AND-ed within the caller's existing clinic scope — filters never cross clinics or organizations.
- Privacy in exports. Only a coarse residential_region reaches de-identified research exports; district, community, and the address note are excluded as re-identifying.

What changed

Data model (@nkwapa/db)

- New enums GhanaRegion (16 regions) and PatientLocationStatus.
- New Patient columns: residentialLocationStatus (defaults NOT_RECORDED), residentialRegion, residentialDistrict, residentialCommunity, residentialAddressNote.
- Clinic-scoped indexes (primaryClinicId, residentialRegion) and (primaryClinicId, residentialLocationStatus).
- Migration 20260819120000_add_patient_residential_location — existing rows backfill to NOT_RECORDED; other fields stay nullable.
- New shared src/ghana-locations.ts: region labels, the region→district reference map, and normalizeDistrict/isDistrictInRegion helpers — one source of truth consumed by both the API and the web app.

API (@nkwapa/api)

- Create/update patient DTOs extend a shared ResidentialLocationDto fragment (DRY) with sanitized, length-limited fields and a custom IsDistrictInRegion cross-field validator.
- A single resolveResidentialLocation invariant (in residential-location.util.ts) is reused by the patient service and the offline sync upsert: RECORDED requires a region and canonicalizes the district; UNKNOWN/NOT_RECORDED clear granular fields; an omitted status is inferred.
- Registry repository gains region/district/community/status filters, AND-ed under the existing primaryClinicId scope; wired through the list query DTO and controller.
- Research subjects export adds a coarse residential_region column only (dataset version bumped to 4).
- RBAC/audit unchanged: existing PATIENT_READ/SEARCH/CREATE/UPDATE permissions, ClinicScopeGuard, Postgres RLS, and full-snapshot audit logging already cover the new fields.

Web (@nkwapa/web)

- Shared lib/residential-location.ts plus three reusable components:
  - ResidentialLocationFields — create/edit form section enforcing the RECORDED-only invariant with a dependent region→district dropdown.
  - ResidentialLocationSummary — detail-page tiles clearly separated from the primary clinic; NOT_RECORDED/UNKNOWN render deliberately.
  - ResidentialLocationFilters — registry region/district/community/status controls.
- Wired into the register screen, edit screen (diff-only PATCH + offline Dexie/outbox payload), both patient detail pages, and both registry pages (with active-filter chips).
- Dexie PatientRecord extended and bumped to schema v7 to index residentialRegion for offline filtering; new fields flow through the existing sync mapper and outbox unchanged.

Access & data policy

- Reads/searches stay gated by PATIENT_READ/PATIENT_SEARCH + clinic scope; writes by PATIENT_CREATE/PATIENT_UPDATE. SYSTEM_ADMIN, DIRECTOR, MANAGER, DOCTOR, and VOLUNTEER read within clinic scope.
- Filters ride the existing clinic-scoped where + RLS, so they cannot widen access across clinics/organizations (covered by a cross-clinic isolation test).
- Patient portal exposure remains out of scope.

Tests

- DB: migration schema assertions; Ghana reference-data unit tests.
- API: DTO normalization/limits/unknown/partial + district-in-region validation; service passthrough + status invariant; repository filter + cross-clinic isolation; sync upsert carries and defaults location; research export includes region only and excludes granular residence.
- Web: residential-location helper unit tests; Dexie region-index schema test.
- E2E: Playwright flow records a location, confirms residence vs primary-clinic separation, filters the registry by region with an active-filter chip, checks responsive overflow across breakpoints, and verifies the deliberate UNKNOWN state.

Migration & rollout notes

- Run npm run db:migrate:deploy to apply the additive migration; existing patients become NOT_RECORDED automatically (no backfill script, no fabricated data).
- Research consumers should note dataset version 4 adds one coarse residential_region column.

Out of scope / non-goals

- No change to primary-clinic assignment.
- No GPS, mapping, geocoding, or route planning.
- No full postal address requirement.

Reviewer checklist

- [ ] Region enum + reference district validation reads correctly for your region data.
- [ ] Unknown vs not-recorded distinction matches operational intent.
- [ ] Confirm district/community/address note stay out of research exports.
