### PR TITLE
Make a refresh visible without letting it move the page

### DIFF
--- a/apps/web/app/(workspace)/audit/page.tsx
+++ b/apps/web/app/(workspace)/audit/page.tsx
@@ -216,7 +216,10 @@ export default function AuditPage() {
             </div>
             <div className="flex flex-wrap gap-2">
               <Button onClick={() => fetchAudit()} disabled={loading} className="rounded-lg">
-                {loading ? 'Loading...' : 'Apply filters'}
+                Apply filters
+                <span aria-live="polite" className="sr-only">
+                  {loading ? 'Applying filters' : ''}
+                </span>
               </Button>
               <Button
                 type="button"
@@ -343,7 +346,10 @@ export default function AuditPage() {
                   disabled={loadingMore}
                   className="rounded-lg"
                 >
-                  {loadingMore ? 'Loading...' : 'Load more'}
+                  Load more
+                  <span aria-live="polite" className="sr-only">
+                    {loadingMore ? 'Loading more results' : ''}
+                  </span>
                 </Button>
               </div>
             )}

--- a/apps/web/app/(workspace)/dashboard/page.tsx
+++ b/apps/web/app/(workspace)/dashboard/page.tsx
@@ -207,8 +207,20 @@ export default function DashboardPage() {
                 onClick={() => void fetchDashboard(true)}
                 disabled={loading}
               >
-                <RefreshCw className={loading ? 'animate-spin' : ''} />
-                {loading ? 'Refreshing' : 'Refresh'}
+                <RefreshCw
+                  aria-hidden="true"
+                  className={loading ? 'animate-spin motion-reduce:animate-none' : ''}
+                />
+                {/*
+                  The label stays put. Swapping it for "Refreshing" grew the button by 19px,
+                  measured, which moved everything beside it in the header every time someone
+                  refreshed. The spinner carries the state visually and the live region carries it
+                  for assistive technology, so nothing is lost by keeping the word still.
+                */}
+                Refresh
+                <span aria-live="polite" className="sr-only">
+                  {loading ? 'Refreshing the dashboard' : ''}
+                </span>
               </Button>
             ) : null
           }

--- a/apps/web/app/(workspace)/reminders/page.tsx
+++ b/apps/web/app/(workspace)/reminders/page.tsx
@@ -272,7 +272,10 @@ export default function RemindersPage() {
                   disabled={loading}
                   className="flex-1 rounded-lg"
                 >
-                  {loading ? 'Loading...' : 'Apply filters'}
+                  Apply filters
+                  <span aria-live="polite" className="sr-only">
+                    {loading ? 'Applying filters' : ''}
+                  </span>
                 </Button>
                 <Button
                   type="button"
@@ -392,7 +395,10 @@ export default function RemindersPage() {
                   disabled={loadingMore}
                   className="rounded-lg"
                 >
-                  {loadingMore ? 'Loading...' : 'Load more'}
+                  Load more
+                  <span aria-live="polite" className="sr-only">
+                    {loadingMore ? 'Loading more results' : ''}
+                  </span>
                 </Button>
               </div>
             )}

--- a/apps/web/components/chat/ChatConversation.tsx
+++ b/apps/web/components/chat/ChatConversation.tsx
@@ -331,7 +331,10 @@ export function ChatConversation({
             disabled={loading}
             className="cursor-pointer self-center py-2 text-xs text-muted-foreground hover:underline"
           >
-            {loading ? 'Loading...' : 'Load older messages'}
+            Load older messages
+            <span aria-live="polite" className="sr-only">
+              {loading ? 'Loading older messages' : ''}
+            </span>
           </button>
         )}
       </div>

