### PR TITLE
feat(design-system): shared state components and primitive token binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ apps/web/pnpm-lock.yaml
 # Playwright run artifacts
 test-results/
 playwright-report/
+
+# Local presentation material
+/docs/demo/

--- a/apps/web/app/SyncStatusBar.tsx
+++ b/apps/web/app/SyncStatusBar.tsx
@@ -31,7 +31,7 @@ export function SyncStatusBar({ clinicId }: SyncStatusBarProps) {
     <div
       className={cn(
         'flex flex-wrap items-center gap-x-4 gap-y-2 border-b px-4 py-2 text-sm',
-        isOnline ? 'border-border/70 bg-card' : 'border-amber-300/60 bg-amber-50',
+        isOnline ? 'border-border/70 bg-card' : 'border-warning/35 bg-warning/10',
       )}
       // Connection and queue state change without user action, so the change is announced.
       role="status"
@@ -40,13 +40,13 @@ export function SyncStatusBar({ clinicId }: SyncStatusBarProps) {
       <span className="flex items-center gap-1.5 font-medium">
         {isOnline ? (
           <>
-            <Wifi aria-hidden="true" className="size-4 text-emerald-600" />
-            <span className="text-emerald-700">Online</span>
+            <Wifi aria-hidden="true" className="size-4 text-success" />
+            <span className="text-success-ink">Online</span>
           </>
         ) : (
           <>
-            <CloudOff aria-hidden="true" className="size-4 text-amber-700" />
-            <span className="text-amber-800">Offline</span>
+            <CloudOff aria-hidden="true" className="size-4 text-warning" />
+            <span className="text-warning-ink">Offline</span>
           </>
         )}
       </span>
@@ -61,7 +61,7 @@ export function SyncStatusBar({ clinicId }: SyncStatusBarProps) {
         type="button"
         variant="outline"
         size="sm"
-        className="cursor-pointer rounded-2xl"
+        className="cursor-pointer rounded-lg"
         onClick={() => syncNow(clinicId)}
         disabled={!isOnline || isSyncing}
       >

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -43,6 +43,19 @@
     --success-foreground: 0 0% 100%;
     --warning: 32 90% 48%;
     --warning-foreground: 200 25% 15%;
+    /* Info carries the "awaiting review" workflow state, which is neither success, warning, nor
+       destructive. It is not a brand colour and must not be used for actions. */
+    --info: 200 60% 40%;
+    --info-foreground: 0 0% 100%;
+    /* Ink for tinted status badges (bg-<token>/12 + text-<token>-ink), the pattern the badge
+       component already used via bg-emerald-100 / text-emerald-800.
+       Reusing the fill token as the text colour on its own tint FAILS AA: measured 4.28:1 for
+       success and 2.42:1 for warning, because the tint lightens the ground while the ink stays
+       put. These are darkened until they clear on their own tint with headroom: success 5.20:1,
+       warning 5.94:1, info 7.52:1. */
+    --success-ink: 152 65% 26%;
+    --warning-ink: 32 90% 28%;
+    --info-ink: 200 60% 26%;
     --destructive: 0 72% 51%;
     --destructive-foreground: 0 0% 100%;
     /* --border stays soft at 1.26:1 on the canvas. WCAG 1.4.11 requires 3:1 only for boundaries
@@ -95,6 +108,13 @@
     --success-foreground: 200 25% 10%;
     --warning: 35 90% 58%;
     --warning-foreground: 200 25% 10%;
+    --info: 200 60% 58%;
+    --info-foreground: 200 25% 10%;
+    /* Dark inverts the badge: a dark tint of the hue carrying light ink. Measured on a 22% tint
+       over the dark card: success 6.82:1, warning 6.74:1, info 6.49:1. */
+    --success-ink: 152 40% 74%;
+    --warning-ink: 35 75% 74%;
+    --info-ink: 200 45% 74%;
     --destructive: 0 62% 45%;
     --destructive-foreground: 0 0% 100%;
     /* Same split as light mode: --border stays a soft decorative divider, --input carries the

--- a/apps/web/components/app-shell/AppMetricCard.tsx
+++ b/apps/web/components/app-shell/AppMetricCard.tsx
@@ -21,12 +21,7 @@ export function AppMetricCard({
   className?: string;
 }) {
   return (
-    <Card
-      className={cn(
-        'overflow-hidden border-border/80 bg-card/90 shadow-lg shadow-black/5',
-        className,
-      )}
-    >
+    <Card className={cn('overflow-hidden border-border/80 bg-card/90', className)}>
       <CardHeader className="pb-3">
         <div className="flex items-start justify-between gap-3">
           <div>
@@ -41,7 +36,7 @@ export function AppMetricCard({
             </CardTitle>
           </div>
           {Icon ? (
-            <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+            <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-primary/10 text-primary">
               <Icon className="h-5 w-5" />
             </div>
           ) : null}

--- a/apps/web/components/app-shell/AppNavList.tsx
+++ b/apps/web/components/app-shell/AppNavList.tsx
@@ -45,17 +45,17 @@ export function AppNavList({
                   title={collapsed && !mobile ? item.label : undefined}
                   onClick={enabled ? onNavigate : undefined}
                   className={cn(
-                    'group flex items-center gap-3 rounded-2xl border px-3 py-2.5 transition-all duration-200',
+                    'group flex items-center gap-3 rounded-lg border px-3 py-2.5 transition-all duration-200',
                     collapsed && !mobile ? 'justify-center px-2.5' : '',
                     active
-                      ? 'border-primary/30 bg-primary text-primary-foreground shadow-lg shadow-primary/20'
+                      ? 'border-primary/30 bg-primary text-primary-foreground'
                       : 'border-transparent text-muted-foreground hover:border-border/70 hover:bg-background/80 hover:text-foreground',
                     !enabled && 'pointer-events-none opacity-45',
                   )}
                 >
                   <span
                     className={cn(
-                      'flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl transition-colors',
+                      'flex h-10 w-10 shrink-0 items-center justify-center rounded-lg transition-colors',
                       active
                         ? 'bg-primary-foreground/16 text-primary-foreground'
                         : 'bg-background/80 text-primary group-hover:bg-primary/10',

--- a/apps/web/components/app-shell/AppPageHeader.tsx
+++ b/apps/web/components/app-shell/AppPageHeader.tsx
@@ -30,7 +30,7 @@ export function AppPageHeader({
       className={cn(
         // Flat, per the design system: no gradient and no heavy shadow on a clinical view. The
         // header should frame the chart, not compete with the measurements in it.
-        'overflow-hidden rounded-[30px] border border-border/80 bg-card p-5 md:p-6',
+        'overflow-hidden rounded-lg border border-border/80 bg-card p-5 md:p-6',
         className,
       )}
     >

--- a/apps/web/components/app-shell/FormSectionCard.tsx
+++ b/apps/web/components/app-shell/FormSectionCard.tsx
@@ -23,12 +23,7 @@ export function FormSectionCard({
   contentClassName,
 }: FormSectionCardProps) {
   return (
-    <Card
-      className={cn(
-        'rounded-[28px] border-border/80 bg-card/90 shadow-lg shadow-black/5',
-        className,
-      )}
-    >
+    <Card className={cn('rounded-lg border-border/80 bg-card/90', className)}>
       <CardHeader className="space-y-2 pb-4">
         <div className="flex items-start gap-2">
           <CardTitle className="text-lg">{title}</CardTitle>

--- a/apps/web/components/app-shell/SegmentedControl.tsx
+++ b/apps/web/components/app-shell/SegmentedControl.tsx
@@ -49,7 +49,7 @@ export function SegmentedControl<TValue extends string>({
       role="group"
       aria-label={label}
       className={cn(
-        'grid h-auto w-full gap-2 rounded-2xl border border-border/70 bg-background p-2',
+        'grid h-auto w-full gap-2 rounded-lg border border-border/70 bg-background p-2',
         className,
       )}
       style={{ gridTemplateColumns: `repeat(${options.length}, minmax(0, 1fr))` }}

--- a/apps/web/components/feedback/AppState.tsx
+++ b/apps/web/components/feedback/AppState.tsx
@@ -1,7 +1,16 @@
 'use client';
 
 import Link from 'next/link';
-import { Activity, AlertTriangle, RefreshCw, ShieldCheck, Stethoscope } from 'lucide-react';
+import {
+  Activity,
+  AlertTriangle,
+  Inbox,
+  Lock,
+  RefreshCw,
+  ShieldCheck,
+  Stethoscope,
+} from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
@@ -20,7 +29,7 @@ export function PageSkeleton({
   return (
     <div className={cn('min-h-[60vh] bg-clinical-grid px-4 py-8 md:px-6', className)}>
       <div className="mx-auto flex max-w-6xl flex-col gap-6">
-        <div className="overflow-hidden rounded-[32px] border border-border/70 bg-card/95 shadow-2xl shadow-black/5">
+        <div className="overflow-hidden rounded-xl border border-border/70 bg-card/95">
           <div className="h-1.5 w-full overflow-hidden bg-muted/50">
             <div className="h-full w-1/2 animate-[loading-bar_1.7s_ease-in-out_infinite] bg-primary/80" />
           </div>
@@ -43,7 +52,7 @@ export function PageSkeleton({
                   {steps.map((step, index) => (
                     <div
                       key={step}
-                      className="flex items-center gap-2 rounded-2xl border border-border/70 bg-background/75 px-3 py-2 text-xs font-medium text-muted-foreground"
+                      className="flex items-center gap-2 rounded-md border border-border/70 bg-background/75 px-3 py-2 text-xs font-medium text-muted-foreground"
                     >
                       <span
                         className="h-2 w-2 rounded-full bg-primary"
@@ -58,7 +67,7 @@ export function PageSkeleton({
                 {Array.from({ length: 3 }).map((_, index) => (
                   <div
                     key={index}
-                    className="h-24 animate-pulse rounded-2xl border border-border/70 bg-muted/40"
+                    className="h-24 animate-pulse rounded-md border border-border/70 bg-muted/40"
                   />
                 ))}
               </div>
@@ -66,8 +75,8 @@ export function PageSkeleton({
           </div>
         </div>
 
-        <SectionSkeleton lines={2} className="rounded-[28px] p-6 md:p-8" />
-        <SectionSkeleton lines={5} className="rounded-[28px] p-6 md:p-8" />
+        <SectionSkeleton lines={2} className="rounded-lg p-6 md:p-8" />
+        <SectionSkeleton lines={5} className="rounded-lg p-6 md:p-8" />
       </div>
     </div>
   );
@@ -76,14 +85,14 @@ export function PageSkeleton({
 export function DashboardLoadingState({ clinicName }: { clinicName?: string | null }) {
   return (
     <div className="space-y-5">
-      <div className="rounded-[28px] border border-border/70 bg-card/90 p-5 shadow-sm">
+      <div className="rounded-lg border border-border/70 bg-card/90 p-5 shadow-sm">
         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
           <div className="space-y-2">
             <div className="h-4 w-36 animate-pulse rounded-full bg-primary/20" />
             <div className="h-7 w-64 max-w-full animate-pulse rounded-full bg-muted/60" />
             <div className="h-4 w-80 max-w-full animate-pulse rounded-full bg-muted/40" />
           </div>
-          <div className="inline-flex items-center gap-3 rounded-2xl border border-primary/20 bg-primary/10 px-4 py-3 text-sm font-medium text-primary">
+          <div className="inline-flex items-center gap-3 rounded-md border border-primary/20 bg-primary/10 px-4 py-3 text-sm font-medium text-primary">
             <Stethoscope className="h-4 w-4 animate-pulse" />
             {clinicName ? `Loading ${clinicName}` : 'Loading clinic dashboard'}
           </div>
@@ -94,19 +103,19 @@ export function DashboardLoadingState({ clinicName }: { clinicName?: string | nu
         {Array.from({ length: 5 }).map((_, index) => (
           <div
             key={index}
-            className="h-32 animate-pulse rounded-2xl border border-border/70 bg-card/80"
+            className="h-32 animate-pulse rounded-md border border-border/70 bg-card/80"
           />
         ))}
       </div>
 
-      <SectionSkeleton lines={4} className="rounded-[28px] p-6" />
+      <SectionSkeleton lines={4} className="rounded-lg p-6" />
     </div>
   );
 }
 
 export function SectionSkeleton({ lines = 4, className }: { lines?: number; className?: string }) {
   return (
-    <Card className={cn('border-border/70 bg-card/90 shadow-lg shadow-black/5', className)}>
+    <Card className={cn('border-border/70 bg-card/90', className)}>
       <CardContent className="space-y-4 p-0">
         <div className="space-y-3">
           <div className="h-5 w-40 animate-pulse rounded-full bg-muted/50" />
@@ -116,7 +125,7 @@ export function SectionSkeleton({ lines = 4, className }: { lines?: number; clas
           {Array.from({ length: lines }).map((_, index) => (
             <div
               key={index}
-              className="h-20 animate-pulse rounded-2xl border border-border/60 bg-muted/35"
+              className="h-20 animate-pulse rounded-md border border-border/60 bg-muted/35"
             />
           ))}
         </div>
@@ -135,7 +144,7 @@ export function RetryAction({
   variant?: 'default' | 'outline';
 }) {
   return (
-    <Button onClick={onRetry} variant={variant} className="rounded-2xl">
+    <Button onClick={onRetry} variant={variant} className="rounded-md">
       <RefreshCw className="h-4 w-4" />
       {label}
     </Button>
@@ -158,7 +167,7 @@ export function InlineErrorState({
   return (
     <div
       className={cn(
-        'rounded-[28px] border border-destructive/20 bg-destructive/5 p-5 text-sm shadow-sm',
+        'rounded-lg border border-destructive/20 bg-destructive/5 p-5 text-sm shadow-sm',
         className,
       )}
     >
@@ -193,10 +202,9 @@ export function FullscreenStatus({
 }) {
   return (
     <div className="flex min-h-screen items-center justify-center bg-clinical-grid p-6">
-      <Card className="w-full max-w-3xl overflow-hidden rounded-[32px] border-border/70 bg-card/95 shadow-2xl shadow-black/5">
+      <Card className="w-full max-w-3xl overflow-hidden rounded-xl border-border/70 bg-card/95">
         <CardContent className="grid gap-0 lg:grid-cols-[1.08fr_0.92fr]">
           <section className="relative overflow-hidden px-6 py-8 md:px-8 md:py-10">
-            <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,hsl(var(--primary)/0.14),transparent_35%),radial-gradient(circle_at_bottom_right,hsl(var(--secondary)/0.12),transparent_32%)]" />
             <div className="relative space-y-5">
               <p
                 className={cn(
@@ -245,15 +253,98 @@ export function NotFoundState() {
       title="This page couldn't be found"
       description="The address may be outdated, or the page may have moved after a clinic or portal update."
       primaryAction={
-        <Button asChild className="rounded-2xl">
+        <Button asChild className="rounded-md">
           <Link href="/dashboard">Open dashboard</Link>
         </Button>
       }
       secondaryAction={
-        <Button asChild variant="outline" className="rounded-2xl">
+        <Button asChild variant="outline" className="rounded-md">
           <Link href="/">Back to home</Link>
         </Button>
       }
     />
+  );
+}
+
+/**
+ * "There is nothing here yet", not "something went wrong".
+ *
+ * Kept visually distinct from InlineErrorState on purpose: an empty queue at the start of a
+ * clinic day is the normal case, and dressing it in destructive colour trains staff to read
+ * a calm system as a broken one. Neutral surface, no alarm colour, no retry.
+ */
+export function EmptyState({
+  title,
+  description,
+  icon: Icon = Inbox,
+  action,
+  className,
+}: {
+  title: string;
+  /** What the reader can do about it, in plain language. Not an apology. */
+  description: string;
+  icon?: LucideIcon;
+  action?: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-border bg-muted/30 px-6 py-12 text-center',
+        className,
+      )}
+    >
+      <span className="flex h-11 w-11 items-center justify-center rounded-full bg-muted text-muted-foreground">
+        <Icon aria-hidden="true" className="h-5 w-5" />
+      </span>
+      <div className="space-y-1">
+        <p className="font-medium text-foreground">{title}</p>
+        <p className="mx-auto max-w-prose text-sm leading-6 text-muted-foreground">{description}</p>
+      </div>
+      {action ? <div className="pt-1">{action}</div> : null}
+    </div>
+  );
+}
+
+/**
+ * Permission and tenant-scope refusals.
+ *
+ * Deliberately NOT an error state and deliberately without a retry control. Issue #22 requires
+ * that fallbacks never disguise a permission or clinic-scope problem as a transient failure:
+ * offering "Try again" on a wall the user cannot pass teaches them to hammer it, and hides the
+ * real fix, which is asking an administrator or switching clinic.
+ *
+ * Never name the record the user was denied. On a patient route, saying which patient they may
+ * not see is itself a disclosure.
+ */
+export function NoAccessState({
+  title = 'You do not have access to this',
+  description = 'Your current role and active clinic do not include this record. Switch clinic if you expected it elsewhere, or ask an administrator to review your access.',
+  action,
+  className,
+}: {
+  title?: string;
+  description?: string;
+  action?: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        'rounded-lg border border-border bg-card px-6 py-8 text-sm shadow-sm',
+        className,
+      )}
+    >
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div className="flex gap-3">
+          <Lock aria-hidden="true" className="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" />
+          <div className="space-y-1">
+            <p className="font-medium text-foreground">{title}</p>
+            <p className="max-w-prose leading-6 text-muted-foreground">{description}</p>
+          </div>
+        </div>
+        {action ? <div className="shrink-0">{action}</div> : null}
+      </div>
+    </div>
   );
 }

