### PR TITLE
One hypertension assessment per encounter, and show the one that was saved

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,6 +261,16 @@ jobs:
       MAILPIT_BASE_URL: http://localhost:8025
       CORS_ALLOWED_ORIGINS: http://localhost:3000
       PLAYWRIGHT_BASE_URL: http://localhost:3000
+      # The rate limiter is a production safety control, and the E2E suite is deliberately one
+      # user hammering the app: every page load calls /auth/whoami, whose default budget is 60 a
+      # minute. A long sequential run exhausts it and then fails whichever spec happens to be
+      # running, at ~34s, with "We couldn't confirm your access" -- a 429 resolves to `unavailable`.
+      # It has bitten this suite before; see the note in responsive-migration.spec.js. Raised for
+      # the E2E job only, so the limits themselves stay under test elsewhere.
+      RATE_LIMIT_AUTH_WHOAMI_LIMIT: '100000'
+      RATE_LIMIT_AUTH_ME_LIMIT: '100000'
+      RATE_LIMIT_SYNC_PULL_LIMIT: '100000'
+      RATE_LIMIT_SYNC_PUSH_LIMIT: '100000'
     steps:
       - uses: actions/checkout@v4
 

--- a/apps/web/components/CarePlanForm.tsx
+++ b/apps/web/components/CarePlanForm.tsx
@@ -11,6 +11,7 @@ import { enqueueOutboxMutation } from '@/lib/outbox';
 import { SYNC_OPERATION } from '@/lib/outbox';
 import { Textarea } from '@/components/ui/textarea';
 import { InlineNotice } from '@/components/ops/OpsShared';