--- a/apps/web/components/feedback/ResourceState.tsx
+++ b/apps/web/components/feedback/ResourceState.tsx
@@ -93,7 +93,29 @@ export function ResourceState<T>({
   const showEmpty = empty && isEmpty?.(state.data);
 
   return (
-    <div className={cn('space-y-4', className)} aria-busy={state.isRefreshing || undefined}>
+    <div
+      className={cn('relative space-y-4', className)}
+      aria-busy={state.isRefreshing || undefined}
+    >
+      {/*
+        A refresh that shows nothing is indistinguishable from a page that has stopped working.
+
+        `aria-busy` above told assistive technology, and three call sites had each built their own
+        spinner, but the other six refreshed in complete silence for a sighted user. This is the
+        one indicator, so every surface using ResourceState gets the same one.
+
+        It is absolutely positioned and therefore cannot move the content beneath it, which is the
+        whole point: MASTER.md section 7 forbids a loading affordance that shifts what is being
+        read. Under prefers-reduced-motion it holds still as a full-width bar instead of sweeping.
+      */}
+      {state.isRefreshing ? (
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-x-0 -top-2 h-0.5 overflow-hidden rounded-full bg-primary/15"
+        >
+          <span className="block h-full w-1/4 animate-refresh-sweep rounded-full bg-primary motion-reduce:w-full motion-reduce:animate-none" />
+        </span>
+      ) : null}
       {/*
         The refresh failed but the previous result is still on screen. Say so, and say how old it
         is not -- claiming a timestamp we do not have would be worse than admitting the gap.

--- a/apps/web/e2e/stale-refresh.spec.js
+++ b/apps/web/e2e/stale-refresh.spec.js
@@ -1,0 +1,102 @@
+const { test, expect } = require('@playwright/test');
+
+const { storageStateFor } = require('../playwright/roles');
+
+/**
+ * Refreshing must not take the page away from the person reading it.
+ *
+ * #23's contract, and the two ways it is usually broken: clearing content while a refetch is in
+ * flight, and indicating the refetch with something that resizes and moves the layout.
+ *
+ * Both were real here. The dashboard's Refresh button swapped its label for "Refreshing" and grew
+ * 19px, shifting everything beside it in the header. And `ResourceState` set `aria-busy` and
+ * nothing else, so on six of the nine surfaces using it a refresh was completely invisible to a
+ * sighted user — indistinguishable from a page that had stopped working.
+ */
+
+test.use({ storageState: storageStateFor('staff') });
+
+/** Hold the API open long enough to observe the refreshing state. */
+async function slowDown(page, pattern) {
+  await page.route(pattern, async (route) => {
+    if (route.request().resourceType() === 'document') {
+      await route.continue();
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 2500));
+    await route.continue();
+  });
+}
+
+test('a refresh control does not change size when it becomes busy', async ({ page }) => {
+  await page.goto('/dashboard');
+  await expect(page.locator('#main-content')).toBeVisible({ timeout: 30_000 });
+  const refresh = page.getByRole('button', { name: /Refresh/ });
+  await expect(refresh).toBeEnabled({ timeout: 20_000 });
+
+  const idle = await refresh.boundingBox();
+  await slowDown(page, '**/clinics/*/dashboard*');
+  await refresh.click();
+
+  // Busy: the icon spins and a live region announces it, but the word stays put.
+  await expect(refresh).toBeDisabled();
+  const busy = await refresh.boundingBox();
+
+  expect(
+    Math.abs(busy.width - idle.width),
+    `the refresh control resized by ${Math.round(busy.width - idle.width)}px while busy`,
+  ).toBeLessThanOrEqual(1);
+  expect(Math.abs(busy.x - idle.x)).toBeLessThanOrEqual(1);
+});
+
+test('a refetch keeps the rows that are already on screen', async ({ page }) => {
+  await page.goto('/patients');
+  await expect(page.locator('#main-content')).toBeVisible({ timeout: 30_000 });
+  const rows = page.locator('.MuiDataGrid-row');
+  await expect(rows.first()).toBeVisible({ timeout: 30_000 });
+  const before = await rows.count();
+  expect(before).toBeGreaterThan(0);
+
+  await slowDown(page, '**/clinics/*/patients*');
+  // Paging re-reads the registry. Deliberately not a search: changing the filter changes the
+  // result set, so an empty grid afterwards would be correct and the test would prove nothing.
+  await page
+    .getByRole('button', { name: /next page/i })
+    .first()
+    .click()
+    .catch(() => {});
+
+  // The point of the whole contract: mid-refetch, the previous result is still readable.
+  await expect(rows.first()).toBeVisible();
+  expect(await rows.count(), 'the registry blanked while refetching').toBeGreaterThan(0);
+});
+
+test('the refresh indicator cannot move the content it sits above', async ({ page }) => {
+  await page.goto('/patients');
+  await expect(page.locator('#main-content')).toBeVisible({ timeout: 30_000 });
+  await expect(page.locator('.MuiDataGrid-row').first()).toBeVisible({ timeout: 30_000 });
+
+  await slowDown(page, '**/clinics/*/patients*');
+  await page
+    .getByRole('button', { name: /next page/i })
+    .first()
+    .click()
+    .catch(() => {});
+
+  const busyRegion = page.locator('[aria-busy="true"]').first();
+  await expect(busyRegion).toBeAttached({ timeout: 10_000 });
+
+  /*
+    Taken out of flow, so it cannot push anything down however tall it is. Asserting the CSS
+    rather than a pixel measurement, because a pixel measurement passes for the wrong reason when
+    the element simply has not rendered yet.
+  */
+  const position = await busyRegion
+    .locator('span[aria-hidden="true"]')
+    .first()
+    .evaluate((el) => getComputedStyle(el).position)
+    .catch(() => null);
+  expect(position, 'the refresh indicator is in normal flow and will shift content').toBe(
+    'absolute',
+  );
+});

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -34,9 +34,16 @@ module.exports = {
           '0%': { transform: 'translateX(0)' },
           '100%': { transform: 'translateX(-100%)' },
         },
+        // The indeterminate refresh bar. Travels rather than pulsing, so it reads as "still
+        // working" rather than as something blinking for attention.
+        'refresh-sweep': {
+          '0%': { transform: 'translateX(-100%)' },
+          '100%': { transform: 'translateX(400%)' },
+        },
       },
       animation: {
         marquee: 'marquee var(--marquee-duration, 30s) linear infinite',
+        'refresh-sweep': 'refresh-sweep 1.1s ease-in-out infinite',
       },
       colors: {
         border: 'hsl(var(--border))',

--- a/docs/USER_TESTING_GUIDE.md
+++ b/docs/USER_TESTING_GUIDE.md
@@ -375,6 +375,19 @@ authentication alone. Check instead that an authenticated user _without_ a pendi
 redirected away, and that while identity is still loading the page does **not** claim that no
 invitation was found.
 
+### Refresh behaviour
+
+The contract is in `docs/design-system/MASTER.md` section 11; these are the checks.
+
+- [ ] a refresh **never clears the screen** — trigger one on a slow connection and confirm the
+      previous result stays readable throughout
+- [ ] a refresh is **visible** — a thin bar appears above the content, and it does not push the
+      content down
+- [ ] a refresh control **does not resize**. "Refresh" must not become "Refreshing", "Apply
+      filters" must not become "Loading…". The icon spins; the word holds still
+- [ ] the one case where blanking is correct: **changing the subject**. A date change on the Today
+      board, or a clinic switch, should re-skeleton rather than relabel the previous day's data
+
 ### Spot checks worth doing by hand
 
 The automated suite covers these routes rendering and not overflowing. It does not judge whether

--- a/docs/design-system/MASTER.md
+++ b/docs/design-system/MASTER.md
@@ -403,6 +403,7 @@ Shared primitives live in `apps/web/components/app-shell/` and `apps/web/compone
 | A field's error                 | `FieldError` + `fieldErrorProps`                    | A bare `<p className="text-destructive">` |
 | A required field                | `RequiredMark` + one `RequiredLegend` per form      | An asterisk baked into the label string   |
 | A form-level message            | `InlineNotice`                                      | A `<div>` with no role                    |
+| Refresh in progress             | `ResourceState`'s own indicator                     | A control that resizes when it goes busy  |
 | One read's five states          | `ResourceState` + `useAsyncResource`                | A hand-rolled `useState` triple           |
 | Loading                         | `SectionSkeleton` / `PageSkeleton`                  | A spinner in the middle of content        |
 | Nothing here yet                | `EmptyState`                                        | A dashed div with a paragraph             |
@@ -564,19 +565,68 @@ non-goal puts outside that issue.
 
 ---
 
-## 11. Still open
+## 11. Refresh and optimistic updates
+
+The contract for what happens between asking for data again and getting it. #23 exists because
+this was implemented four different ways.
+
+### Refreshing must not take the page away
+
+`useAsyncResource` keeps the last successful result across a refetch and across a _failed_
+refetch. `ResourceState` renders that: the content stays, with a stale banner above it if the
+refresh failed. Nothing may clear a screen someone is reading because a request is in flight.
+
+**Blanking is correct in exactly one case: when the subject changes.** Refreshing today's board is
+a refresh; switching to another date is a different question, and showing yesterday's patients
+under today's heading would be worse than a skeleton. The Today board draws that line correctly —
+its explicit refreshes preserve, and a date change re-skeletons.
+
+### Indicating a refresh
+
+- One indicator, in `ResourceState`: a 2px bar, **absolutely positioned** so it is out of flow and
+  cannot move the content beneath it. It holds still under `prefers-reduced-motion`.
+- A control that triggers a refresh **keeps its label**. Swapping "Refresh" for "Refreshing" grew
+  the dashboard button by 19px, measured, and moved everything beside it in the header. Spin the
+  icon, and put the state in an `aria-live` `sr-only` span.
+- The same applies to "Apply filters" and "Load more". "Loading…" also breaks section 9's rule that
+  a control names its action.
+
+`e2e/stale-refresh.spec.js` holds all three.
+
+### Optimistic updates
+
+An optimistic update shows a result before the server has confirmed it, and must roll back visibly
+if the server disagrees.
+
+**Where it is used:** chat message send, which carries `deliveryState: 'pending' | 'failed'` and
+reconciles against the delivered message.
+
+**Where it must never be used**, per #23: patient merge, consent, encounter finalization, role
+changes, and research export approval. Anything where a wrongly-shown success could be acted on
+clinically, or where rollback would leave the reader unsure what is true, is not a candidate.
+
+**Why there is not more of it.** The surfaces that would benefit are the ones with a rendered state
+a mutation flips, and in this product those are almost exactly the forbidden list. The reversible
+ones — patient check-in, shift check-in and check-out — render no list state to flip: their result
+is a notice, not a row that changes. Adding optimism there would mean inventing UI to be optimistic
+about. That is a finding, not an omission; revisit it if a surface gains a status a mutation
+toggles.
+
+---
+
+## 12. Still open
 
 - **Wireframes as artwork.** #61 offers "approved wireframes **or** annotated patterns"; sections
   9 and 10 are the annotated patterns, and drawn wireframes were not attempted.
 - **The application's own fonts** still load through a render-blocking `@import` in `globals.css`
   plus a second CDN link in `layout.tsx`. The Keycloak theme self-hosts (section 2); the app does
   not. Moving it to `next/font` is its own issue.
-- **#23** stale-refresh and optimistic updates. Re-read it against `useAsyncResource`, which
-  already preserves last-known-good data across a failed refetch.
+- **More optimistic updates**, if a surface ever gains a status a mutation toggles. Section 11
+  records why there is only one today.
 
 ---
 
-## 12. Verification
+## 13. Verification
 
 Run after any change to this file or to `globals.css`:
 
@@ -592,6 +642,8 @@ npm run e2e
 
 `role-access.spec.js`, `workspace-smoke.spec.js`, and `accessibility.spec.js` are the specs that
 catch a visual change silently breaking a role or tenant boundary.
+`stale-refresh.spec.js` holds section 11's contract: content survives a refetch, and no refresh
+affordance resizes or moves what it sits above.
 `responsive-migration.spec.js` performs the breakpoint pass on ten routes at five widths, and
 `login-theme.spec.js` guards the Keycloak theme, which no build step in this repo can see.
 


### PR DESCRIPTION
Closes #23, the last open Phase 6 issue.

Two of this issue's acceptance criteria were unmet, and both were measurable rather than matters of taste.

## A refresh was invisible

`ResourceState` set `aria-busy` and nothing else. On **six of the nine surfaces** using it, a refetch was completely silent to a sighted user — indistinguishable from a page that had stopped working. Three other call sites had each built their own spinner, which is the inconsistency this issue's Context describes.

There is one indicator now, in `ResourceState`, so every surface gets the same one: a 2px bar, **absolutely positioned** so it is out of flow and cannot move the content beneath it, holding still under `prefers-reduced-motion`.

## The refresh UI caused layout jumps

The dashboard's Refresh button swapped its label for "Refreshing" and grew **19px** — measured, not estimated — moving everything beside it in the page header every time anyone refreshed. Five more controls did the same, with "Apply filters" and "Load more" becoming "Loading…".

The label holds still now, the icon carries the state visually, and an `aria-live` `sr-only` span carries it for assistive technology. Nothing is lost, and "Loading…" also broke section 9's rule that a control names its action.

## The other two criteria were already met

They are now pinned rather than changed. `useAsyncResource` keeps the last good result across a refetch *and* a failed refetch, and the dashboard, Today board and reminders each already avoided blanking — by three different hand-rolled means, which is why the contract is now written down.

**The Today board draws the one line that matters, and it draws it correctly:** an explicit refresh preserves content, a date change re-skeletons. Showing yesterday's patients under today's heading would be worse than a skeleton, so that blanking is correct. It is documented as correct rather than "fixed" — it would have been easy to mistake for the bug and regress.

## On optimistic updates — the honest finding

**There is no safe surface left to add one to.**

- Chat send is **already optimistic**, with `deliveryState: 'pending' | 'failed'` and reconciliation against the delivered message.
- The surfaces with a rendered state that a mutation flips are almost exactly this issue's own forbidden list: merge, consent, finalization, role changes, research export approval.
- The genuinely reversible ones — patient check-in, shift check-in and check-out — **render no list state to flip**. Their result is a notice, not a row that changes. Adding optimism there would mean inventing UI to be optimistic about.

Recorded in `MASTER.md` section 11 as a finding, with the condition under which to revisit it: if a surface ever gains a status a mutation toggles.

## Verification

`MASTER.md` section 11 is the contract, including when blanking *is* correct — previously encoded only implicitly, in one page, where the next person would have read it as a bug.

`e2e/stale-refresh.spec.js` holds it, and was checked the usual way: the two fixes **fail against this commit's parent** with `the refresh control resized by 19px while busy` and `the refresh indicator is in normal flow and will shift content`. The third test guards behaviour that already worked and passes on both sides — said plainly so nobody reads it as proof of a change.

Full suite: **119 passed, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)