--- a/apps/web/components/ops/OpsShared.tsx
+++ b/apps/web/components/ops/OpsShared.tsx
@@ -95,7 +95,7 @@ export function OpsMetricCard({
   detail?: string;
 }) {
   return (
-    <div className="rounded-2xl border border-border/80 bg-card/85 p-4 shadow-sm backdrop-blur-sm">
+    <div className="rounded-lg border border-border/80 bg-card/85 p-4 shadow-sm backdrop-blur-sm">
       <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
         {label}
       </p>
@@ -118,11 +118,11 @@ export function InlineNotice({
     tone === 'error'
       ? 'border-destructive/25 bg-destructive/10 text-destructive'
       : tone === 'success'
-        ? 'border-emerald-200 bg-emerald-50 text-emerald-800'
+        ? 'border-success/25 bg-success/10 text-success-ink'
         : 'border-primary/20 bg-primary/10 text-foreground';
 
   return (
-    <div className={cn('rounded-2xl border px-4 py-3 text-sm', toneClass, className)}>
+    <div className={cn('rounded-lg border px-4 py-3 text-sm', toneClass, className)}>
       {children}
     </div>
   );
@@ -154,7 +154,7 @@ export function EmptyStateCard({
   icon?: React.ReactNode;
 }) {
   return (
-    <div className="rounded-2xl border border-dashed border-border bg-background/80 p-5 text-sm text-muted-foreground">
+    <div className="rounded-lg border border-dashed border-border bg-background/80 p-5 text-sm text-muted-foreground">
       <div className="flex items-start gap-3">
         {icon ? <span className="mt-0.5 shrink-0 text-muted-foreground">{icon}</span> : null}
         <div>
@@ -194,7 +194,7 @@ export function ShiftControlCard({
   return (
     <Card
       className={cn(
-        'overflow-hidden border-primary/15 bg-gradient-to-br from-primary/10 via-card to-secondary/10 shadow-lg shadow-primary/5',
+        'overflow-hidden border-primary/15 bg-gradient-to-br from-primary/10 via-card to-secondary/10',
         className,
       )}
     >
@@ -223,7 +223,7 @@ export function ShiftControlCard({
       <CardContent className="space-y-4">
         {currentShift ? (
           <div className="space-y-4">
-            <div className="grid gap-3 rounded-2xl border border-border/80 bg-card/75 p-4 sm:grid-cols-2">
+            <div className="grid gap-3 rounded-lg border border-border/80 bg-card/75 p-4 sm:grid-cols-2">
               <div>
                 <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
                   Checked In As

--- a/apps/web/components/portal/MeasurementTrendChart.tsx
+++ b/apps/web/components/portal/MeasurementTrendChart.tsx
@@ -42,7 +42,7 @@ export function MeasurementTrendChart({
       </CardHeader>
       <CardContent>
         {data.length === 0 ? (
-          <div className="flex h-[240px] items-center justify-center rounded-2xl border border-dashed border-border/70 bg-muted/20 px-6 text-center text-sm text-muted-foreground">
+          <div className="flex h-[240px] items-center justify-center rounded-lg border border-dashed border-border/70 bg-muted/20 px-6 text-center text-sm text-muted-foreground">
             {emptyMessage}
           </div>
         ) : (

--- a/apps/web/components/ui/badge.tsx
+++ b/apps/web/components/ui/badge.tsx
@@ -14,14 +14,17 @@ const badgeVariants = cva(
         destructive:
           'border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80',
         outline: 'text-foreground',
-        draft:
-          'border-transparent bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300',
-        review:
-          'border-transparent bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
-        finalized:
-          'border-transparent bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300',
-        warning:
-          'border-transparent bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300',
+        // Workflow and status states. Tint plus same-hue ink, per docs/design-system/MASTER.md.
+        // The ink tokens are darker than the fill tokens on purpose: using the fill colour as
+        // text on its own tint measures 4.28:1 for success and 2.42:1 for warning, both below
+        // AA. These clear it with headroom, and resolve correctly in dark mode.
+        //
+        // Draft is intentionally neutral. A draft note is not a warning, and colouring it amber
+        // put it in the same visual class as an out-of-range value.
+        draft: 'border-transparent bg-muted text-muted-foreground',
+        review: 'border-transparent bg-info/12 text-info-ink',
+        finalized: 'border-transparent bg-success/12 text-success-ink',
+        warning: 'border-transparent bg-warning/12 text-warning-ink',
       },
     },
     defaultVariants: {

--- a/apps/web/components/ui/card.tsx
+++ b/apps/web/components/ui/card.tsx
@@ -10,7 +10,7 @@ const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElemen
         // No hover translate: the design system forbids layout shift on hover, and a card that
         // lifts under the cursor is actively unhelpful when someone is reading a measurement off
         // it. Colour and border still respond, which is the affordance that was wanted.
-        'rounded-[24px] border border-border/80 bg-card/92 text-card-foreground shadow-sm shadow-black/5 transition-colors duration-200 hover:border-border',
+        'rounded-lg border border-border/80 bg-card/92 text-card-foreground shadow-sm shadow-black/5 transition-colors duration-200 hover:border-border',
         className,
       )}
       {...props}

--- a/apps/web/components/ui/dialog.tsx
+++ b/apps/web/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
         // A dialog must fit the screen it opens on. The default was a fixed max width with no
         // height bound and no scrolling, so a long clinical form ran off a 375 pixel viewport with
         // its actions unreachable. Every panel had been working around this with its own override.
-        'fixed left-[50%] top-[50%] z-50 grid max-h-[calc(100dvh-2rem)] w-[calc(100%-1.5rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto overscroll-contain rounded-3xl border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]',
+        'fixed left-[50%] top-[50%] z-50 grid max-h-[calc(100dvh-2rem)] w-[calc(100%-1.5rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto overscroll-contain rounded-lg border bg-background p-6 duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]',
         className,
       )}
       {...props}

--- a/apps/web/components/ui/info-hint.tsx
+++ b/apps/web/components/ui/info-hint.tsx
@@ -96,7 +96,7 @@ export function InfoHint({ label, className }: { label: string; className?: stri
               id={bubbleId}
               role="tooltip"
               className={cn(
-                'fixed z-[120] w-72 rounded-2xl border border-border/80 bg-popover px-4 py-3 text-left text-sm leading-6 text-popover-foreground shadow-2xl shadow-black/15 outline-none animate-in fade-in-0 zoom-in-95',
+                'fixed z-[120] w-72 rounded-lg border border-border/80 bg-popover px-4 py-3 text-left text-sm leading-6 text-popover-foreground outline-none animate-in fade-in-0 zoom-in-95',
                 position.placement === 'top'
                   ? '-translate-y-full slide-in-from-bottom-1'
                   : 'slide-in-from-top-1',

--- a/apps/web/components/ui/progressive-help.tsx
+++ b/apps/web/components/ui/progressive-help.tsx
@@ -15,7 +15,7 @@ export function ProgressiveHelp({
   return (
     <details
       className={cn(
-        'group w-full rounded-2xl border border-border/70 bg-background/80 shadow-sm',
+        'group w-full rounded-lg border border-border/70 bg-background/80 shadow-sm',
         className,
       )}
     >

--- a/apps/web/components/ui/toast.tsx
+++ b/apps/web/components/ui/toast.tsx
@@ -44,13 +44,13 @@ const toneStyles: Record<
   },
   success: {
     icon: CheckCircle2,
-    className: 'border-emerald-200 bg-emerald-50 text-emerald-950',
-    iconClassName: 'text-emerald-600',
+    className: 'border-success/25 bg-success/10 text-success-ink',
+    iconClassName: 'text-success',
   },
   warning: {
     icon: AlertTriangle,
-    className: 'border-amber-200 bg-amber-50 text-amber-950',
-    iconClassName: 'text-amber-600',
+    className: 'border-warning/25 bg-warning/10 text-warning-ink',
+    iconClassName: 'text-warning',
   },
   error: {
     icon: XCircle,
@@ -117,10 +117,7 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
           return (
             <div
               key={toast.id}
-              className={cn(
-                'rounded-2xl border p-4 shadow-2xl shadow-black/10 backdrop-blur transition-all',
-                tone.className,
-              )}
+              className={cn('rounded-lg border p-4 backdrop-blur transition-all', tone.className)}
             >
               <div className="flex items-start gap-3">
                 <Icon className={cn('mt-0.5 h-5 w-5 shrink-0', tone.iconClassName)} />

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -58,10 +58,17 @@ module.exports = {
         success: {
           DEFAULT: 'hsl(var(--success))',
           foreground: 'hsl(var(--success-foreground))',
+          ink: 'hsl(var(--success-ink))',
         },
         warning: {
           DEFAULT: 'hsl(var(--warning))',
           foreground: 'hsl(var(--warning-foreground))',
+          ink: 'hsl(var(--warning-ink))',
+        },
+        info: {
+          DEFAULT: 'hsl(var(--info))',
+          foreground: 'hsl(var(--info-foreground))',
+          ink: 'hsl(var(--info-ink))',
         },
         sidebar: {
           DEFAULT: 'hsl(var(--sidebar))',

--- a/docs/design-system/MASTER.md
+++ b/docs/design-system/MASTER.md
@@ -98,6 +98,23 @@ Defined in `apps/web/app/globals.css` under `:root`. Consume via Tailwind utilit
 
 Status colour is never the only signal. Pair every status fill with a label or icon.
 
+### Tinted status: use the ink tokens, never the fill token
+
+| Token           | Value         | Hex       | On its own 12% tint        |
+| --------------- | ------------- | --------- | -------------------------- |
+| `--info`        | `200 60% 40%` | `#297AA3` | workflow "awaiting review" |
+| `--success-ink` | `152 65% 26%` | `#176D45` | 5.20:1                     |
+| `--warning-ink` | `32 90% 28%`  | `#884C07` | 5.94:1                     |
+| `--info-ink`    | `200 60% 26%` | `#1B506A` | 7.52:1                     |
+
+The tinted badge pattern is `bg-<token>/12` plus `text-<token>-ink`.
+
+**Reusing the fill token as text on its own tint fails AA.** Measured: `text-success` on `bg-success/12` is **4.28:1**, and `text-warning` on `bg-warning/12` is **2.42:1**. The tint lightens the ground while the ink stays put, so contrast falls below the solid-on-white baseline. The ink tokens are the same hue and saturation, darkened until they clear with headroom.
+
+`--info` exists because the clinical note workflow has a **draft → review → finalized** progression, and "awaiting review" is neither success, warning, nor destructive. It is not a brand colour and must not be used for actions.
+
+**`draft` is deliberately neutral** (`bg-muted` + `--muted-foreground`, 4.94:1). A draft note is not a warning; colouring it amber put it in the same visual class as an out-of-range clinical value.
+
 **Migration debt: 105 raw-palette status colours already exist.** Before these tokens, status was expressed with Tailwind's raw palette: **62 uses of `emerald-*`** and **43 of `amber-*`**, plus smaller counts of `rose-`, `green-`, `red-`, and `yellow-`. `components/ui/badge.tsx` already ships `success` and `warning` variants built on `bg-emerald-100` and `bg-amber-100`.
 
 The semantic intent is already there throughout the app; it is simply bound to the wrong values. Until these call sites are swept, Nkwapa has **two parallel status colour systems**, which is exactly the mixed old/new state #65 forbids.
@@ -136,7 +153,7 @@ Do not "fix" `--border` or `--sidebar-border` to reach 3:1. They are correctly e
 
 ## 4. Colour tokens — dark
 
-Defined under `.dark`. Dark mode inverts which side carries the ink: fills stay bright and take dark text.
+Defined under `.dark`. Dark mode inverts which side carries the ink: fills stay bright and take dark text. The tinted badge inverts too, becoming a dark tint of the hue carrying light ink.
 
 | Token                        | Value         | Hex       | Contrast            |
 | ---------------------------- | ------------- | --------- | ------------------- |
@@ -148,6 +165,10 @@ Defined under `.dark`. Dark mode inverts which side carries the ink: fills stay 
 | `--success`                  | `152 55% 50%` | `#39C684` | 7.89:1 dark ink on  |
 | `--warning`                  | `35 90% 58%`  | `#F4A434` | 8.43:1 dark ink on  |
 | `--input`                    | `200 14% 50%` | `#6E8591` | 4.74:1              |
+| `--info`                     | `200 60% 58%` | `#54A9D4` | workflow state      |
+| `--success-ink`              | `152 40% 74%` | `#A2D7BE` | 6.82:1 on its tint  |
+| `--warning-ink`              | `35 75% 74%`  | `#EEC58B` | 6.74:1 on its tint  |
+| `--info-ink`                 | `200 45% 74%` | `#9FC7DB` | 6.49:1 on its tint  |
 
 All other `.dark` values are unchanged and already correct.
 


### PR DESCRIPTION
**Stacked on #84.** Base is `design-system/token-contract-and-dark-mode`, not `release/dev`, because these changes reference tokens that only exist there. Merge #84 first, then this retargets cleanly.

Phase 1 of the migration: everything imported by 2+ of the #65 groups, landed once so the six parallel agents start from one settled base.

## Why this exists

I had assumed the #65 groups were file-disjoint and could fan out immediately. Measured, they are not:

| Shared component | Groups importing it |
|---|---|
| `ui/button` | all 6 |
| `ui/card`, `ui/badge`, `ui/input`, `ops/OpsShared` | 5 each |
| `ui/dialog`, `ui/select`, `ui/label`, `feedback/AppState` | 4 each |

Group A and Group C have **zero exclusive imports**. Six agents would have edited `button.tsx` and `badge.tsx` simultaneously.

## The two states every route was missing

`AppState` covered loading, error, and retry. **Empty and no-access had no component at all**, so pages either invented one or rendered nothing. #22 requires both.

`NoAccessState` deliberately carries **no retry control**. #22 requires that fallbacks never disguise a permission or clinic-scope refusal as a transient failure. Its copy also never names the refused record — on a patient route, saying which patient the user may not see is itself the disclosure.

`EmptyState` is deliberately not styled like an error. An empty queue at the start of a clinic day is the normal case.

## The badge retarget would have broken accessibility

Pointing the status badges at `--success` / `--warning` directly **introduces failures rather than fixing any**. Text in the fill colour on a 12% tint of itself measures:

| | Measured | Required |
|---|---|---|
| `text-success` on `bg-success/12` | 4.28:1 | 4.5:1 |
| `text-warning` on `bg-warning/12` | **2.42:1** | 4.5:1 |

The tint lightens the ground while the ink stays put. Adds `--success-ink`, `--warning-ink`, `--info-ink` — same hue and saturation, darkened until they clear on their own tint with headroom (5.20:1 / 5.94:1 / 7.52:1). This is the structure the old `emerald-100` / `emerald-800` pairing already had; it just had no token behind it.

`--info` is new because the clinical note workflow runs **draft → review → finalized**, and "awaiting review" is none of success, warning, or destructive. Not a brand colour, not for actions.

**`draft` becomes neutral.** A draft note is not a warning, and amber put it in the same visual class as an out-of-range clinical value.

## Also swept

Bespoke and `2xl`/`3xl` radii onto the scale, decorative shadows removed (`shadow-sm` kept where it delineates a surface), and raw `emerald`/`amber` in `toast`, `SyncStatusBar`, and `OpsShared` onto tokens so they track the system and resolve in dark mode.

## Verification

`npm run typecheck`, `npm run lint`, and `npm run build` all pass.

Refs #22, #61, #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)