### PR TITLE
Give destructive an ink token — the one status without one

### DIFF
--- a/apps/web/app/(workspace)/admin/clinics/page.tsx
+++ b/apps/web/app/(workspace)/admin/clinics/page.tsx
@@ -281,7 +281,7 @@ export default function AdminClinicsPage() {
                           className={`rounded-full px-3 py-1 text-xs font-semibold ${
                             clinic.isActive
                               ? 'bg-success/12 text-success-ink'
-                              : 'bg-destructive/10 text-destructive'
+                              : 'bg-destructive/10 text-destructive-ink'
                           }`}
                         >
                           {clinic.isActive ? 'Active' : 'Inactive'}

--- a/apps/web/app/(workspace)/appointments/page.tsx
+++ b/apps/web/app/(workspace)/appointments/page.tsx
@@ -1078,7 +1078,7 @@ export default function StaffAppointmentsPage() {
             <div
               id="lifecycle-dialog-error"
               role="alert"
-              className="rounded-lg border border-destructive/25 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+              className="rounded-lg border border-destructive/25 bg-destructive/10 px-4 py-3 text-sm text-destructive-ink"
             >
               {lifecycleError}
             </div>

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -58,6 +58,11 @@
     --info-ink: 200 60% 26%;
     --destructive: 0 72% 51%;
     --destructive-foreground: 0 0% 100%;
+    /* The fourth ink, and the one that was missing while the rule above already forbade its
+       absence. --destructive is fine as text on a neutral surface (4.64:1 on the card) and fails
+       on every tint of itself: 4.29:1 at /5, 3.99:1 at /10, 3.13:1 at /25, 2.66:1 at /35. Same
+       hue and saturation, lightness moved only; measures 6.20:1 on a 10% tint over the card. */
+    --destructive-ink: 0 72% 38%;
     /* --border stays soft at 1.26:1 on the canvas. WCAG 1.4.11 requires 3:1 only for boundaries
        needed to identify a control; card edges and decorative dividers are exempt. Do not
        "fix" this value. --input is NOT exempt, which is why it is now split away from --border:
@@ -142,6 +147,10 @@
     --success-ink: 152 40% 74%;
     --warning-ink: 35 75% 74%;
     --info-ink: 200 45% 74%;
+    /* 8.06:1 on a 10% tint over the dark card. --destructive itself already clears that ground
+       here (4.79:1) after this mode's retune, but the token exists in both so a call site never
+       needs a `dark:` override -- the app has none left and should keep none. */
+    --destructive-ink: 0 50% 80%;
     /*
       Lighter than light mode's, and carrying dark ink rather than white.
 

--- a/apps/web/components/VitalsForm.tsx
+++ b/apps/web/components/VitalsForm.tsx
@@ -737,7 +737,7 @@ export function VitalsForm({
             className={cn(
               'rounded-lg border p-3 text-sm',
               statusIsError
-                ? 'border-destructive/30 bg-destructive/5 text-destructive'
+                ? 'border-destructive/30 bg-destructive/5 text-destructive-ink'
                 : 'border-primary/25 bg-primary/5 text-foreground',
             )}
           >

--- a/apps/web/components/appointments/AppointmentRequestsPanel.tsx
+++ b/apps/web/components/appointments/AppointmentRequestsPanel.tsx
@@ -459,7 +459,7 @@ export function AppointmentRequestsPanel({
                 <p
                   id="triage-dialog-error"
                   role="alert"
-                  className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive"
+                  className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive-ink"
                 >
                   {dialogError}
                 </p>

--- a/apps/web/components/ops/OpsShared.tsx
+++ b/apps/web/components/ops/OpsShared.tsx
@@ -103,7 +103,7 @@ export function InlineNotice({
 }) {
   const toneClass =
     tone === 'error'
-      ? 'border-destructive/25 bg-destructive/10 text-destructive'
+      ? 'border-destructive/25 bg-destructive/10 text-destructive-ink'
       : tone === 'success'
         ? 'border-success/25 bg-success/10 text-success-ink'
         : 'border-primary/20 bg-primary/10 text-foreground';

--- a/apps/web/components/patients/AllergySummaryBanner.tsx
+++ b/apps/web/components/patients/AllergySummaryBanner.tsx
@@ -10,7 +10,7 @@ const presentations = {
     title: 'Active allergies or adverse reactions',
     description: 'Review these entries before prescribing medication.',
     icon: AlertTriangle,
-    className: 'border-destructive/35 bg-destructive/10 text-destructive',
+    className: 'border-destructive/35 bg-destructive/10 text-destructive-ink',
   },
   NO_KNOWN_ALLERGIES: {
     title: 'No known allergies recorded',

--- a/apps/web/components/research/ResearchExportsScreen.tsx
+++ b/apps/web/components/research/ResearchExportsScreen.tsx
@@ -90,7 +90,7 @@ const STATUS_STYLES: Record<ExportStatus, string> = {
   APPROVED: 'border-info/25 bg-info/10 text-info-ink',
   PROCESSING: 'border-info/25 bg-info/10 text-info-ink',
   COMPLETED: 'border-success/25 bg-success/10 text-success-ink',
-  FAILED: 'border-destructive/25 bg-destructive/10 text-destructive',
+  FAILED: 'border-destructive/25 bg-destructive/10 text-destructive-ink',
   REJECTED: 'border-border bg-muted text-muted-foreground',
 };
 
@@ -422,7 +422,7 @@ export function ResearchExportsScreen({ clinicId }: { clinicId: string }) {
               <p
                 id="date-range-error"
                 role="alert"
-                className="rounded-lg border border-destructive/25 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+                className="rounded-lg border border-destructive/25 bg-destructive/10 px-4 py-3 text-sm text-destructive-ink"
               >
                 The end date must be on or after the start date.
               </p>
@@ -558,7 +558,7 @@ export function ResearchExportsScreen({ clinicId }: { clinicId: string }) {
                           )}
 
                           {item.failureReason ? (
-                            <div className="rounded-lg border border-destructive/25 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+                            <div className="rounded-lg border border-destructive/25 bg-destructive/10 px-4 py-3 text-sm text-destructive-ink">
                               <div className="mb-1 flex items-center gap-2 font-medium">
                                 <AlertTriangle aria-hidden="true" className="h-4 w-4" />
                                 Processing failed

--- a/apps/web/e2e/route-fallbacks.spec.js
+++ b/apps/web/e2e/route-fallbacks.spec.js
@@ -1,4 +1,5 @@
 const { test, expect } = require('@playwright/test');
+const AxeBuilder = require('@axe-core/playwright').default;
 
 const { storageStateFor } = require('../playwright/roles');
 
@@ -127,4 +128,33 @@ test('claim-record never reports a missing invitation while identity is still lo
   // Matches the old copy ("No pending patient invitation was found for this account") as well as
   // the new, so the test measures the behaviour and not this implementation's wording.
   await expect(page.getByText(/no pending/i)).toHaveCount(0);
+});
+
+test('an error state on screen passes contrast in light mode', async ({ page }) => {
+  /*
+    Nothing in this suite used to run axe over a page that was actually reporting an error, which
+    is why `text-destructive` on a destructive tint sat below AA in light mode for as long as the
+    token contract existed -- 3.99:1 on a /10 tint, on nine surfaces including the allergy banner
+    a clinician reads before prescribing. The dark half was found by accident. This is the light
+    half's guard, on the cheapest page to drive into an error state deliberately.
+  */
+  const clinicId = await activeClinicId(page);
+  await page.goto(`/clinics/${clinicId}/research/exports`);
+  await expect(page.getByRole('heading', { name: /request export pack/i })).toBeVisible({
+    timeout: 30_000,
+  });
+
+  // End before start: renders the tinted, role="alert" range error without touching the network.
+  await page.getByLabel('From date').fill('2026-08-20');
+  await page.getByLabel('To date').fill('2026-08-10');
+  const rangeError = page.getByRole('alert').filter({ hasText: /end date must be on or after/i });
+  await expect(rangeError).toBeVisible();
+
+  const results = await new AxeBuilder({ page })
+    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+    .analyze();
+  const summary = results.violations.map(
+    (violation) => `${violation.id} (${violation.nodes.length}) — ${violation.help}`,
+  );
+  expect(summary, summary.join('\n')).toEqual([]);
 });

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -55,6 +55,7 @@ module.exports = {
         destructive: {
           DEFAULT: 'hsl(var(--destructive))',
           foreground: 'hsl(var(--destructive-foreground))',
+          ink: 'hsl(var(--destructive-ink))',
         },
         muted: {
           DEFAULT: 'hsl(var(--muted))',

--- a/docs/design-system/MASTER.md
+++ b/docs/design-system/MASTER.md
@@ -123,14 +123,27 @@ Status colour is never the only signal. Pair every status fill with a label or i
 
 ### Tinted status: use the ink tokens, never the fill token
 
-| Token           | Value         | Hex       | On its own 12% tint        |
-| --------------- | ------------- | --------- | -------------------------- |
-| `--info`        | `200 60% 40%` | `#297AA3` | workflow "awaiting review" |
-| `--success-ink` | `152 65% 26%` | `#176D45` | 5.20:1                     |
-| `--warning-ink` | `32 90% 28%`  | `#884C07` | 5.94:1                     |
-| `--info-ink`    | `200 60% 26%` | `#1B506A` | 7.52:1                     |
+| Token               | Value         | Hex       | On its own 12% tint        |
+| ------------------- | ------------- | --------- | -------------------------- |
+| `--info`            | `200 60% 40%` | `#297AA3` | workflow "awaiting review" |
+| `--success-ink`     | `152 65% 26%` | `#176D45` | 5.20:1                     |
+| `--warning-ink`     | `32 90% 28%`  | `#884C07` | 5.94:1                     |
+| `--info-ink`        | `200 60% 26%` | `#1B506A` | 7.52:1                     |
+| `--destructive-ink` | `0 72% 38%`   | `#A71B1B` | 6.20:1                     |
 
 The tinted badge pattern is `bg-<token>/12` plus `text-<token>-ink`.
+
+**All four statuses have an ink token.** Destructive did not until #94, and it was the one status
+still using its fill as text on its own tint, on nine surfaces including
+`AllergySummaryBanner` -- the banner a clinician reads before prescribing. `--destructive` is fine
+as text on a neutral surface (4.64:1 on the card) and fails on every tint of itself: 4.29:1 at
+`/5`, 3.99:1 at `/10`, 3.13:1 at `/25`, 2.66:1 at `/35`. Use `text-destructive` on a plain
+surface and for icons, which need 3:1 rather than 4.5:1; use `text-destructive-ink` the moment
+there is a destructive tint underneath.
+
+That gap survived a token contract, a full migration and a dedicated dark-mode pass because
+**nothing in the suite ran axe over a page that was reporting an error**.
+`e2e/route-fallbacks.spec.js` now does, on a deliberately invalid date range.
 
 **Reusing the fill token as text on its own tint fails AA.** Measured: `text-success` on `bg-success/12` is **4.28:1**, and `text-warning` on `bg-warning/12` is **2.42:1**. The tint lightens the ground while the ink stays put, so contrast falls below the solid-on-white baseline. The ink tokens are the same hue and saturation, darkened until they clear with headroom.
 
@@ -233,6 +246,7 @@ Defined under `.dark`. Dark mode inverts which side carries the ink: fills stay 
 | `--success-ink`              | `152 40% 74%` | `#A2D7BE` | 6.82:1 on its tint     |
 | `--warning-ink`              | `35 75% 74%`  | `#EEC58B` | 6.74:1 on its tint     |
 | `--info-ink`                 | `200 45% 74%` | `#9FC7DB` | 6.49:1 on its tint     |
+| `--destructive-ink`          | `0 50% 80%`   | `#E6B3B3` | 8.06:1 on its tint     |
 | `--destructive`              | `0 62% 66%`   | `#DE7373` | 5.48:1 as text on card |
 
 All other `.dark` values are unchanged and already correct.


### PR DESCRIPTION
Closes #94.

## The gap

`MASTER.md` section 3 has stated the rule since the token contract landed: never reuse a status fill as text on its own tint, because the tint lightens the ground while the ink stays put. Success, warning and info each got an `-ink` token in **both** modes.

**Destructive never did, and destructive was the one still breaking the rule.** There was a literal hole in that table where it belonged.

## Measured

`--destructive` as text on its own tint over the light card:

| Tint | Contrast | |
|---|---|---|
| none (plain card) | 4.64:1 | passes — which is why it looked healthy wherever anyone checked |
| `/5` | **4.29:1** | fails |
| `/10` | **3.99:1** | fails |
| `/25` | **3.13:1** | fails |
| `/35` | **2.66:1** | fails |

Nine surfaces put it on a tint, including `AllergySummaryBanner` — the banner a clinician reads before prescribing, and one of the three files `MASTER.md` itself names as worth naming.

## The change

`--destructive-ink`, same hue and saturation with lightness moved only, matching how the other three inks were derived:

| Mode | Value | Hex | On a 10% tint over `--card` |
|---|---|---|---|
| light | `0 72% 38%` | `#A71B1B` | **6.20:1** |
| dark | `0 50% 80%` | `#E6B3B3` | **8.06:1** |

The dark value is defined even though dark's `--destructive` already clears its own tint after #90's retune, because a token that exists in only one mode forces a `dark:` override at the call site — and #86 removed the last of those.

Nine call sites swapped. `text-destructive` stays correct on a plain surface and on **icons**, which need 3:1 rather than 4.5:1: `InlineErrorState`'s warning triangle sits on a `/5` tint at 4.29:1 and is deliberately left alone.

The light value was already in the tree — the Keycloak theme defines `--nkwapa-danger-ink: #a71b1b` for exactly this reason — so this also closes the last gap between that theme's token set and the app's.

## Why it survived everything

A token contract, a full migration and a dedicated dark-mode pass all missed it, because **nothing in the suite ran axe over a page that was actually reporting an error**. The dark half was found by accident, when #93 put the appointment fixtures back in the visible week and a `Decline` control appeared on `/appointments`.

`e2e/route-fallbacks.spec.js` now drives a deliberately invalid date range and runs axe on the result — no network stubbing, so it is stable. Verified the only way worth verifying: **it fails against this commit's parent and passes here.**

## Verification

`typecheck`, `lint`, `prettier --check`, `build`, unit tests, and `design:check-charts` all pass. Full Playwright suite: **115 passed, 0 failed** — the first entirely clean run since #93 also fixed the appointment fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)