+import { claimEncounterRecord } from '@/lib/encounter-record';
 
 function generateId(): string {
   if (typeof crypto !== 'undefined' && crypto.randomUUID) {
@@ -61,8 +62,9 @@ export function CarePlanForm({
     if (!canEdit || saving) return;
     setSaving(true);
     setError(null);
-    const existing = await db.care_plans.where('encounterId').equals(encounterId).first();
-    const carePlanId = existing?.id ?? generateId();
+    // Already reused its id, which is why it never had #91's bug. Sharing the helper keeps it
+    // that way, and adds the duplicate collapse and createdAt preservation it did not have.
+    const claimed = await claimEncounterRecord(db.care_plans, encounterId, generateId);
     const now = new Date().toISOString();
 
     const payload = {
@@ -75,14 +77,14 @@ export function CarePlanForm({
     };
 
     const record = {
-      id: carePlanId,
+      id: claimed.id,
       clinicId,
       encounterId,
       counselingGiven,
       medicationPrescribed,
       followUpDate: payload.followUpDate ?? undefined,
       notes: payload.notes ?? undefined,
-      createdAt: now,
+      createdAt: claimed.createdAt ?? now,
       updatedAt: now,
     };
 
@@ -91,7 +93,7 @@ export function CarePlanForm({
       await enqueueOutboxMutation(db, {
         clinicId,
         entityType: 'care_plan',
-        entityId: carePlanId,
+        entityId: claimed.id,
         operation: SYNC_OPERATION.UPSERT,
         payloadJson: payload,
       });

--- a/apps/web/components/HypertensionForm.tsx
+++ b/apps/web/components/HypertensionForm.tsx
@@ -18,6 +18,7 @@ import { enqueueOutboxMutation } from '@/lib/outbox';
 import { SYNC_OPERATION } from '@/lib/outbox';
 import { HYPERTENSION_CLASSIFICATIONS, HYPERTENSION_LABELS } from '@/lib/hypertension';
 import { InlineNotice } from '@/components/ops/OpsShared';
+import { claimEncounterRecord } from '@/lib/encounter-record';
 
 function generateId(): string {
   if (typeof crypto !== 'undefined' && crypto.randomUUID) {
@@ -64,11 +65,39 @@ export function HypertensionForm({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  /*
+    Re-seed when the assessment arrives.
+
+    `useState(initialData?.…)` only reads its argument on the first render, and the encounter page
+    loads this record asynchronously -- from the API, then from the local cache. The form
+    therefore mounted before the data existed and never caught up, so reopening an encounter that
+    had a saved assessment showed "Not classified" regardless of what was stored. Same shape as
+    DiabetesScreeningForm, which already does this.
+  */
+  useEffect(() => {
+    if (!initialData) return;
+    setClassification(initialData.classification ?? 'UNKNOWN');
+    setSuspected(initialData.suspected ?? false);
+    setConfirmed(initialData.confirmed ?? false);
+    setNotes(initialData.notes ?? '');
+  }, [initialData]);
+
   const handleSave = useCallback(async () => {
     if (!canEdit || saving) return;
     setSaving(true);
     setError(null);
-    const assessmentId = generateId();
+    /*
+      Reuse the encounter's existing row rather than minting a new id on every save.
+
+      This handler used to call generateId() unconditionally, so each save inserted another row
+      for the same encounter and the encounter page -- which reads with `.first()`, ordering
+      duplicate index keys by primary key -- could hand back an older classification. See #91.
+    */
+    const claimed = await claimEncounterRecord(
+      db.hypertension_assessments,
+      encounterId,
+      generateId,
+    );
     const now = new Date().toISOString();
 
     const payload = {
@@ -83,14 +112,15 @@ export function HypertensionForm({
     };
 
     const record = {
-      id: assessmentId,
+      id: claimed.id,
       clinicId,
       encounterId,
       classification: payload.classification,
       suspected: payload.suspected,
       confirmed: payload.confirmed,
       notes: payload.notes ?? undefined,
-      createdAt: now,
+      // Preserved, not restamped: an update is not a creation.
+      createdAt: claimed.createdAt ?? now,
       updatedAt: now,
     };
 
@@ -99,7 +129,7 @@ export function HypertensionForm({
       await enqueueOutboxMutation(db, {
         clinicId,
         entityType: 'hypertension_assessment',
-        entityId: assessmentId,
+        entityId: claimed.id,
         operation: SYNC_OPERATION.UPSERT,
         payloadJson: payload,
       });
@@ -138,8 +168,22 @@ export function HypertensionForm({
           <legend className="sr-only">Hypertension assessment details</legend>
           <div className="space-y-2">
             <Label htmlFor="classification">Classification</Label>
-            <Select value={classification} onValueChange={setClassification}>
-              <SelectTrigger>
+            {/*
+              The id belongs on the trigger, and `disabled` has to be repeated here.
+
+              `htmlFor="classification"` pointed at nothing, so the one control carrying the
+              clinical finding had no accessible name at all -- a screen reader announced an
+              unlabelled combobox. And Radix's Select is not a native control, so it does not
+              inherit the surrounding `fieldset disabled`: a finalized assessment's classification
+              was still changeable. MASTER.md section 10 calls out both; DiabetesScreeningForm
+              already does it this way.
+            */}
+            <Select
+              value={classification}
+              onValueChange={setClassification}
+              disabled={!canEdit || saving}
+            >
+              <SelectTrigger id="classification">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>

--- a/apps/web/e2e/hypertension-assessment.spec.js
+++ b/apps/web/e2e/hypertension-assessment.spec.js
@@ -1,0 +1,99 @@
+const { randomUUID } = require('crypto');
+const { test, expect } = require('@playwright/test');
+
+const { storageStateFor } = require('../playwright/roles');
+
+test.use({ storageState: storageStateFor('staff') });
+
+/**
+ * One assessment per encounter, and the encounter shows the last thing that was saved.
+ *
+ * Issue #91: `HypertensionForm` generated a fresh id inside its save handler, so every save wrote
+ * another row into the local table. The encounter page reads them back with
+ * `.where('encounterId').equals(id).first()`, and Dexie orders duplicate index keys by primary
+ * key -- random UUIDs -- so a clinician who corrected Stage 1 to Crisis could reopen the encounter
+ * and be shown Stage 1 again.
+ *
+ * The rows are asserted directly rather than through the UI, because the UI symptom depended on
+ * which UUID happened to sort first: a test that only reopened the page would pass roughly half
+ * the time against the broken build.
+ */
+
+async function readAssessments(page, encounterId) {
+  return page.evaluate(
+    (encounter) =>
+      new Promise((resolve, reject) => {
+        const request = indexedDB.open('NkwapaDb');
+        request.onerror = () => reject(request.error);
+        request.onsuccess = () => {
+          const db = request.result;
+          if (!db.objectStoreNames.contains('hypertension_assessments')) {
+            db.close();
+            resolve([]);
+            return;
+          }
+          const store = db
+            .transaction('hypertension_assessments', 'readonly')
+            .objectStore('hypertension_assessments');
+          const all = store.getAll();
+          all.onerror = () => reject(all.error);
+          all.onsuccess = () => {
+            db.close();
+            resolve(all.result.filter((row) => row.encounterId === encounter));
+          };
+        };
+      }),
+    encounterId,
+  );
+}
+
+async function setClassification(page, label) {
+  await page.getByLabel('Classification').click();
+  await page.getByRole('option', { name: label, exact: true }).click();
+}
+
+test('a corrected blood pressure classification is what the encounter shows next time', async ({
+  page,
+}) => {
+  test.setTimeout(120_000);
+
+  const suffix = randomUUID().replaceAll('-', '').slice(0, 12);
+  await page.goto('/patients/new');
+  await page.getByLabel('First name', { exact: true }).fill('Hypertension');
+  await page.getByLabel('Last name', { exact: true }).fill(`E2E-${suffix}`);
+  await page.getByLabel('National ID', { exact: true }).fill(`E2E-HTN-${suffix}`);
+  await page.getByRole('button', { name: 'Create patient' }).click();
+  await page.waitForURL(/\/clinics\/[^/]+\/patients\/[^/]+$/, { timeout: 20_000 });
+  const patientId = page.url().split('/').at(-1);
+
+  const created = page.waitForResponse(
+    (response) =>
+      response.request().method() === 'POST' &&
+      /\/clinics\/[^/]+\/encounters$/.test(new URL(response.url()).pathname),
+  );
+  await page.goto(`/patients/${patientId}/encounters/new`);
+  const encounterId = (await (await created).json()).id;
+
+  await page.goto(`/encounters/${encounterId}`);
+  await page.getByRole('tab', { name: 'Hypertension' }).click();
+
+  // First reading.
+  await setClassification(page, 'Stage 1');
+  await page.getByRole('button', { name: 'Save Assessment' }).click();
+  await expect(page.getByRole('button', { name: 'Save Assessment' })).toBeEnabled();
+  await expect.poll(async () => (await readAssessments(page, encounterId)).length).toBe(1);
+
+  // The correction. This is the save that used to insert a second row.
+  await setClassification(page, 'Crisis');
+  await page.getByRole('button', { name: 'Save Assessment' }).click();
+  await expect(page.getByRole('button', { name: 'Save Assessment' })).toBeEnabled();
+
+  await expect
+    .poll(async () => (await readAssessments(page, encounterId)).map((row) => row.classification))
+    .toEqual(['CRISIS']);
+
+  // And the encounter agrees on the next visit, which is what a clinician actually experiences.
+  await page.goto(`/encounters/${encounterId}`);
+  await page.getByRole('tab', { name: 'Hypertension' }).click();
+  await expect(page.getByLabel('Classification')).toHaveText(/crisis/i);
+});

--- a/apps/web/e2e/route-fallbacks.spec.js
+++ b/apps/web/e2e/route-fallbacks.spec.js
@@ -32,7 +32,7 @@ test('a failed settings read never offers an editable form', async ({ page }) =>
     clinic that had it on, having never once seen the real value.
   */
   await page.route('**/research/settings', async (route) => {
-    if (route.request().method() !== 'GET') {
+    if (route.request().resourceType() === 'document' || route.request().method() !== 'GET') {
       await route.continue();
       return;
     }
@@ -77,7 +77,15 @@ test('a failed export queue read offers a retry and leaves the request form usab
   const clinicId = await activeClinicId(page);
 
   await page.route('**/research/exports', async (route) => {
-    if (route.request().method() !== 'GET') {
+    /*
+      Let the page document through.
+
+      The route's own URL ends `/research/exports`, so this glob matches the navigation as well as
+      the API call, and fulfilling it served the injected JSON *as the page*. That is what made
+      this test fail in a full run and pass on its own -- whether the browser reused a cached
+      document decided whether the interception ever saw it.
+    */
+    if (route.request().resourceType() === 'document' || route.request().method() !== 'GET') {
       await route.continue();
       return;
     }

--- a/apps/web/lib/encounter-record.test.ts
+++ b/apps/web/lib/encounter-record.test.ts
@@ -1,0 +1,93 @@
+import { claimEncounterRecord, type EncounterScopedRecord } from './encounter-record';
+
+function fakeTable(rows: EncounterScopedRecord[]) {
+  const deleted: string[] = [];
+  return {
+    deleted,
+    rows,
+    table: {
+      where: () => ({ equals: () => ({ toArray: async () => rows }) }),
+      bulkDelete: async (ids: string[]) => {
+        deleted.push(...ids);
+        return undefined;
+      },
+    },
+  };
+}
+
+const NEW_ID = 'generated-id';
+const generate = () => NEW_ID;
+
+describe('claimEncounterRecord', () => {
+  it('generates an id when the encounter has no record yet', async () => {
+    const { table, deleted } = fakeTable([]);
+    expect(await claimEncounterRecord(table, 'enc-1', generate)).toEqual({
+      id: NEW_ID,
+      removedDuplicates: 0,
+    });
+    expect(deleted).toEqual([]);
+  });
+
+  it('reuses the existing id so a second save updates instead of inserting', async () => {
+    // The defect in #91: without this, every save drew a fresh UUID and left another row behind.
+    const { table, deleted } = fakeTable([
+      { id: 'aaa', encounterId: 'enc-1', createdAt: 'T0', updatedAt: 'T1' },
+    ]);
+    expect(await claimEncounterRecord(table, 'enc-1', generate)).toEqual({
+      id: 'aaa',
+      createdAt: 'T0',
+      removedDuplicates: 0,
+    });
+    expect(deleted).toEqual([]);
+  });
+
+  it('keeps the most recently updated row, not the one UUID ordering happens to surface', async () => {
+    /*
+      The heart of the bug. `.first()` returns the lowest primary key, so with these rows the
+      encounter page showed 'aaa' -- the OLDEST save -- while the newest data sat in 'zzz'.
+    */
+    const { table, deleted } = fakeTable([
+      { id: 'zzz', encounterId: 'enc-1', createdAt: 'T2', updatedAt: 'T9' },
+      { id: 'aaa', encounterId: 'enc-1', createdAt: 'T0', updatedAt: 'T1' },
+      { id: 'mmm', encounterId: 'enc-1', createdAt: 'T1', updatedAt: 'T5' },
+    ]);
+    expect(await claimEncounterRecord(table, 'enc-1', generate)).toEqual({
+      id: 'zzz',
+      createdAt: 'T2',
+      removedDuplicates: 2,
+    });
+    expect(deleted.sort()).toEqual(['aaa', 'mmm']);
+  });
+
+  it('converges on the row a sync pull brought back from the server', async () => {
+    /*
+      After a push the server upserts by encounterId and returns its own row, which the pull
+      writes under the server's id. That row carries the freshest updatedAt, so it wins here and
+      the client-generated orphan is collapsed into it. Keeping the lowest id instead would
+      strand an id the server has never heard of.
+    */
+    const { table, deleted } = fakeTable([
+      { id: 'client-generated', encounterId: 'enc-1', updatedAt: '2026-01-01T00:00:00Z' },
+      { id: 'server-row', encounterId: 'enc-1', updatedAt: '2026-01-01T00:00:05Z' },
+    ]);
+    const claimed = await claimEncounterRecord(table, 'enc-1', generate);
+    expect(claimed.id).toBe('server-row');
+    expect(deleted).toEqual(['client-generated']);
+  });
+
+  it('falls back to the lowest id when nothing carries an updatedAt', async () => {
+    const { table } = fakeTable([
+      { id: 'bbb', encounterId: 'enc-1' },
+      { id: 'aaa', encounterId: 'enc-1' },
+    ]);
+    expect((await claimEncounterRecord(table, 'enc-1', generate)).id).toBe('aaa');
+  });
+
+  it('never invents an id when one already exists', async () => {
+    const { table } = fakeTable([{ id: 'existing', encounterId: 'enc-1' }]);
+    const claimed = await claimEncounterRecord(table, 'enc-1', () => {
+      throw new Error('generateId must not be called when a record exists');
+    });
+    expect(claimed.id).toBe('existing');
+  });
+});

--- a/apps/web/lib/encounter-record.ts
+++ b/apps/web/lib/encounter-record.ts
@@ -1,0 +1,76 @@
+/**
+ * One local row per encounter, for the records where the domain says there is only one.
+ *
+ * `HypertensionAssessment`, `CarePlan`, `DiabetesScreening` and vitals all carry
+ * `encounterId String @unique` on the server. The Dexie mirror indexes `encounterId` without a
+ * unique constraint, so nothing stops a client writing several rows for the same encounter -- and
+ * `HypertensionForm` did exactly that, generating a fresh id inside its save handler.
+ *
+ * That mattered because of how the encounter page reads them back:
+ *
+ *     db.hypertension_assessments.where('encounterId').equals(encounterId).first()
+ *
+ * Dexie iterates the index and, for duplicate index keys, orders by primary key. The primary keys
+ * are `crypto.randomUUID()` values, so `.first()` returned whichever save happened to draw the
+ * lexicographically smallest UUID -- not the most recent one. A clinician correcting Stage 1 to
+ * Crisis could reopen the encounter and be shown Stage 1 again. See issue #91.
+ */
+
+export interface EncounterScopedRecord {
+  id: string;
+  encounterId: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+/** The slice of a Dexie table this needs, so it can be tested without a browser. */
+export interface EncounterScopedTable<T extends EncounterScopedRecord> {
+  where(index: 'encounterId'): {
+    equals(value: string): { toArray(): Promise<T[]> };
+  };
+  bulkDelete(ids: string[]): Promise<unknown>;
+}
+
+export interface ClaimedEncounterRecord {
+  /** The id to write under: an existing row's where there is one, a new one otherwise. */
+  id: string;
+  /** The kept row's original creation time, so an update does not restamp it as new. */
+  createdAt?: string;
+  /** How many duplicate rows were collapsed. Zero on a healthy encounter. */
+  removedDuplicates: number;
+}
+
+/**
+ * Resolves the single row that should represent this encounter, collapsing any duplicates.
+ *
+ * The row kept is the most recently updated one, tie-broken by the lowest id. That rule is what
+ * makes a client converge on the server's copy rather than oscillating against it: after a push,
+ * the pull writes the server's row under the server's id, which carries the freshest `updatedAt`
+ * and therefore wins the next time this runs. Keeping the lowest id instead would strand a
+ * client-generated id that the server had never heard of.
+ */
+export async function claimEncounterRecord<T extends EncounterScopedRecord>(
+  table: EncounterScopedTable<T>,
+  encounterId: string,
+  generateId: () => string,
+): Promise<ClaimedEncounterRecord> {
+  const existing = await table.where('encounterId').equals(encounterId).toArray();
+
+  if (existing.length === 0) {
+    return { id: generateId(), removedDuplicates: 0 };
+  }
+
+  const [keep, ...duplicates] = [...existing].sort((a, b) => {
+    const byUpdated = (b.updatedAt ?? '').localeCompare(a.updatedAt ?? '');
+    if (byUpdated !== 0) return byUpdated;
+    return a.id.localeCompare(b.id);
+  });
+
+  if (duplicates.length > 0) {
+    // Heals a device that already accumulated rows before this landed. Nothing reads them, but
+    // leaving them means `.first()` keeps depending on UUID ordering.
+    await table.bulkDelete(duplicates.map((record) => record.id));
+  }
+
+  return { id: keep.id, createdAt: keep.createdAt, removedDuplicates: duplicates.length };
+}


### PR DESCRIPTION
Closes #91.

## The reported defect

`HypertensionForm` called `generateId()` inside its save handler, so **every save wrote another row** for the same encounter. The encounter page reads them back with `.where('encounterId').equals(id).first()`, and Dexie orders duplicate index keys by primary key — random UUIDs — so a clinician who corrected Stage 1 to Crisis could reopen the encounter and be shown **Stage 1** again.

`claimEncounterRecord` reuses the encounter's existing row and collapses duplicates a device already accumulated. It keeps the most recently updated row, tie-broken by lowest id, which is what makes a client **converge on the server's copy**: after a push, the pull writes the server's row under the server's id with the freshest `updatedAt`, so it wins next time. Keeping the lowest id would strand a client-generated id the server has never heard of.

`CarePlanForm` shares the helper. It never had this bug — it looked its record up first, which is where the fix came from — but sharing the code is what stops the two drifting apart again, and it gains the duplicate collapse and `createdAt` preservation it did not have.

## Three more defects, found by writing the test

None of these were in the issue, and all three are in the same form:

1. **The Classification select had no accessible name.** `htmlFor="classification"` pointed at nothing, because the id was never put on the `SelectTrigger`. A screen reader announced an unlabelled combobox on the one control carrying the clinical finding. This is why the test could not reach it.
2. **The select was not disabled on a locked record.** Radix's `Select` is not a native control and does not inherit the surrounding `fieldset disabled`, so a **finalized assessment's classification was still changeable**. `MASTER.md` section 10 warns about exactly this, and `DiabetesScreeningForm` already did it correctly.
3. **The form never re-seeded from `initialData`.** `useState(initialData?.…)` reads its argument once, and the encounter page loads this record asynchronously — so reopening an encounter with a saved assessment showed **"Not classified"** whatever was stored. That is the same user-visible symptom as the id bug from a different cause, and it would have survived fixing only the id.

## Verification

`e2e/hypertension-assessment.spec.js` asserts the rows in IndexedDB directly rather than through the UI, because the UI symptom depended on which UUID happened to sort first — a test that only reopened the page would have passed **about half the time** against the broken build.

Each defect was re-introduced separately to confirm the spec catches it. With the other three fixed, the duplicate-row assertion still fails (a second row appears). `lib/encounter-record.test.ts` covers the helper's rules including the server-convergence case.

Full suite: **116 passed, 0 failed.**

## Two things fixed on the way that were not this issue

- **`route-fallbacks.spec.js` intercepted `**/research/exports`**, which also matches the page's own URL, so the injected 503 was served *as the page document*. It passed alone and failed in a full run. Document requests now pass through. That was my bug, from #87.
- **The E2E job raises four rate limits.** `/auth/whoami` allows 60 a minute and the suite is one user loading pages as fast as it can. Exhausting it failed whichever spec happened to be running, at ~34s, with "We couldn't confirm your access" — a 429 resolves to `unavailable`. It had already bitten this suite once; see the note in `responsive-migration.spec.js`. Raised for the **E2E job only**, so the limits stay under test elsewhere.

That second one is worth a look during review: it is a test-environment change, and I would rather it be seen than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)