### PR TITLE
Fix the appointment fixtures that fall outside the week the schedule renders

### DIFF
--- a/packages/db/index.ts
+++ b/packages/db/index.ts
@@ -75,3 +75,9 @@ export {
   type TenantFixtureUser,
   type TenantFixturePatient,
 } from './src/testing/tenant-fixture';
+export {
+  confirmedVisitStart,
+  terminalVisitStart,
+  weekStartUtc,
+  isInVisibleWeek,
+} from './src/appointment-fixture-window';

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -27,6 +27,8 @@ import {
   nationalIdLast4,
   hasEncryptionKey,
   generatePatientCode,
+  confirmedVisitStart,
+  terminalVisitStart,
 } from '../index';
 import { seedDrugs } from './seed-drugs';
 
@@ -147,8 +149,12 @@ async function ensureSingleRoleUser(params: {
  * staff screen could do that. Rather than leave the suite unable to reach its own subject, seed one
  * appointment in each state plus the two request shapes a patient can open.
  *
- * Times are relative to the run so that `complete` and `no-show`, which the API refuses before the
- * start time, are exercisable and the confirmed visit stays in the future.
+ * Times are placed against the Monday-start week the staff schedule renders, not against the
+ * clock, because the schedule only ever shows the week containing today. See
+ * `src/appointment-fixture-window.ts`.
+ *
+ * The guard below is on the demo *patient*, not on the appointments, so deleting appointments
+ * alone will not cause this to run again -- remove the patient, which cascades.
  */
 async function seedSampleAppointments(
   prisma: PrismaClient,
@@ -187,14 +193,29 @@ async function seedSampleAppointments(
 
   const hours = (offset: number) => new Date(Date.now() + offset * 60 * 60 * 1000);
   const dateOnly = (date: Date) => new Date(`${date.toISOString().slice(0, 10)}T00:00:00.000Z`);
+  const plusHours = (from: Date, offset: number) =>
+    new Date(from.getTime() + offset * 60 * 60 * 1000);
+
+  /*
+    Placed against the week the schedule actually shows, not against the clock.
+
+    The staff schedule renders exactly one Monday-start week, the one containing today. These
+    fixtures used to sit at `now + 26h` and `now - 48h`, which fall outside that week near its
+    edges -- the confirmed row crossed into next Monday on any Sunday, and the terminal rows fell
+    into the previous week on a Monday or Tuesday. See appointment-fixture-window.ts, which keeps
+    the original offsets wherever they are safe and clamps them where they are not.
+  */
+  const seededAt = new Date();
+  const confirmedStart = confirmedVisitStart(seededAt);
+  const terminalStart = terminalVisitStart(seededAt);
 
   // Confirmed and still ahead: the row every lifecycle action is applied to.
   const confirmed = await prisma.appointment.create({
     data: {
       clinicId,
       patientId: patient.id,
-      startsAt: hours(26),
-      endsAt: hours(27),
+      startsAt: confirmedStart,
+      endsAt: plusHours(confirmedStart, 1),
       status: AppointmentStatus.CONFIRMED,
       notes: 'Blood pressure review',
     },
@@ -204,26 +225,28 @@ async function seedSampleAppointments(
   // something to show without a test having to create them first.
   await prisma.appointment.createMany({
     data: [
+      // Staggered by an hour rather than by a day: a day apart put the older two outside the
+      // visible week for most of it, and nothing depends on the spacing, only on the statuses.
       {
         clinicId,
         patientId: patient.id,
-        startsAt: hours(-48),
-        endsAt: hours(-47),
+        startsAt: terminalStart,
+        endsAt: plusHours(terminalStart, 1),
         status: AppointmentStatus.COMPLETED,
         notes: 'Reviewed home readings',
       },
       {
         clinicId,
         patientId: patient.id,
-        startsAt: hours(-72),
-        endsAt: hours(-71),
+        startsAt: plusHours(terminalStart, 1),
+        endsAt: plusHours(terminalStart, 2),
         status: AppointmentStatus.CANCELLED,
       },
       {
         clinicId,
         patientId: patient.id,
-        startsAt: hours(-96),
-        endsAt: hours(-95),
+        startsAt: plusHours(terminalStart, 2),
+        endsAt: plusHours(terminalStart, 3),
         status: AppointmentStatus.NO_SHOW,
       },
     ],

--- a/packages/db/src/appointment-fixture-window.spec.ts
+++ b/packages/db/src/appointment-fixture-window.spec.ts
@@ -1,0 +1,74 @@
+import {
+  confirmedVisitStart,
+  isInVisibleWeek,
+  terminalVisitStart,
+  weekStartUtc,
+} from './appointment-fixture-window';
+
+/** Every hour of a full week, so no run time is left untested. */
+function everyHourOfAWeek(): Date[] {
+  const start = Date.UTC(2026, 7, 24, 0, 0, 0); // Monday 2026-08-24
+  return Array.from({ length: 24 * 7 }, (_, i) => new Date(start + i * 60 * 60 * 1000));
+}
+
+describe('appointment fixture window', () => {
+  it('starts the week on Monday, matching the schedule view', () => {
+    // Sunday must resolve back to the preceding Monday, which is the case the old fixtures broke on.
+    expect(weekStartUtc(new Date('2026-08-30T03:58:00Z')).toISOString()).toBe(
+      '2026-08-24T00:00:00.000Z',
+    );
+    expect(weekStartUtc(new Date('2026-08-24T00:00:00Z')).toISOString()).toBe(
+      '2026-08-24T00:00:00.000Z',
+    );
+    expect(weekStartUtc(new Date('2026-08-31T09:00:00Z')).toISOString()).toBe(
+      '2026-08-31T00:00:00.000Z',
+    );
+  });
+
+  it('keeps both fixtures inside the visible week whatever hour the suite runs at', () => {
+    for (const reference of everyHourOfAWeek()) {
+      const confirmed = confirmedVisitStart(reference);
+      const terminal = terminalVisitStart(reference);
+      expect({
+        at: reference.toISOString(),
+        confirmed: isInVisibleWeek(reference, confirmed),
+      }).toEqual({ at: reference.toISOString(), confirmed: true });
+      expect({
+        at: reference.toISOString(),
+        terminal: isInVisibleWeek(reference, terminal),
+      }).toEqual({ at: reference.toISOString(), terminal: true });
+    }
+  });
+
+  it('leaves the original offsets alone away from the week edges', () => {
+    // Wednesday midday: +26h and -48h are both comfortably inside the week, so nothing moves.
+    const wednesday = new Date('2026-08-26T12:00:00Z');
+    expect(confirmedVisitStart(wednesday).toISOString()).toBe('2026-08-27T14:00:00.000Z');
+    expect(terminalVisitStart(wednesday).toISOString()).toBe('2026-08-24T12:00:00.000Z');
+  });
+
+  it('pulls the confirmed visit back rather than letting it cross into next week', () => {
+    // The exact run that failed CI: a Sunday. +26h would have been Monday 05:58.
+    const sunday = new Date('2026-08-30T03:58:00Z');
+    const confirmed = confirmedVisitStart(sunday);
+    expect(confirmed.toISOString()).toBe('2026-08-30T21:00:00.000Z');
+    expect(confirmed.getTime()).toBeGreaterThan(sunday.getTime());
+  });
+
+  it('pushes the terminal rows forward rather than letting them fall into last week', () => {
+    // A Monday morning: -48h would have been Saturday, in the previous week.
+    const monday = new Date('2026-08-31T09:00:00Z');
+    const terminal = terminalVisitStart(monday);
+    expect(terminal.toISOString()).toBe('2026-08-31T01:00:00.000Z');
+    expect(terminal.getTime()).toBeLessThan(monday.getTime());
+  });
+
+  it('keeps the confirmed visit in the future for all but the tail of a Sunday', () => {
+    const stillFuture = everyHourOfAWeek().filter(
+      (reference) => confirmedVisitStart(reference) > reference,
+    );
+    // 165 of 168 hours. The exceptions are the last three hours of Sunday, where no time remains
+    // in the visible week; the row is then a past CONFIRMED one, which still renders its menu.
+    expect(stillFuture.length).toBe(165);
+  });
+});

--- a/packages/db/src/appointment-fixture-window.ts
+++ b/packages/db/src/appointment-fixture-window.ts
@@ -1,0 +1,71 @@
+/**
+ * Where the sample appointments have to sit so the schedule can actually show them.
+ *
+ * The staff schedule's week view renders exactly one Monday-start week, the one containing today
+ * (`getWeekStart` in `apps/web/app/(workspace)/appointments/page.tsx`). The seed placed its
+ * fixtures at `now + 26h` and `now - 48h`, which silently fall outside that week near its edges:
+ *
+ *   - `now + 26h` crosses into next Monday whenever the suite runs on a Sunday, or after roughly
+ *     22:00 on a Saturday. The whole confirmed row then vanishes from the view, and with it the
+ *     "Open appointment actions" control that four specs depend on.
+ *   - `now - 48h` falls into the previous week on a Monday or Tuesday, taking the terminal rows
+ *     with it.
+ *
+ * Together that is a fixture set which fails for roughly three days out of seven, depending on
+ * which specs are looking. It went unnoticed because CI happened to run mid-week; the failure was
+ * first seen on a Sunday.
+ *
+ * These helpers keep the original offsets wherever they are safe and clamp them into the visible
+ * week where they are not.
+ */
+
+const HOUR_MS = 60 * 60 * 1000;
+
+/** Monday 00:00 UTC of the week containing `reference`, matching the schedule's own arithmetic. */
+export function weekStartUtc(reference: Date): Date {
+  const start = new Date(
+    Date.UTC(reference.getUTCFullYear(), reference.getUTCMonth(), reference.getUTCDate()),
+  );
+  const day = start.getUTCDay();
+  start.setUTCDate(start.getUTCDate() + (day === 0 ? -6 : 1 - day));
+  return start;
+}
+
+function atHourOfWeek(reference: Date, dayOffset: number, hour: number): Date {
+  const day = weekStartUtc(reference);
+  day.setUTCDate(day.getUTCDate() + dayOffset);
+  day.setUTCHours(hour, 0, 0, 0);
+  return day;
+}
+
+/**
+ * The confirmed, still-upcoming visit: `reference + 26h`, pulled back to Sunday 21:00 of this week
+ * when that would cross into the next one.
+ *
+ * It stays genuinely in the future for all but the last few hours of a Sunday. Past that it is a
+ * past CONFIRMED row, which still renders its lifecycle menu -- the menu is gated on status, not
+ * on time -- so the specs hold either way.
+ */
+export function confirmedVisitStart(reference: Date): Date {
+  const preferred = new Date(reference.getTime() + 26 * HOUR_MS);
+  const latestInWeek = atHourOfWeek(reference, 6, 21);
+  return preferred <= latestInWeek ? preferred : latestInWeek;
+}
+
+/**
+ * The terminal rows (completed, cancelled, no-show): `reference - 48h`, pushed forward to Monday
+ * 01:00 of this week when that would fall into the previous one.
+ */
+export function terminalVisitStart(reference: Date): Date {
+  const preferred = new Date(reference.getTime() - 48 * HOUR_MS);
+  const earliestInWeek = atHourOfWeek(reference, 0, 1);
+  return preferred >= earliestInWeek ? preferred : earliestInWeek;
+}
+
+/** True when `at` falls inside the Monday-start week the schedule would show for `reference`. */
+export function isInVisibleWeek(reference: Date, at: Date): boolean {
+  const start = weekStartUtc(reference);
+  const end = new Date(start);
+  end.setUTCDate(end.getUTCDate() + 7);
+  return at >= start && at < end;
+}


### PR DESCRIPTION
Closes #92. Unblocks E2E on #87, #88, #89 and #90, none of which caused it.

## Why this exists

Four `appointments.spec.js` tests fail on **every** open PR, including #88, which touches nothing but `infra/nkwapa/keycloak/themes/**` and docs. A login theme cannot break appointment lifecycle actions.

The staff schedule renders exactly one **Monday-start** week — the one containing today (`getWeekStart`, `appointments/page.tsx:118`). The fixtures were placed against the clock:

```ts
startsAt: hours(26),    // the CONFIRMED row every lifecycle action is applied to
startsAt: hours(-48),   // COMPLETED
```

`now + 26h` crosses into next Monday whenever the suite runs on a **Sunday**, or after ~22:00 on a Saturday. The confirmed row leaves the view, taking the `Open appointment actions` control with it. `now - 48h` has the mirror bug: it falls into the previous week on a Monday or Tuesday, and the `-72h`/`-96h` rows are outside the week for most of it.

The timestamps settle it:

| Run | Seeded | Confirmed row lands | Week shown | Result |
|---|---|---|---|---|
| #86 merge | Sat 08-29 01:46 | Sun 08-30 03:46 | Aug 24–30 | ✅ green |
| #87–#90 | Sun 08-30 03:58 | Mon 08-31 05:58 | Aug 24–30 | ❌ 4 failed |

## The change

`packages/db/src/appointment-fixture-window.ts` keeps the original offsets where they are safe and clamps them where they are not:

- **confirmed visit** — `now + 26h`, pulled back to Sunday 21:00 of this week when that would cross into the next;
- **terminal rows** — `now - 48h`, pushed forward to Monday 01:00 when that would fall into the previous, and staggered by an hour rather than a day so the older two stay in view.

The confirmed row stays genuinely in the future for **165 of the 168 hours** in a week. In the remaining three — the tail of a Sunday — it becomes a past `CONFIRMED` row, which still renders its lifecycle menu: `AppointmentActions` gates on **status, not time** (`appointments/page.tsx:262-272`). No spec performs `complete` or `no-show`, the only actions carrying a `requireStarted` guard (`patient-portal.service.ts:2170`).

## Also documented

The seed's skip guard is on the demo **patient**, not on the appointments:

```ts
const existing = await prisma.patient.findFirst({
  where: { primaryClinicId: clinicId, firstName: 'Appointment', lastName: 'Demo' },
});
if (existing) { console.log('Sample appointments already exist; skipping.'); return; }
```

So the `patient request triage` specs, which consume the PENDING requests they act on, cannot be repaired by re-seeding — `db:seed` reports "already exist" while the fixtures are gone. Deleting the appointments does not help; the demo patient has to go and appointments cascade from it. That is now stated in the function's docblock, because it has cost time more than once.

## Verification

`packages/db/src/appointment-fixture-window.spec.ts` walks **all 168 hours of a week** and asserts both fixture groups land inside the visible week at every one, plus the specific Saturday-night, Sunday and Monday cases and the 165/168 future-visit figure.

Verified end to end **on a Sunday — the day this reproduces**: all **21** `appointments.spec.js` tests pass against freshly seeded fixtures, including the four failing in CI and the two `patient request triage` specs.

Fixtures and one helper only. No product behaviour, no schema, no API change.

## Follow-up not attempted here

The deeper fix is for the specs not to depend on the seeded appointment happening to fall in this week — `openWeekSchedule` could navigate to the appointment's week using the existing next/previous controls. That is a larger change to the appointment suite and belongs to whoever owns it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)