### PR TITLE
Patient identity: merge preview and safety checks

### DIFF
--- a/IMPLEMENTATION_STATUS.md
+++ b/IMPLEMENTATION_STATUS.md
@@ -117,23 +117,23 @@ nkwapa/
 
 ### Clinical Workflows
 
-| Feature                                           | Status | %    | Notes                                                                                    |
-| ------------------------------------------------- | ------ | ---- | ---------------------------------------------------------------------------------------- |
-| Patient registry (create, update, search, detail) | ✅     | 100% | Code generation, encrypted national ID                                                   |
-| Patient merge & code alias                        | ✅     | 100% | SYSTEM_ADMIN-only merge with alias preservation                                          |
-| Portal link/invite                                | ✅     | 100% | Link, invite, claim; enforced expiry, resend/cancel, audited lifecycle                   |
-| Duplicate review queue                            | ❌     | 0%   | Hashed ID collision detected, no dedicated queue UI                                      |
-| Cross-clinic chart consolidation                  | ❌     | 0%   | Merge is clinic-local only                                                               |
-| Encounter workflow (draft -> review -> finalize)  | ✅     | 100% | Full state machine with role-based transitions                                           |
-| Role-aware patient chart and longitudinal history | ✅     | 100% | Deep-linked lazy tabs, server-enforced sections, cursor-paginated vitals and visits      |
-| HAP clinical notes, cosign, and addenda           | ✅     | 100% | Flagged online-only HAP lifecycle with immutable signing and assigned-doctor cosign      |
-| Vitals recording                                  | ✅     | 100% | Contextual BP, pulse, temperature, respiration, SpO2, anthropometrics, tobacco screening |
-| Diabetes screening                                | ✅     | 100% | Glucose, HbA1c, symptoms, DM suspicion                                                   |
-| Hypertension assessment                           | ✅     | 100% | BP classification per thresholds                                                         |
-| Care plan creation                                | ✅     | 100% | Counseling, medication, follow-up date                                                   |
-| Prescription & drug catalog                       | ✅     | 100% | Clinic-scoped drug catalog, encounter prescriptions                                      |
-| Medication reconciliation & pharmacy history      | ✅     | 100% | Patient-level revisions, reconciliation, preference periods, offline sync                |
-| Consent grant/revoke                              | ✅     | 100% | Witness fields, snapshot text, offline supported                                         |
+| Feature                                           | Status | %    | Notes                                                                                      |
+| ------------------------------------------------- | ------ | ---- | ------------------------------------------------------------------------------------------ |
+| Patient registry (create, update, search, detail) | ✅     | 100% | Code generation, encrypted national ID                                                     |
+| Patient merge & code alias                        | ✅     | 100% | SYSTEM_ADMIN-only, previewed before commit, blocked conditions, alias and record preserved |
+| Portal link/invite                                | ✅     | 100% | Link, invite, claim; enforced expiry, resend/cancel, audited lifecycle                     |
+| Duplicate review queue                            | ✅     | 100% | Scored candidates, reviewable decisions, links into the merge preview                      |
+| Cross-clinic chart consolidation                  | ❌     | 0%   | Merge is clinic-local only                                                                 |
+| Encounter workflow (draft -> review -> finalize)  | ✅     | 100% | Full state machine with role-based transitions                                             |
+| Role-aware patient chart and longitudinal history | ✅     | 100% | Deep-linked lazy tabs, server-enforced sections, cursor-paginated vitals and visits        |
+| HAP clinical notes, cosign, and addenda           | ✅     | 100% | Flagged online-only HAP lifecycle with immutable signing and assigned-doctor cosign        |
+| Vitals recording                                  | ✅     | 100% | Contextual BP, pulse, temperature, respiration, SpO2, anthropometrics, tobacco screening   |
+| Diabetes screening                                | ✅     | 100% | Glucose, HbA1c, symptoms, DM suspicion                                                     |
+| Hypertension assessment                           | ✅     | 100% | BP classification per thresholds                                                           |
+| Care plan creation                                | ✅     | 100% | Counseling, medication, follow-up date                                                     |
+| Prescription & drug catalog                       | ✅     | 100% | Clinic-scoped drug catalog, encounter prescriptions                                        |
+| Medication reconciliation & pharmacy history      | ✅     | 100% | Patient-level revisions, reconciliation, preference periods, offline sync                  |
+| Consent grant/revoke                              | ✅     | 100% | Witness fields, snapshot text, offline supported                                           |
 
 ### Clinic Operations
 

--- a/apps/api/src/admin/admin.controller.ts
+++ b/apps/api/src/admin/admin.controller.ts
@@ -20,6 +20,7 @@ import { UserRole } from '@prisma/client';
 import { AssignRoleDto } from './dto/assign-role.dto';
 import { MergePatientsDto } from './dto/merge-patients.dto';
 import { PatientDuplicateService } from '../patients/patient-duplicate.service';
+import { PatientMergeService } from '../patients/patient-merge.service';
 import { ListDuplicateCandidatesQueryDto } from '../patients/dto/list-duplicate-candidates.query.dto';
 import { ReviewDuplicatePairDto } from '../patients/dto/review-duplicate-pair.dto';
 import type { ReqUserWithRoles } from '../auth/guards/rbac.guard';
@@ -31,6 +32,7 @@ export class AdminController {
   constructor(
     private readonly adminService: AdminService,
     private readonly patientDuplicateService: PatientDuplicateService,
+    private readonly patientMergeService: PatientMergeService,
   ) {}
 
   @Get('users')
@@ -131,22 +133,25 @@ export class AdminController {
     );
   }
 
+  /**
+   * Consolidate two charts. Irreversible, and system-admin only.
+   *
+   * `PatientMergeService` re-runs the same evaluation the preview showed and refuses on any
+   * blocker, so a client that skips the preview is held to exactly the same safety checks.
+   */
   @Post('patients/merge')
   async mergePatients(
     @Body() dto: MergePatientsDto,
     @Request() req: { user: ReqUserWithRoles; headers?: { 'x-request-id'?: string } },
   ) {
-    const actor = {
-      userId: req.user.user.id,
-      roles: req.user.roles,
-    };
-    return this.adminService.mergePatients(
-      actor,
+    return this.patientMergeService.merge(
+      { userId: req.user.user.id, roles: req.user.roles },
       dto.canonicalPatientId,
       dto.sourcePatientId,
       {
         portalLinkStrategy: dto.portalLinkStrategy,
         inviteStrategy: dto.inviteStrategy,
+        expectedFingerprint: dto.previewFingerprint,
       },
       req.headers?.['x-request-id'] ?? randomUUID(),
     );

--- a/apps/api/src/admin/admin.controller.ts
+++ b/apps/api/src/admin/admin.controller.ts
@@ -19,6 +19,7 @@ import { PERMISSIONS } from '../auth/constants/permissions';
 import { UserRole } from '@prisma/client';
 import { AssignRoleDto } from './dto/assign-role.dto';
 import { MergePatientsDto } from './dto/merge-patients.dto';
+import { AdminMergePreviewQueryDto } from '../patients/dto/merge-preview.query.dto';
 import { PatientDuplicateService } from '../patients/patient-duplicate.service';
 import { PatientMergeService } from '../patients/patient-merge.service';
 import { ListDuplicateCandidatesQueryDto } from '../patients/dto/list-duplicate-candidates.query.dto';
@@ -134,12 +135,37 @@ export class AdminController {
   }
 
   /**
+   * The all-clinics twin of the chart-scoped preview.
+   *
+   * Mirrors how the duplicate queue is exposed on both controllers: the clinic-scoped route is
+   * where an operator working a chart reaches it, and this one is reachable without first
+   * knowing which clinic owns the pair.
+   */
+  @Get('patients/merge/preview')
+  @RequirePermission(PERMISSIONS.PATIENT_MERGE)
+  async previewMerge(
+    @Query() query: AdminMergePreviewQueryDto,
+    @Request() req: { user: ReqUserWithRoles },
+  ) {
+    return this.patientMergeService.preview(
+      { userId: req.user.user.id, roles: req.user.roles },
+      query.canonicalPatientId,
+      query.sourcePatientId,
+      {
+        portalLinkStrategy: query.portalLinkStrategy,
+        inviteStrategy: query.inviteStrategy,
+      },
+    );
+  }
+
+  /**
    * Consolidate two charts. Irreversible, and system-admin only.
    *
    * `PatientMergeService` re-runs the same evaluation the preview showed and refuses on any
    * blocker, so a client that skips the preview is held to exactly the same safety checks.
    */
   @Post('patients/merge')
+  @RequirePermission(PERMISSIONS.PATIENT_MERGE)
   async mergePatients(
     @Body() dto: MergePatientsDto,
     @Request() req: { user: ReqUserWithRoles; headers?: { 'x-request-id'?: string } },

--- a/apps/api/src/admin/admin.service.spec.ts
+++ b/apps/api/src/admin/admin.service.spec.ts
@@ -68,39 +68,6 @@ describe('AdminService', () => {
         findFirst: jest.fn().mockResolvedValue({ id: 'clinic-1' }),
         findUnique: jest.fn().mockResolvedValue({ name: 'Clinic One' }),
       },
-      encounter: {
-        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
-      },
-      patientConsent: {
-        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
-      },
-      reminder: {
-        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
-      },
-      patientSelfReport: {
-        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
-      },
-      patientMeasurement: {
-        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
-      },
-      patientCheckIn: {
-        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
-      },
-      appointmentRequest: {
-        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
-      },
-      appointment: {
-        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
-      },
-      patientPortalInvite: {
-        findMany: jest.fn().mockResolvedValue([]),
-        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
-      },
-      patientCodeAlias: {
-        createMany: jest.fn().mockResolvedValue({ count: 0 }),
-        deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
-        create: jest.fn().mockResolvedValue({ id: 'alias-1' }),
-      },
       patientAccountLink: {
         findMany: jest.fn().mockResolvedValue([]),
         findUnique: jest.fn().mockResolvedValue(null),
@@ -541,82 +508,5 @@ describe('AdminService', () => {
 
     expect(prisma.user.findUnique).not.toHaveBeenCalled();
     expect(prisma.userClinicRole.create).not.toHaveBeenCalled();
-  });
-
-  it('merges a duplicate patient into the canonical chart and records the legacy code as an alias', async () => {
-    const { prisma, auditService, service } = createService();
-    prisma.patient.findUnique
-      .mockResolvedValueOnce({
-        id: 'patient-1',
-        patientCode: 'NKP-2026-000001',
-        primaryClinicId: 'clinic-1',
-        portalUserId: 'user-1',
-        mergedIntoPatientId: null,
-        codeAliases: [],
-      })
-      .mockResolvedValueOnce({
-        id: 'patient-2',
-        patientCode: 'NKP-2026-000099',
-        primaryClinicId: 'clinic-1',
-        portalUserId: null,
-        mergedIntoPatientId: null,
-        codeAliases: [],
-      });
-    prisma.patientAccountLink.findUnique
-      .mockResolvedValueOnce({
-        id: 'link-1',
-        patientId: 'patient-1',
-        keycloakSub: 'kc-1',
-        createdAt: new Date('2026-04-04T12:00:00.000Z'),
-      })
-      .mockResolvedValueOnce(null);
-
-    const result = await service.mergePatients(
-      systemAdminActor,
-      'patient-1',
-      'patient-2',
-      {
-        portalLinkStrategy: 'CANONICAL',
-        inviteStrategy: 'MERGE',
-      },
-      'req-merge-1',
-    );
-
-    expect(prisma.encounter.updateMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { patientId: 'patient-2' },
-        data: { patientId: 'patient-1' },
-      }),
-    );
-    expect(prisma.patient.update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { id: 'patient-2' },
-        data: expect.objectContaining({
-          mergedIntoPatientId: 'patient-1',
-          mergedByUserId: 'sysadmin-1',
-        }),
-      }),
-    );
-    expect(prisma.patientCodeAlias.create).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: {
-          patientId: 'patient-1',
-          code: 'NKP-2026-000099',
-        },
-      }),
-    );
-    expect(auditService.logWrite).toHaveBeenCalledWith(
-      expect.objectContaining({
-        action: 'PATIENT.MERGE',
-        entityId: 'patient-1',
-      }),
-    );
-    expect(result).toEqual({
-      success: true,
-      canonicalPatientId: 'patient-1',
-      canonicalPatientCode: 'NKP-2026-000001',
-      mergedPatientId: 'patient-2',
-      mergedPatientCodeAlias: 'NKP-2026-000099',
-    });
   });
 });

--- a/apps/api/src/admin/admin.service.ts
+++ b/apps/api/src/admin/admin.service.ts
@@ -6,6 +6,7 @@ import {
   ConflictException,
 } from '@nestjs/common';
 import { Prisma, UserRole } from '@prisma/client';
+import { isSystemAdmin } from '../auth/clinic-roles';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
 import { ReminderService } from '../reminders/reminder.service';
@@ -243,267 +244,6 @@ export class AdminService {
     }
 
     return { deleted: true };
-  }
-
-  async mergePatients(
-    actor: AdminActor,
-    canonicalPatientId: string,
-    sourcePatientId: string,
-    options?: {
-      portalLinkStrategy?: 'CANONICAL' | 'SOURCE';
-      inviteStrategy?: 'CANONICAL' | 'SOURCE' | 'MERGE';
-    },
-    requestId?: string,
-  ) {
-    this.assertSystemAdmin(actor, 'Only System Admin can merge patient records');
-
-    if (canonicalPatientId === sourcePatientId) {
-      throw new BadRequestException('Canonical and source patient must be different records');
-    }
-
-    const [
-      canonicalPatient,
-      sourcePatient,
-      canonicalLink,
-      sourceLink,
-      canonicalInvites,
-      sourceInvites,
-    ] = await Promise.all([
-      this.prisma.patient.findUnique({
-        where: { id: canonicalPatientId },
-        include: {
-          codeAliases: true,
-        },
-      }),
-      this.prisma.patient.findUnique({
-        where: { id: sourcePatientId },
-        include: {
-          codeAliases: true,
-        },
-      }),
-      this.prisma.patientAccountLink.findUnique({
-        where: { patientId: canonicalPatientId },
-      }),
-      this.prisma.patientAccountLink.findUnique({
-        where: { patientId: sourcePatientId },
-      }),
-      this.prisma.patientPortalInvite.findMany({
-        where: { patientId: canonicalPatientId },
-      }),
-      this.prisma.patientPortalInvite.findMany({
-        where: { patientId: sourcePatientId },
-      }),
-    ]);
-
-    if (!canonicalPatient || !sourcePatient) {
-      throw new NotFoundException('Patient not found');
-    }
-    if (canonicalPatient.mergedIntoPatientId) {
-      throw new ConflictException('Canonical patient has already been merged into another chart');
-    }
-    if (sourcePatient.mergedIntoPatientId) {
-      throw new ConflictException('Source patient has already been merged into another chart');
-    }
-    if (canonicalPatient.primaryClinicId !== sourcePatient.primaryClinicId) {
-      throw new BadRequestException('Patient merge is limited to records in the same clinic');
-    }
-
-    const retainedPortalLink =
-      options?.portalLinkStrategy === 'SOURCE' && sourceLink
-        ? sourceLink
-        : (canonicalLink ?? sourceLink ?? null);
-    const retainedPortalUser =
-      retainedPortalLink != null
-        ? await this.prisma.user.findUnique({
-            where: { keycloakSub: retainedPortalLink.keycloakSub },
-            select: { id: true },
-          })
-        : null;
-    const retainedPortalUserId =
-      options?.portalLinkStrategy === 'SOURCE' && sourcePatient.portalUserId
-        ? sourcePatient.portalUserId
-        : (canonicalPatient.portalUserId ??
-          sourcePatient.portalUserId ??
-          retainedPortalUser?.id ??
-          null);
-    const inviteStrategy = options?.inviteStrategy ?? 'MERGE';
-    const mergedAt = new Date();
-    const sourceLegacyCode = sourcePatient.patientCode;
-    const tombstonePatientCode = this.buildMergedPatientCode(sourceLegacyCode, sourcePatient.id);
-
-    await this.prisma.$transaction(async (tx) => {
-      await tx.encounter.updateMany({
-        where: { patientId: sourcePatientId },
-        data: { patientId: canonicalPatientId },
-      });
-      await tx.patientConsent.updateMany({
-        where: { patientId: sourcePatientId },
-        data: { patientId: canonicalPatientId },
-      });
-      await tx.reminder.updateMany({
-        where: { patientId: sourcePatientId },
-        data: { patientId: canonicalPatientId },
-      });
-      await tx.patientSelfReport.updateMany({
-        where: { patientId: sourcePatientId },
-        data: { patientId: canonicalPatientId },
-      });
-      await tx.patientMeasurement.updateMany({
-        where: { patientId: sourcePatientId },
-        data: { patientId: canonicalPatientId },
-      });
-      await tx.patientCheckIn.updateMany({
-        where: { patientId: sourcePatientId },
-        data: { patientId: canonicalPatientId },
-      });
-      await tx.appointmentRequest.updateMany({
-        where: { patientId: sourcePatientId },
-        data: { patientId: canonicalPatientId },
-      });
-      await tx.appointment.updateMany({
-        where: { patientId: sourcePatientId },
-        data: { patientId: canonicalPatientId },
-      });
-
-      await tx.patientAccountLink.deleteMany({
-        where: {
-          patientId: {
-            in: [canonicalPatientId, sourcePatientId],
-          },
-        },
-      });
-
-      if (retainedPortalLink) {
-        await tx.patientAccountLink.create({
-          data: {
-            patientId: canonicalPatientId,
-            keycloakSub: retainedPortalLink.keycloakSub,
-          },
-        });
-      }
-
-      const sourcePendingInviteIds = sourceInvites
-        .filter((invite) => invite.status === 'PENDING')
-        .map((invite) => invite.id);
-      const canonicalPendingInviteIds = canonicalInvites
-        .filter((invite) => invite.status === 'PENDING')
-        .map((invite) => invite.id);
-
-      if (inviteStrategy === 'CANONICAL' && sourcePendingInviteIds.length > 0) {
-        await tx.patientPortalInvite.updateMany({
-          where: { id: { in: sourcePendingInviteIds } },
-          data: {
-            patientId: canonicalPatientId,
-            status: 'CANCELLED',
-            cancelledAt: mergedAt,
-          },
-        });
-      } else if (inviteStrategy === 'SOURCE') {
-        if (canonicalPendingInviteIds.length > 0) {
-          await tx.patientPortalInvite.updateMany({
-            where: { id: { in: canonicalPendingInviteIds } },
-            data: {
-              status: 'CANCELLED',
-              cancelledAt: mergedAt,
-            },
-          });
-        }
-        await tx.patientPortalInvite.updateMany({
-          where: { patientId: sourcePatientId },
-          data: { patientId: canonicalPatientId },
-        });
-      } else {
-        await tx.patientPortalInvite.updateMany({
-          where: { patientId: sourcePatientId },
-          data: { patientId: canonicalPatientId },
-        });
-      }
-
-      if (sourcePatient.codeAliases.length > 0) {
-        await tx.patientCodeAlias.createMany({
-          data: sourcePatient.codeAliases.map((alias) => ({
-            patientId: canonicalPatientId,
-            code: alias.code,
-          })),
-          skipDuplicates: true,
-        });
-        await tx.patientCodeAlias.deleteMany({
-          where: { patientId: sourcePatientId },
-        });
-      }
-
-      await tx.patient.update({
-        where: { id: canonicalPatientId },
-        data: {
-          portalUserId: retainedPortalUserId,
-        },
-      });
-
-      await tx.patient.update({
-        where: { id: sourcePatientId },
-        data: {
-          patientCode: tombstonePatientCode,
-          portalUserId: null,
-          mergedIntoPatientId: canonicalPatientId,
-          mergedAt,
-          mergedByUserId: actor.userId,
-        },
-      });
-
-      await tx.patientCodeAlias.create({
-        data: {
-          patientId: canonicalPatientId,
-          code: sourceLegacyCode,
-        },
-      });
-
-      if (retainedPortalUserId) {
-        await tx.userClinicRole.upsert({
-          where: {
-            userId_clinicId_role: {
-              userId: retainedPortalUserId,
-              clinicId: canonicalPatient.primaryClinicId,
-              role: UserRole.PATIENT,
-            },
-          },
-          create: {
-            userId: retainedPortalUserId,
-            clinicId: canonicalPatient.primaryClinicId,
-            role: UserRole.PATIENT,
-          },
-          update: {},
-        });
-      }
-    });
-
-    await this.auditService.logWrite({
-      clinicId: canonicalPatient.primaryClinicId,
-      actorUserId: actor.userId,
-      action: 'PATIENT.MERGE',
-      entityType: 'Patient',
-      entityId: canonicalPatientId,
-      beforeJson: JSON.stringify({
-        canonicalPatientId,
-        sourcePatientId,
-        sourcePatientCode: sourceLegacyCode,
-      }),
-      afterJson: JSON.stringify({
-        canonicalPatientId,
-        sourcePatientId,
-        sourcePatientCode: sourceLegacyCode,
-        retainedPortalLinkKeycloakSub: retainedPortalLink?.keycloakSub ?? null,
-        retainedPortalUserId,
-      }),
-      requestId,
-    });
-
-    return {
-      success: true,
-      canonicalPatientId,
-      canonicalPatientCode: canonicalPatient.patientCode,
-      mergedPatientId: sourcePatientId,
-      mergedPatientCodeAlias: sourceLegacyCode,
-    };
   }
 
   async revokeClinicRole(
@@ -901,7 +641,7 @@ export class AdminService {
   }
 
   private isSystemAdmin(actor: AdminActor) {
-    return actor.roles.some((r) => r.role === UserRole.SYSTEM_ADMIN && r.clinicId === null);
+    return isSystemAdmin(actor.roles);
   }
 
   private async toAdminUserSummaries(users: UserWithRolesAndClinics[]) {
@@ -1117,10 +857,7 @@ export class AdminService {
       );
     }
 
-    const isSystemAdmin = actor.roles.some(
-      (r) => r.role === UserRole.SYSTEM_ADMIN && r.clinicId === null,
-    );
-    if (isSystemAdmin) return;
+    if (isSystemAdmin(actor.roles)) return;
 
     if (role === UserRole.SYSTEM_ADMIN || role === UserRole.DIRECTOR) {
       throw new ForbiddenException('Only System Admin can assign SYSTEM_ADMIN or DIRECTOR roles');
@@ -1136,10 +873,7 @@ export class AdminService {
   }
 
   private validateRemoveRole(actor: AdminActor, clinicId: string | null, role: UserRole) {
-    const isSystemAdmin = actor.roles.some(
-      (r) => r.role === UserRole.SYSTEM_ADMIN && r.clinicId === null,
-    );
-    if (isSystemAdmin) return;
+    if (isSystemAdmin(actor.roles)) return;
 
     if (role === UserRole.SYSTEM_ADMIN || role === UserRole.DIRECTOR) {
       throw new ForbiddenException('Only System Admin can remove SYSTEM_ADMIN or DIRECTOR roles');
@@ -1152,11 +886,5 @@ export class AdminService {
     if (!isDirectorOfClinic) {
       throw new ForbiddenException('You can only remove roles for clinics you direct');
     }
-  }
-
-  private buildMergedPatientCode(sourceCode: string, patientId: string) {
-    const suffix = patientId.replace(/-/g, '').slice(0, 8).toUpperCase();
-    const candidate = `${sourceCode}-M-${suffix}`;
-    return candidate.slice(0, 32);
   }
 }

--- a/apps/api/src/admin/dto/merge-patients.dto.ts
+++ b/apps/api/src/admin/dto/merge-patients.dto.ts
@@ -1,4 +1,4 @@
-import { IsIn, IsOptional, IsUUID } from 'class-validator';
+import { IsIn, IsOptional, IsUUID, Matches } from 'class-validator';
 
 export class MergePatientsDto {
   @IsUUID()
@@ -14,4 +14,16 @@ export class MergePatientsDto {
   @IsOptional()
   @IsIn(['CANONICAL', 'SOURCE', 'MERGE'])
   inviteStrategy?: 'CANONICAL' | 'SOURCE' | 'MERGE';
+
+  /**
+   * The fingerprint the preview returned.
+   *
+   * Optional so an existing caller keeps working, but the web client always sends it: without it
+   * an operator can commit a merge against a panel that a concurrent edit, portal claim or
+   * competing merge has already made untrue, which is the window a preview otherwise widens
+   * rather than closes.
+   */
+  @IsOptional()
+  @Matches(/^[0-9a-f]{16}$/)
+  previewFingerprint?: string;
 }

--- a/apps/api/src/auth/clinic-roles.ts
+++ b/apps/api/src/auth/clinic-roles.ts
@@ -33,6 +33,21 @@ export function rolesForClinic(
     .map((entry) => ({ role: entry.role }));
 }
 
+/**
+ * Whether a user is a system administrator.
+ *
+ * The seat is global by definition, so the role must be held with no clinic attached: a
+ * SYSTEM_ADMIN row carrying a clinicId is a clinic-scoped grant and does not confer the global
+ * seat. That predicate was being re-implemented inline at every call site, and a boundary
+ * restated in many places is a boundary that will eventually disagree with itself. The admin and
+ * duplicate-review services now share this one; the remaining copies in clinic.service,
+ * clinics-admin.controller, auth.controller and prisma-rls.interceptor are the same expression
+ * and should fold into it, but they are on no path this change touches.
+ */
+export function isSystemAdmin(roles: readonly ScopedRole[]): boolean {
+  return roles.some((entry) => entry.role === UserRole.SYSTEM_ADMIN && entry.clinicId === null);
+}
+
 /** Effective permission strings for a user at one clinic. `'*'` means system admin. */
 export function permissionsForClinic(
   roles: readonly ScopedRole[],

--- a/apps/api/src/auth/constants/permissions.ts
+++ b/apps/api/src/auth/constants/permissions.ts
@@ -77,6 +77,17 @@ export const PERMISSIONS = {
   PATIENT_PORTAL_LINK: 'PATIENT.PORTAL.LINK',
   // Admin: review suspected duplicate charts. Read-only; merging stays SYSTEM_ADMIN only.
   PATIENT_DUPLICATE_REVIEW: 'PATIENT.DUPLICATE.REVIEW',
+  /*
+    Admin: preview and execute a chart merge.
+
+    Granted to no role in ROLE_PERMISSIONS below. SYSTEM_ADMIN holds it through its '*' wildcard
+    and nobody else can, which is the point: merge previously sat behind the class-level
+    CLINIC_MANAGE on AdminController, so a director reached the service and was turned away there.
+    Naming the permission moves that refusal up to the guard, and PatientMergeService still
+    asserts the seat itself -- a boundary that depends on one layer is one refactor from not
+    being a boundary.
+  */
+  PATIENT_MERGE: 'PATIENT.MERGE',
   // Chat
   CHAT_SEND: 'CHAT.SEND',
   CHAT_READ: 'CHAT.READ',

--- a/apps/api/src/auth/permissions.spec.ts
+++ b/apps/api/src/auth/permissions.spec.ts
@@ -46,6 +46,20 @@ describe('OPS permissions', () => {
     expect(computeEffectivePermissions([UserRole.SYSTEM_ADMIN])).toEqual(['*']);
   });
 
+  it('gives merge to nobody but the wildcard', () => {
+    // Consolidating two records is irreversible, so the seat is deliberately unreachable by
+    // grant: only SYSTEM_ADMIN's '*' satisfies it, and adding the permission to any role's list
+    // would be a policy change rather than a refactor.
+    for (const role of Object.values(UserRole)) {
+      const permissions = computeEffectivePermissions([role]);
+      if (role === UserRole.SYSTEM_ADMIN) {
+        expect(permissions).toEqual(['*']);
+      } else {
+        expect(permissions).not.toContain(PERMISSIONS.PATIENT_MERGE);
+      }
+    }
+  });
+
   it('grants managers clinic scope but not org-wide research export approval', () => {
     const permissions = computeEffectivePermissions([UserRole.MANAGER]);
 

--- a/apps/api/src/clinics/clinics-patients.controller.ts
+++ b/apps/api/src/clinics/clinics-patients.controller.ts
@@ -21,11 +21,13 @@ import { RbacGuard } from '../auth/guards/rbac.guard';
 import { ClinicScopeGuard } from '../auth/guards/clinic-scope.guard';
 import { PatientService } from '../patients/patient.service';
 import { PatientDuplicateService } from '../patients/patient-duplicate.service';
+import { PatientMergeService } from '../patients/patient-merge.service';
 import { PatientPortalService } from '../patient-portal/patient-portal.service';
 import { CreatePatientBodyDto } from '../patients/dto/create-patient-body.dto';
 import { ListPatientRegistryQueryDto } from '../patients/dto/list-patient-registry.query.dto';
 import { ListDuplicateCandidatesQueryDto } from '../patients/dto/list-duplicate-candidates.query.dto';
 import { ReviewDuplicatePairDto } from '../patients/dto/review-duplicate-pair.dto';
+import { MergePreviewQueryDto } from '../patients/dto/merge-preview.query.dto';
 import { LinkPortalDto } from '../patient-portal/dto/link-portal.dto';
 import { CreatePatientPortalInviteDto } from '../patient-portal/dto/portal-invite.dto';
 import { UpdatePatientBodyDto } from '../patients/dto/update-patient-body.dto';
@@ -59,6 +61,7 @@ export class ClinicsPatientsController {
     private readonly patientService: PatientService,
     private readonly patientPortalService: PatientPortalService,
     private readonly patientDuplicateService: PatientDuplicateService,
+    private readonly patientMergeService: PatientMergeService,
   ) {}
 
   @Post()
@@ -146,6 +149,33 @@ export class ClinicsPatientsController {
       { clinicId: params.clinicId },
       body,
       req.headers?.['x-request-id'] ?? randomUUID(),
+    );
+  }
+
+  /**
+   * What merging `sourcePatientId` into this chart would do.
+   *
+   * Read-only, and system-admin only: PATIENT.MERGE is held by no role except through
+   * SYSTEM_ADMIN's wildcard, and `PatientMergeService` asserts the seat again below the guard.
+   * It lives here rather than only under /admin because this is the chart the operator is
+   * looking at, so the request carries the clinic and `ClinicScopeGuard` can narrow it.
+   */
+  @Get(':patientId/merge-preview')
+  @ClinicScoped({ type: 'param', paramKey: 'clinicId' })
+  @RequirePermission(PERMISSIONS.PATIENT_MERGE)
+  async previewMerge(
+    @Param() params: ClinicAndPatientParamsDto,
+    @Query() query: MergePreviewQueryDto,
+    @Request() req: { user: ReqUserWithRoles },
+  ) {
+    return this.patientMergeService.preview(
+      { userId: req.user.user.id, roles: req.user.roles },
+      params.patientId,
+      query.sourcePatientId,
+      {
+        portalLinkStrategy: query.portalLinkStrategy,
+        inviteStrategy: query.inviteStrategy,
+      },
     );
   }
 

--- a/apps/api/src/common/error-response.ts
+++ b/apps/api/src/common/error-response.ts
@@ -10,4 +10,12 @@ export interface ApiErrorResponse {
   retryable: boolean;
   fieldErrors?: ApiFieldError[];
   recoveryAction?: string;
+  /**
+   * Structured context a client can render, when a sentence is not enough.
+   *
+   * Only ever what the throwing service put there deliberately: the filter copies this key and
+   * drops every other extra field on the payload, so an exception cannot leak internals into a
+   * response by accident.
+   */
+  details?: Record<string, unknown>;
 }

--- a/apps/api/src/common/http-exception.filter.ts
+++ b/apps/api/src/common/http-exception.filter.ts
@@ -78,6 +78,7 @@ export class ApiExceptionFilter implements ExceptionFilter {
     let code = fallbackCode(status);
     let fieldErrors: ApiFieldError[] | undefined;
     let recoveryAction: string | undefined;
+    let details: Record<string, unknown> | undefined;
 
     if (typeof exceptionResponse === 'string') {
       message = exceptionResponse;
@@ -98,6 +99,16 @@ export class ApiExceptionFilter implements ExceptionFilter {
 
       if (typeof payload.recoveryAction === 'string' && payload.recoveryAction.trim()) {
         recoveryAction = payload.recoveryAction;
+      }
+
+      // Deliberately the only extra key that survives. Anything else a thrower attached to the
+      // payload is dropped, so an exception cannot widen a response body by accident.
+      if (
+        payload.details &&
+        typeof payload.details === 'object' &&
+        !Array.isArray(payload.details)
+      ) {
+        details = payload.details as Record<string, unknown>;
       }
     } else if (exception instanceof Error && status < 500) {
       message = exception.message;
@@ -123,6 +134,7 @@ export class ApiExceptionFilter implements ExceptionFilter {
       retryable: status === HttpStatus.TOO_MANY_REQUESTS || status >= 500,
       ...(fieldErrors ? { fieldErrors } : {}),
       ...(recoveryAction ? { recoveryAction } : {}),
+      ...(details ? { details } : {}),
     };
 
     if (status >= 500) {

--- a/apps/api/src/patients/dto/merge-preview.query.dto.ts
+++ b/apps/api/src/patients/dto/merge-preview.query.dto.ts
@@ -1,0 +1,27 @@
+import { IsIn, IsOptional, IsUUID } from 'class-validator';
+
+/**
+ * Which duplicate to preview against, and under which strategies.
+ *
+ * The strategies are query parameters rather than a body because the preview is a GET: it writes
+ * nothing, and an operator flipping between "keep this chart's app account" and "keep the other
+ * one's" is asking a different read, not performing an action.
+ */
+export class MergePreviewQueryDto {
+  @IsUUID()
+  sourcePatientId!: string;
+
+  @IsOptional()
+  @IsIn(['CANONICAL', 'SOURCE'])
+  portalLinkStrategy?: 'CANONICAL' | 'SOURCE';
+
+  @IsOptional()
+  @IsIn(['CANONICAL', 'SOURCE', 'MERGE'])
+  inviteStrategy?: 'CANONICAL' | 'SOURCE' | 'MERGE';
+}
+
+/** The admin twin, which names both charts because it is not scoped to one already. */
+export class AdminMergePreviewQueryDto extends MergePreviewQueryDto {
+  @IsUUID()
+  canonicalPatientId!: string;
+}

--- a/apps/api/src/patients/index.ts
+++ b/apps/api/src/patients/index.ts
@@ -1,4 +1,5 @@
 export { PatientModule } from './patient.module';
 export { PatientService } from './patient.service';
 export { PatientRepository } from './patient.repository';
+export { PatientMergeService } from './patient-merge.service';
 export { CreatePatientDto } from './dto/create-patient.dto';

--- a/apps/api/src/patients/patient-duplicate.service.ts
+++ b/apps/api/src/patients/patient-duplicate.service.ts
@@ -6,6 +6,7 @@ import {
   type DuplicateConfidence,
   type DuplicateMatchReason,
 } from '@nkwapa/db';
+import { isSystemAdmin } from '../auth/clinic-roles';
 import { AuditService } from '../audit/audit.service';
 import { PrismaService } from '../prisma/prisma.service';
 import {
@@ -317,10 +318,7 @@ export class PatientDuplicateService {
    */
   private assertScopeAllowed(actor: DuplicateReviewActor, scope: DuplicateScope) {
     if (scope.clinicId) return;
-    const isSystemAdmin = actor.roles.some(
-      (role) => role.role === UserRole.SYSTEM_ADMIN && role.clinicId === null,
-    );
-    if (!isSystemAdmin) {
+    if (!isSystemAdmin(actor.roles)) {
       throw new ForbiddenException(
         'Only System Admin can review suspected duplicates across clinics',
       );

--- a/apps/api/src/patients/patient-merge.controller.spec.ts
+++ b/apps/api/src/patients/patient-merge.controller.spec.ts
@@ -1,0 +1,132 @@
+import { Reflector } from '@nestjs/core';
+import { AdminController } from '../admin/admin.controller';
+import { ClinicsPatientsController } from '../clinics/clinics-patients.controller';
+import { PERMISSIONS } from '../auth/constants/permissions';
+
+/**
+ * The routes that reach `PatientMergeService`.
+ *
+ * Guards are not exercised here -- the suite has no HTTP layer -- so what these assert is the
+ * metadata the guards read plus the arguments each route forwards. Authorization itself is
+ * proved in `patient-merge.service.spec.ts`, which is also the layer that would still refuse if
+ * a decorator were removed.
+ */
+describe('patient merge routes', () => {
+  const reflector = new Reflector();
+  const request = {
+    user: { user: { id: 'sysadmin-1' }, roles: [{ clinicId: null, role: 'SYSTEM_ADMIN' }] },
+    headers: { 'x-request-id': 'req-1' },
+  };
+
+  function permissionOf(target: object, handler: string): string | undefined {
+    return reflector.get<string>(
+      'requirePermission',
+      (target as Record<string, () => unknown>)[handler],
+    );
+  }
+
+  describe('the chart-scoped preview', () => {
+    const patientMergeService = { preview: jest.fn().mockResolvedValue({ canMerge: true }) };
+    const controller = new ClinicsPatientsController(
+      {} as never,
+      {} as never,
+      {} as never,
+      patientMergeService as never,
+    );
+
+    beforeEach(() => jest.clearAllMocks());
+
+    it('requires the merge permission, which no role but the wildcard holds', () => {
+      expect(permissionOf(ClinicsPatientsController.prototype, 'previewMerge')).toBe(
+        PERMISSIONS.PATIENT_MERGE,
+      );
+    });
+
+    it('previews against the chart in the path, not one named in the query', async () => {
+      await controller.previewMerge(
+        { clinicId: 'clinic-1', patientId: 'patient-1' },
+        { sourcePatientId: 'patient-2' },
+        request as never,
+      );
+
+      expect(patientMergeService.preview).toHaveBeenCalledWith(
+        { userId: 'sysadmin-1', roles: request.user.roles },
+        'patient-1',
+        'patient-2',
+        { portalLinkStrategy: undefined, inviteStrategy: undefined },
+      );
+    });
+
+    it('passes the strategies through, so the panel can answer a different question', async () => {
+      await controller.previewMerge(
+        { clinicId: 'clinic-1', patientId: 'patient-1' },
+        { sourcePatientId: 'patient-2', portalLinkStrategy: 'SOURCE', inviteStrategy: 'CANONICAL' },
+        request as never,
+      );
+
+      expect(patientMergeService.preview).toHaveBeenCalledWith(
+        expect.anything(),
+        'patient-1',
+        'patient-2',
+        { portalLinkStrategy: 'SOURCE', inviteStrategy: 'CANONICAL' },
+      );
+    });
+  });
+
+  describe('the admin routes', () => {
+    const patientMergeService = {
+      preview: jest.fn().mockResolvedValue({ canMerge: true }),
+      merge: jest.fn().mockResolvedValue({ success: true }),
+    };
+    const controller = new AdminController({} as never, {} as never, patientMergeService as never);
+
+    beforeEach(() => jest.clearAllMocks());
+
+    /*
+      The gap this closes. Merge used to sit behind the class-level CLINIC_MANAGE, which a
+      director and a manager both hold, so they reached the service and were refused there. The
+      refusal is now at the guard, and the service still refuses independently.
+    */
+    it('lifts both merge routes off the class-level CLINIC_MANAGE', () => {
+      expect(reflector.get<string>('requirePermission', AdminController)).toBe(
+        PERMISSIONS.CLINIC_MANAGE,
+      );
+      for (const handler of ['previewMerge', 'mergePatients']) {
+        expect(permissionOf(AdminController.prototype, handler)).toBe(PERMISSIONS.PATIENT_MERGE);
+      }
+    });
+
+    it('takes both chart ids from the query, since no clinic scopes the request', async () => {
+      await controller.previewMerge(
+        { canonicalPatientId: 'patient-1', sourcePatientId: 'patient-2' },
+        request as never,
+      );
+
+      expect(patientMergeService.preview).toHaveBeenCalledWith(
+        { userId: 'sysadmin-1', roles: request.user.roles },
+        'patient-1',
+        'patient-2',
+        { portalLinkStrategy: undefined, inviteStrategy: undefined },
+      );
+    });
+
+    it('forwards the preview fingerprint so a stale panel cannot be committed', async () => {
+      await controller.mergePatients(
+        {
+          canonicalPatientId: 'patient-1',
+          sourcePatientId: 'patient-2',
+          previewFingerprint: 'abcdef0123456789',
+        },
+        request as never,
+      );
+
+      expect(patientMergeService.merge).toHaveBeenCalledWith(
+        { userId: 'sysadmin-1', roles: request.user.roles },
+        'patient-1',
+        'patient-2',
+        expect.objectContaining({ expectedFingerprint: 'abcdef0123456789' }),
+        'req-1',
+      );
+    });
+  });
+});

--- a/apps/api/src/patients/patient-merge.service.spec.ts
+++ b/apps/api/src/patients/patient-merge.service.spec.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, ConflictException, ForbiddenException } from '@nestjs/common';
-import { UserRole } from '@prisma/client';
+import { Prisma, UserRole } from '@prisma/client';
 import { MERGE_RELATIONS } from '@nkwapa/db';
 import { PatientMergeService, type MergeActor } from './patient-merge.service';
 
@@ -157,6 +157,35 @@ function stubCharts(prisma: PrismaMock, canonical = canonicalChart(), source = s
 async function findingCodes(promise: Promise<{ findings: { code: string }[] }>) {
   return (await promise).findings.map((finding) => finding.code);
 }
+
+describe('the relation keys the merge loop indexes by', () => {
+  /*
+    MERGE_RELATIONS lives in @nkwapa/db, which cannot import the generated Prisma client, so its
+    keys are plain strings and the loop reaches the delegates through a cast. A typo there would
+    not fail to compile -- it would throw at runtime, part-way through an irreversible merge.
+    Prisma.ModelName is generated, so checking against it costs nothing and closes that gap.
+  */
+  const modelNames = new Set<string>(Object.values(Prisma.ModelName));
+
+  it.each(MERGE_RELATIONS.map((relation) => relation.key))(
+    '%s names a real Prisma model',
+    (key) => {
+      expect(modelNames).toContain(key.charAt(0).toUpperCase() + key.slice(1));
+    },
+  );
+
+  it('covers the models the merge reaches for by hand as well', () => {
+    for (const model of [
+      'PatientMergeRecord',
+      'PatientDuplicateReview',
+      'PatientCodeAlias',
+      'PatientAccountLink',
+      'PatientPortalInvite',
+    ]) {
+      expect(modelNames).toContain(model);
+    }
+  });
+});
 
 describe('PatientMergeService.evaluate', () => {
   it('refuses anyone who is not a system administrator', async () => {

--- a/apps/api/src/patients/patient-merge.service.spec.ts
+++ b/apps/api/src/patients/patient-merge.service.spec.ts
@@ -36,6 +36,8 @@ type ChartOverrides = Partial<{
   nationalIdHash: string | null;
   nationalIdType: string | null;
   nationalIdLast4: string | null;
+  sex: string;
+  createdAt: Date;
   updatedAt: Date;
   codeAliases: { code: string }[];
 }>;
@@ -61,6 +63,8 @@ function chart(overrides: ChartOverrides = {}) {
     nationalIdHash: overrides.nationalIdHash ?? 'hash-a',
     nationalIdType: overrides.nationalIdType ?? 'NATIONAL_ID',
     nationalIdLast4: overrides.nationalIdLast4 ?? '4471',
+    sex: overrides.sex ?? 'FEMALE',
+    createdAt: overrides.createdAt ?? new Date('2026-01-05T08:00:00.000Z'),
     updatedAt: overrides.updatedAt ?? new Date('2026-09-04T09:00:00.000Z'),
     codeAliases: overrides.codeAliases ?? [],
   };
@@ -457,6 +461,150 @@ describe('PatientMergeService.evaluate', () => {
     const after = await service.evaluate(systemAdmin, 'patient-1', 'patient-2');
 
     expect(after.fingerprint).not.toBe(before.fingerprint);
+  });
+});
+
+describe('PatientMergeService.preview', () => {
+  it('publishes both charts in the shape the duplicate queue already uses', async () => {
+    const { service, prisma } = createService();
+    stubCharts(prisma);
+
+    const preview = await service.preview(systemAdmin, 'patient-1', 'patient-2');
+
+    // Same field set as DuplicateCandidatePatient, so one comparison table serves both screens.
+    for (const side of [preview.canonical, preview.source]) {
+      expect(Object.keys(side).sort()).toEqual(
+        [
+          'clinic',
+          'createdAt',
+          'dob',
+          'email',
+          'firstName',
+          'id',
+          'lastName',
+          'nationalIdLast4',
+          'nationalIdType',
+          'patientCode',
+          'phoneE164',
+          'portalLinked',
+          'sex',
+          'updatedAt',
+        ].sort(),
+      );
+      expect(side.clinic).toEqual({
+        id: 'clinic-1',
+        name: 'Clinic One',
+        organizationId: 'org-1',
+        organizationName: 'Akomapa',
+      });
+    }
+    expect(preview.canonical.dob).toBe('1988-07-04T00:00:00.000Z');
+  });
+
+  it('never carries the national ID itself, only its last four digits', async () => {
+    const { service, prisma } = createService();
+    stubCharts(prisma);
+
+    const preview = await service.preview(systemAdmin, 'patient-1', 'patient-2');
+    const serialized = JSON.stringify(preview);
+
+    expect(serialized).not.toContain('nationalIdCiphertext');
+    expect(serialized).not.toContain('hash-a');
+    expect(preview.source.nationalIdLast4).toBe('4472');
+  });
+
+  it('splits findings into what stops the merge and what merely warns about it', async () => {
+    const { service, prisma } = createService({ relationCounts: { encounter: [0, 3] } });
+    prisma.patient.findUnique.mockImplementation(async (args: { where: { id: string } }) =>
+      args.where.id === 'patient-1'
+        ? canonicalChart()
+        : chart({
+            ...sourceChart(),
+            primaryClinicId: 'clinic-2',
+            primaryClinic: { ...CLINIC, id: 'clinic-2', name: 'Clinic Two' },
+          }),
+    );
+
+    const preview = await service.preview(systemAdmin, 'patient-1', 'patient-2');
+
+    expect(preview.blockers.map((f) => f.code)).toEqual(['CROSS_CLINIC']);
+    expect(preview.warnings.map((f) => f.code)).toContain('SOURCE_HAS_MORE_HISTORY');
+    expect(preview.blockers.every((f) => f.severity === 'BLOCK')).toBe(true);
+    expect(preview.warnings.every((f) => f.severity === 'WARN')).toBe(true);
+    expect(preview.canMerge).toBe(false);
+  });
+
+  it('says what each finding means and what to do about it', async () => {
+    const { service, prisma } = createService();
+    stubCharts(prisma);
+    prisma.patientCodeAlias.findMany.mockResolvedValue([{ code: 'NKP-2026-000099' }]);
+
+    const preview = await service.preview(systemAdmin, 'patient-1', 'patient-2');
+
+    const blocker = preview.blockers[0];
+    expect(blocker.label).not.toMatch(/^[A-Z_]+$/);
+    expect(blocker.recovery.length).toBeGreaterThan(20);
+  });
+
+  it('reports the whole relation list, including the ones with nothing to move', async () => {
+    const { service, prisma } = createService({ relationCounts: { encounter: [2, 1] } });
+    stubCharts(prisma);
+
+    const preview = await service.preview(systemAdmin, 'patient-1', 'patient-2');
+
+    // An empty row is information: it says the duplicate holds no notes, rather than leaving an
+    // operator to wonder whether notes were checked at all.
+    expect(preview.relations).toHaveLength(MERGE_RELATIONS.length);
+    expect(preview.relations.every((row) => typeof row.label === 'string')).toBe(true);
+  });
+
+  it('states the strategies it answered under, including the defaults', async () => {
+    const { service, prisma } = createService();
+    stubCharts(prisma);
+
+    expect((await service.preview(systemAdmin, 'patient-1', 'patient-2')).strategies).toEqual({
+      portalLinkStrategy: 'CANONICAL',
+      inviteStrategy: 'MERGE',
+    });
+    expect(
+      (
+        await service.preview(systemAdmin, 'patient-1', 'patient-2', {
+          portalLinkStrategy: 'SOURCE',
+        })
+      ).strategies.portalLinkStrategy,
+    ).toBe('SOURCE');
+  });
+
+  it('carries a fingerprint the merge will accept', async () => {
+    const { service, prisma } = createService();
+    stubCharts(prisma);
+
+    const preview = await service.preview(systemAdmin, 'patient-1', 'patient-2');
+
+    expect(preview.fingerprint).toMatch(/^[0-9a-f]{16}$/);
+    await expect(
+      service.merge(systemAdmin, 'patient-1', 'patient-2', {
+        expectedFingerprint: preview.fingerprint,
+      }),
+    ).resolves.toMatchObject({ success: true });
+  });
+
+  it('does not leak the rows the transaction needs into the payload', async () => {
+    const { service, prisma } = createService();
+    stubCharts(prisma);
+
+    const preview = await service.preview(systemAdmin, 'patient-1', 'patient-2');
+
+    expect(preview).not.toHaveProperty('portalRows');
+    expect(preview).not.toHaveProperty('findings');
+  });
+
+  it('is refused to anyone who is not a system administrator', async () => {
+    const { service, prisma } = createService();
+    stubCharts(prisma);
+    await expect(service.preview(director, 'patient-1', 'patient-2')).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
   });
 });
 

--- a/apps/api/src/patients/patient-merge.service.spec.ts
+++ b/apps/api/src/patients/patient-merge.service.spec.ts
@@ -724,6 +724,70 @@ describe('PatientMergeService.merge', () => {
     });
   });
 
+  it('moves every invitation, whatever state it is in', async () => {
+    const { service, prisma } = createService();
+    stubCharts(prisma);
+    prisma.patientPortalInvite.findMany.mockImplementation(
+      async (args: { where: { patientId: string } }) =>
+        args.where.patientId === 'patient-2'
+          ? [
+              { id: 'invite-pending', status: 'PENDING' },
+              { id: 'invite-claimed', status: 'CLAIMED' },
+            ]
+          : [],
+    );
+    prisma.patientPortalInvite.updateMany.mockResolvedValue({ count: 2 });
+
+    await service.merge(systemAdmin, 'patient-1', 'patient-2', {
+      inviteStrategy: 'CANONICAL',
+    });
+
+    // The unclaimed one is cancelled by name...
+    expect(prisma.patientPortalInvite.updateMany).toHaveBeenCalledWith({
+      where: { id: { in: ['invite-pending'] } },
+      data: { status: 'CANCELLED', cancelledAt: expect.any(Date) },
+    });
+    /*
+      ...and then everything the retired chart held is repointed, claimed rows included. The
+      CANONICAL branch used to move only the PENDING ones, leaving a claimed invitation -- a
+      record of a real exchange with this patient -- on a chart nobody can open.
+    */
+    expect(prisma.patientPortalInvite.updateMany).toHaveBeenCalledWith({
+      where: { patientId: 'patient-2' },
+      data: { patientId: 'patient-1' },
+    });
+  });
+
+  it('counts the invitations it moved, not the ones the survivor already had', async () => {
+    const { service, prisma } = createService();
+    stubCharts(prisma);
+    prisma.patientPortalInvite.updateMany.mockResolvedValue({ count: 2 });
+    // Would be the total on the surviving chart if this were read back with a count().
+    prisma.patientPortalInvite.count.mockResolvedValue(9);
+
+    await service.merge(systemAdmin, 'patient-1', 'patient-2');
+
+    const record = prisma.patientMergeRecord.create.mock.calls[0][0].data;
+    expect(JSON.parse(record.movedCountsJson).patientPortalInvite).toBe(2);
+  });
+
+  it('counts the aliases actually carried across, not the ones offered', async () => {
+    const { service, prisma } = createService();
+    stubCharts(
+      prisma,
+      canonicalChart(),
+      chart({ ...sourceChart(), codeAliases: [{ code: 'OLD-1' }, { code: 'OLD-2' }] }),
+    );
+    // skipDuplicates: the surviving chart already answered to one of them.
+    prisma.patientCodeAlias.createMany.mockResolvedValue({ count: 1 });
+
+    await service.merge(systemAdmin, 'patient-1', 'patient-2');
+
+    const record = prisma.patientMergeRecord.create.mock.calls[0][0].data;
+    // One carried across, plus the code the retired chart gives up.
+    expect(JSON.parse(record.movedCountsJson).patientCodeAlias).toBe(2);
+  });
+
   it('records what it moved, so the merge can be explained later', async () => {
     const { service, prisma } = createService({ relationCounts: { encounter: [0, 5] } });
     stubCharts(prisma);

--- a/apps/api/src/patients/patient-merge.service.spec.ts
+++ b/apps/api/src/patients/patient-merge.service.spec.ts
@@ -1,0 +1,670 @@
+import { BadRequestException, ConflictException, ForbiddenException } from '@nestjs/common';
+import { UserRole } from '@prisma/client';
+import { MERGE_RELATIONS } from '@nkwapa/db';
+import { PatientMergeService, type MergeActor } from './patient-merge.service';
+
+const systemAdmin: MergeActor = {
+  userId: 'sysadmin-1',
+  roles: [{ clinicId: null, role: UserRole.SYSTEM_ADMIN }],
+};
+
+const director: MergeActor = {
+  userId: 'director-1',
+  roles: [{ clinicId: 'clinic-1', role: UserRole.DIRECTOR }],
+};
+
+const CLINIC = {
+  id: 'clinic-1',
+  name: 'Clinic One',
+  isActive: true,
+  organizationId: 'org-1',
+  organization: { name: 'Akomapa' },
+};
+
+type ChartOverrides = Partial<{
+  id: string;
+  patientCode: string;
+  primaryClinicId: string;
+  primaryClinic: typeof CLINIC;
+  portalUserId: string | null;
+  mergedIntoPatientId: string | null;
+  firstName: string;
+  lastName: string;
+  dob: Date | null;
+  phoneE164: string | null;
+  email: string | null;
+  nationalIdHash: string | null;
+  nationalIdType: string | null;
+  nationalIdLast4: string | null;
+  updatedAt: Date;
+  codeAliases: { code: string }[];
+}>;
+
+/*
+  Both fixtures share a name, a birthday and a phone number by default, so the duplicate
+  heuristics score them HIGH. That matters: at LOW the evaluation raises WEAK_DUPLICATE_SIGNAL,
+  and every unrelated assertion would then be reading a findings list with an extra entry in it.
+*/
+function chart(overrides: ChartOverrides = {}) {
+  return {
+    id: overrides.id ?? 'patient-1',
+    patientCode: overrides.patientCode ?? 'NKP-2026-000001',
+    primaryClinicId: overrides.primaryClinicId ?? 'clinic-1',
+    primaryClinic: overrides.primaryClinic ?? CLINIC,
+    portalUserId: overrides.portalUserId ?? null,
+    mergedIntoPatientId: overrides.mergedIntoPatientId ?? null,
+    firstName: overrides.firstName ?? 'Akua',
+    lastName: overrides.lastName ?? 'Boateng',
+    dob: overrides.dob === undefined ? new Date('1988-07-04') : overrides.dob,
+    phoneE164: overrides.phoneE164 === undefined ? '+233209876543' : overrides.phoneE164,
+    email: overrides.email ?? null,
+    nationalIdHash: overrides.nationalIdHash ?? 'hash-a',
+    nationalIdType: overrides.nationalIdType ?? 'NATIONAL_ID',
+    nationalIdLast4: overrides.nationalIdLast4 ?? '4471',
+    updatedAt: overrides.updatedAt ?? new Date('2026-09-04T09:00:00.000Z'),
+    codeAliases: overrides.codeAliases ?? [],
+  };
+}
+
+const canonicalChart = () => chart();
+const sourceChart = () =>
+  chart({
+    id: 'patient-2',
+    patientCode: 'NKP-2026-000099',
+    nationalIdHash: 'hash-b',
+    nationalIdLast4: '4472',
+    updatedAt: new Date('2026-09-04T09:30:00.000Z'),
+  });
+
+/** A bag of jest mocks indexable by model name, which is how the relation loop reaches them. */
+type PrismaMock = Record<string, Record<string, jest.Mock>> & { $transaction: jest.Mock };
+
+function createService(options: { relationCounts?: Record<string, [number, number]> } = {}) {
+  const prisma: PrismaMock = {
+    patient: {
+      findUnique: jest.fn(),
+      update: jest.fn().mockResolvedValue({ id: 'patient-1' }),
+      updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+    },
+    patientAccountLink: {
+      findUnique: jest.fn().mockResolvedValue(null),
+      deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+      create: jest.fn().mockResolvedValue({ id: 'link-1' }),
+    },
+    patientCodeAlias: {
+      findMany: jest.fn().mockResolvedValue([]),
+      createMany: jest.fn().mockResolvedValue({ count: 0 }),
+      deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+      upsert: jest.fn().mockResolvedValue({ id: 'alias-1' }),
+    },
+    patientDuplicateReview: {
+      findUnique: jest.fn().mockResolvedValue(null),
+      deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+    },
+    patientMergeRecord: { create: jest.fn().mockResolvedValue({ id: 'merge-1' }) },
+    user: { findUnique: jest.fn().mockResolvedValue(null) },
+    userClinicRole: { upsert: jest.fn().mockResolvedValue({ id: 'role-1' }) },
+    $transaction: jest.fn(),
+  } as never;
+
+  // Every relation the merge moves gets the same two mocks, so a relation added to the shared
+  // list is exercised here without this file having to name it.
+  for (const relation of MERGE_RELATIONS) {
+    const [canonicalCount, sourceCount] = options.relationCounts?.[relation.key] ?? [0, 0];
+    prisma[relation.key] = {
+      ...(prisma[relation.key] ?? {}),
+      count: jest.fn(async (args: { where: { patientId: string; effectiveTo?: null } }) => {
+        // patientPharmacyPreference is counted twice for different questions: how many rows move,
+        // and how many are still open.
+        if (args.where.effectiveTo === null) return 0;
+        return args.where.patientId === 'patient-1' ? canonicalCount : sourceCount;
+      }),
+      updateMany: jest.fn().mockResolvedValue({ count: sourceCount }),
+    };
+  }
+  prisma.patientPortalInvite = {
+    ...prisma.patientPortalInvite,
+    findMany: jest.fn().mockResolvedValue([]),
+    updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+    count: jest.fn().mockResolvedValue(0),
+  };
+
+  prisma.$transaction.mockImplementation(async (callback: (tx: typeof prisma) => unknown) =>
+    callback(prisma),
+  );
+
+  const auditService = { logWrite: jest.fn().mockResolvedValue(undefined) };
+
+  return {
+    prisma,
+    auditService,
+    service: new PatientMergeService(prisma as never, auditService as never),
+  };
+}
+
+/** Point `patient.findUnique` at the two charts, for both the evaluation and the in-transaction recheck. */
+function stubCharts(prisma: PrismaMock, canonical = canonicalChart(), source = sourceChart()) {
+  prisma.patient.findUnique.mockImplementation(async (args: { where: { id: string } }) =>
+    args.where.id === canonical.id ? canonical : source,
+  );
+  return { canonical, source };
+}
+
+async function findingCodes(promise: Promise<{ findings: { code: string }[] }>) {
+  return (await promise).findings.map((finding) => finding.code);
+}
+
+describe('PatientMergeService.evaluate', () => {
+  it('refuses anyone who is not a system administrator', async () => {
+    const { service, prisma } = createService();
+    stubCharts(prisma);
+    await expect(service.evaluate(director, 'patient-1', 'patient-2')).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+    // The refusal must not have read a chart on the way to being refused.
+    expect(prisma.patient.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('treats a clinic-scoped SYSTEM_ADMIN grant as not holding the global seat', async () => {
+    const { service, prisma } = createService();
+    stubCharts(prisma);
+    await expect(
+      service.evaluate(
+        { userId: 'u', roles: [{ clinicId: 'clinic-1', role: UserRole.SYSTEM_ADMIN }] },
+        'patient-1',
+        'patient-2',
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('refuses one chart against itself', async () => {
+    const { service } = createService();
+    await expect(service.evaluate(systemAdmin, 'patient-1', 'patient-1')).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+  });
+
+  it('reports a missing chart as not found', async () => {
+    const { service, prisma } = createService();
+    prisma.patient.findUnique.mockResolvedValue(null);
+    await expect(service.evaluate(systemAdmin, 'patient-1', 'patient-2')).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+
+  it('writes nothing at all while evaluating', async () => {
+    const { service, prisma, auditService } = createService();
+    stubCharts(prisma);
+    await service.evaluate(systemAdmin, 'patient-1', 'patient-2');
+
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(prisma.patient.update).not.toHaveBeenCalled();
+    expect(prisma.patientCodeAlias.upsert).not.toHaveBeenCalled();
+    expect(prisma.patientMergeRecord.create).not.toHaveBeenCalled();
+    expect(auditService.logWrite).not.toHaveBeenCalled();
+  });
+
+  it('counts every relation the merge moves, on both sides', async () => {
+    const { service, prisma } = createService({
+      relationCounts: { encounter: [4, 2], clinicalNote: [1, 3] },
+    });
+    stubCharts(prisma);
+
+    const preview = await service.evaluate(systemAdmin, 'patient-1', 'patient-2');
+
+    expect(preview.relations).toHaveLength(MERGE_RELATIONS.length);
+    expect(preview.relations.find((row) => row.key === 'encounter')).toMatchObject({
+      label: 'Visits',
+      canonicalCount: 4,
+      sourceCount: 2,
+    });
+    // The relation the original merge left behind.
+    expect(preview.relations.find((row) => row.key === 'clinicalNote')).toMatchObject({
+      canonicalCount: 1,
+      sourceCount: 3,
+    });
+  });
+
+  it('names the code the retired chart gives up and the one it is renamed to', async () => {
+    const { service, prisma } = createService();
+    stubCharts(prisma);
+
+    const preview = await service.evaluate(systemAdmin, 'patient-1', 'patient-2');
+
+    expect(preview.aliases.added).toBe('NKP-2026-000099');
+    expect(preview.tombstonePatientCode).toBe('NKP-2026-000099-M-PATIENT2');
+    expect(preview.tombstonePatientCode.length).toBeLessThanOrEqual(32);
+  });
+
+  it('clears a healthy pair with nothing to report', async () => {
+    const { service, prisma } = createService();
+    stubCharts(prisma);
+
+    const preview = await service.evaluate(systemAdmin, 'patient-1', 'patient-2');
+
+    expect(preview.findings).toEqual([]);
+    expect(preview.canMerge).toBe(true);
+    expect(preview.duplicateSignal.confidence).toBe('HIGH');
+  });
+
+  describe('blocked conditions', () => {
+    it('blocks a chart that has already been merged away', async () => {
+      const { service, prisma } = createService();
+      stubCharts(prisma, canonicalChart(), sourceChart());
+      prisma.patient.findUnique.mockImplementation(async (args: { where: { id: string } }) =>
+        args.where.id === 'patient-1'
+          ? canonicalChart()
+          : chart({ ...sourceChart(), mergedIntoPatientId: 'patient-9' }),
+      );
+
+      const preview = await service.evaluate(systemAdmin, 'patient-1', 'patient-2');
+      expect(preview.findings.map((f) => f.code)).toContain('SOURCE_ALREADY_MERGED');
+      expect(preview.canMerge).toBe(false);
+    });
+
+    it('blocks a surviving chart that is itself a tombstone', async () => {
+      const { service, prisma } = createService();
+      prisma.patient.findUnique.mockImplementation(async (args: { where: { id: string } }) =>
+        args.where.id === 'patient-1' ? chart({ mergedIntoPatientId: 'patient-9' }) : sourceChart(),
+      );
+
+      expect(await findingCodes(service.evaluate(systemAdmin, 'patient-1', 'patient-2'))).toContain(
+        'CANONICAL_ALREADY_MERGED',
+      );
+    });
+
+    it('blocks two charts in different clinics, and names both', async () => {
+      const { service, prisma } = createService();
+      prisma.patient.findUnique.mockImplementation(async (args: { where: { id: string } }) =>
+        args.where.id === 'patient-1'
+          ? canonicalChart()
+          : chart({
+              ...sourceChart(),
+              primaryClinicId: 'clinic-2',
+              primaryClinic: { ...CLINIC, id: 'clinic-2', name: 'Clinic Two' },
+            }),
+      );
+
+      const preview = await service.evaluate(systemAdmin, 'patient-1', 'patient-2');
+      const crossClinic = preview.findings.find((f) => f.code === 'CROSS_CLINIC');
+      expect(crossClinic?.severity).toBe('BLOCK');
+      expect(crossClinic?.detail).toBe('Clinic One and Clinic Two');
+      expect(preview.canMerge).toBe(false);
+    });
+
+    it('blocks a merge inside a deactivated clinic', async () => {
+      const inactive = { ...CLINIC, isActive: false };
+      const { service, prisma } = createService();
+      prisma.patient.findUnique.mockImplementation(async (args: { where: { id: string } }) =>
+        args.where.id === 'patient-1'
+          ? chart({ primaryClinic: inactive })
+          : chart({ ...sourceChart(), primaryClinic: inactive }),
+      );
+
+      expect(await findingCodes(service.evaluate(systemAdmin, 'patient-1', 'patient-2'))).toContain(
+        'CLINIC_INACTIVE',
+      );
+    });
+
+    it('blocks when the retiring code already belongs to a third chart', async () => {
+      const { service, prisma } = createService();
+      stubCharts(prisma);
+      prisma.patientCodeAlias.findMany.mockResolvedValue([{ code: 'NKP-2026-000099' }]);
+
+      const preview = await service.evaluate(systemAdmin, 'patient-1', 'patient-2');
+      const finding = preview.findings.find((f) => f.code === 'ALIAS_CODE_COLLISION');
+      expect(finding?.detail).toBe('NKP-2026-000099');
+      expect(preview.canMerge).toBe(false);
+    });
+
+    it('blocks when both charts have an open preferred pharmacy', async () => {
+      const { service, prisma } = createService();
+      stubCharts(prisma);
+      // A partial unique index allows one open period per patient, so moving the second would
+      // roll the whole transaction back on a constraint nobody can read.
+      prisma.patientPharmacyPreference.count = jest.fn(
+        async (args: { where: { effectiveTo?: null } }) =>
+          args.where.effectiveTo === null ? 1 : 0,
+      );
+
+      expect(await findingCodes(service.evaluate(systemAdmin, 'patient-1', 'patient-2'))).toContain(
+        'OPEN_PHARMACY_PREFERENCE_CONFLICT',
+      );
+    });
+
+    it('blocks two different app accounts until the operator picks one', async () => {
+      const { service, prisma } = createService();
+      stubCharts(prisma);
+      prisma.patientAccountLink.findUnique.mockImplementation(
+        async (args: { where: { patientId: string } }) => ({
+          id: `link-${args.where.patientId}`,
+          patientId: args.where.patientId,
+          keycloakSub: args.where.patientId === 'patient-1' ? 'kc-a' : 'kc-b',
+        }),
+      );
+
+      const blocked = await service.evaluate(systemAdmin, 'patient-1', 'patient-2');
+      expect(blocked.findings.map((f) => f.code)).toContain('PORTAL_LINK_CONFLICT');
+      expect(blocked.canMerge).toBe(false);
+
+      // Naming a strategy is the deliberate choice the block is asking for.
+      const chosen = await service.evaluate(systemAdmin, 'patient-1', 'patient-2', {
+        portalLinkStrategy: 'CANONICAL',
+      });
+      expect(chosen.findings.map((f) => f.code)).not.toContain('PORTAL_LINK_CONFLICT');
+      expect(chosen.findings.map((f) => f.code)).toContain('PORTAL_ACCOUNT_RETIRED');
+      expect(chosen.canMerge).toBe(true);
+    });
+
+    it('does not treat one account reachable from both charts as a conflict', async () => {
+      const { service, prisma } = createService();
+      stubCharts(prisma);
+      prisma.patientAccountLink.findUnique.mockImplementation(
+        async (args: { where: { patientId: string } }) => ({
+          id: 'link',
+          patientId: args.where.patientId,
+          keycloakSub: 'kc-same',
+        }),
+      );
+
+      const preview = await service.evaluate(systemAdmin, 'patient-1', 'patient-2');
+      expect(preview.findings).toEqual([]);
+    });
+  });
+
+  describe('warnings', () => {
+    it('warns when the two charts do not look much alike', async () => {
+      const { service, prisma } = createService();
+      prisma.patient.findUnique.mockImplementation(async (args: { where: { id: string } }) =>
+        args.where.id === 'patient-1'
+          ? chart({ phoneE164: null })
+          : chart({
+              ...sourceChart(),
+              firstName: 'Yaa',
+              lastName: 'Mensah',
+              dob: new Date('1990-01-01'),
+              phoneE164: null,
+              nationalIdHash: 'hash-b',
+            }),
+      );
+
+      const preview = await service.evaluate(systemAdmin, 'patient-1', 'patient-2');
+      expect(preview.findings.map((f) => f.code)).toContain('WEAK_DUPLICATE_SIGNAL');
+      // A warning names a consequence; it does not stop the merge.
+      expect(preview.canMerge).toBe(true);
+    });
+
+    it('warns when the duplicate holds more history than the chart being kept', async () => {
+      const { service, prisma } = createService({ relationCounts: { encounter: [1, 9] } });
+      stubCharts(prisma);
+
+      const preview = await service.evaluate(systemAdmin, 'patient-1', 'patient-2');
+      const finding = preview.findings.find((f) => f.code === 'SOURCE_HAS_MORE_HISTORY');
+      expect(finding?.detail).toBe('9 records against 1');
+    });
+
+    it('warns about invitations the chosen strategy cancels', async () => {
+      const { service, prisma } = createService();
+      stubCharts(prisma);
+      prisma.patientPortalInvite.findMany.mockImplementation(
+        async (args: { where: { patientId: string } }) =>
+          args.where.patientId === 'patient-2'
+            ? [{ id: 'invite-1', status: 'PENDING' }]
+            : [{ id: 'invite-0', status: 'CLAIMED' }],
+      );
+
+      const preview = await service.evaluate(systemAdmin, 'patient-1', 'patient-2', {
+        inviteStrategy: 'CANONICAL',
+      });
+      expect(preview.portal.invitesCancelled).toBe(1);
+      expect(preview.findings.find((f) => f.code === 'PENDING_INVITES_CANCELLED')?.detail).toBe(
+        '1 invitation',
+      );
+
+      // The default strategy carries the invitation across instead of cancelling it.
+      const carried = await service.evaluate(systemAdmin, 'patient-1', 'patient-2');
+      expect(carried.portal.invitesCancelled).toBe(0);
+      expect(carried.findings.map((f) => f.code)).not.toContain('PENDING_INVITES_CANCELLED');
+    });
+
+    it('warns when someone already ruled the pair out, and quotes their note', async () => {
+      const { service, prisma } = createService();
+      stubCharts(prisma);
+      prisma.patientDuplicateReview.findUnique.mockResolvedValue({
+        status: 'DISMISSED',
+        note: 'Sisters, not the same person.',
+      });
+
+      const preview = await service.evaluate(systemAdmin, 'patient-1', 'patient-2');
+      const finding = preview.findings.find(
+        (f) => f.code === 'DUPLICATE_PAIR_PREVIOUSLY_DISMISSED',
+      );
+      expect(finding?.detail).toBe('Sisters, not the same person.');
+      expect(preview.canMerge).toBe(true);
+    });
+  });
+
+  it('changes its fingerprint when a chart changes', async () => {
+    const { service, prisma } = createService();
+    stubCharts(prisma);
+    const before = await service.evaluate(systemAdmin, 'patient-1', 'patient-2');
+
+    prisma.patient.findUnique.mockImplementation(async (args: { where: { id: string } }) =>
+      args.where.id === 'patient-1'
+        ? canonicalChart()
+        : chart({ ...sourceChart(), updatedAt: new Date('2026-09-04T10:00:00.000Z') }),
+    );
+    const after = await service.evaluate(systemAdmin, 'patient-1', 'patient-2');
+
+    expect(after.fingerprint).not.toBe(before.fingerprint);
+  });
+});
+
+describe('PatientMergeService.merge', () => {
+  it('moves every relation in the shared list, including the seven that used to be stranded', async () => {
+    const { service, prisma } = createService();
+    stubCharts(prisma);
+
+    await service.merge(systemAdmin, 'patient-1', 'patient-2', undefined, 'req-1');
+
+    for (const relation of MERGE_RELATIONS) {
+      expect(prisma[relation.key].updateMany).toHaveBeenCalledWith({
+        where: { patientId: 'patient-2' },
+        data: { patientId: 'patient-1' },
+      });
+    }
+    // The ones the original implementation silently left on the retired chart.
+    for (const stranded of [
+      'clinicalNote',
+      'medicalHistoryRecord',
+      'patientMedicationRecord',
+      'medicationReconciliationEvent',
+      'patientPharmacyRecord',
+      'patientPharmacyPreference',
+    ]) {
+      expect(prisma[stranded].updateMany).toHaveBeenCalled();
+    }
+  });
+
+  it('retires the duplicate chart and hands its code to the survivor', async () => {
+    const { service, prisma } = createService();
+    stubCharts(prisma);
+
+    const result = await service.merge(systemAdmin, 'patient-1', 'patient-2', undefined, 'req-1');
+
+    expect(prisma.patient.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'patient-2' },
+        data: expect.objectContaining({
+          patientCode: 'NKP-2026-000099-M-PATIENT2',
+          mergedIntoPatientId: 'patient-1',
+          mergedByUserId: 'sysadmin-1',
+          portalUserId: null,
+        }),
+      }),
+    );
+    expect(result).toMatchObject({
+      success: true,
+      canonicalPatientId: 'patient-1',
+      mergedPatientId: 'patient-2',
+      mergedPatientCodeAlias: 'NKP-2026-000099',
+    });
+  });
+
+  it('upserts the legacy code rather than colliding on a globally unique column', async () => {
+    const { service, prisma } = createService();
+    stubCharts(prisma);
+
+    await service.merge(systemAdmin, 'patient-1', 'patient-2');
+
+    expect(prisma.patientCodeAlias.upsert).toHaveBeenCalledWith({
+      where: { code: 'NKP-2026-000099' },
+      create: { patientId: 'patient-1', code: 'NKP-2026-000099' },
+      update: { patientId: 'patient-1' },
+    });
+  });
+
+  it('follows charts already merged into the duplicate, so no alias chain ends at a tombstone', async () => {
+    const { service, prisma } = createService();
+    stubCharts(prisma);
+
+    await service.merge(systemAdmin, 'patient-1', 'patient-2');
+
+    expect(prisma.patient.updateMany).toHaveBeenCalledWith({
+      where: { mergedIntoPatientId: 'patient-2' },
+      data: { mergedIntoPatientId: 'patient-1' },
+    });
+  });
+
+  it('clears duplicate decisions that referenced the retired chart', async () => {
+    const { service, prisma } = createService();
+    stubCharts(prisma);
+
+    await service.merge(systemAdmin, 'patient-1', 'patient-2');
+
+    expect(prisma.patientDuplicateReview.deleteMany).toHaveBeenCalledWith({
+      where: { OR: [{ patientAId: 'patient-2' }, { patientBId: 'patient-2' }] },
+    });
+  });
+
+  it('records what it moved, so the merge can be explained later', async () => {
+    const { service, prisma } = createService({ relationCounts: { encounter: [0, 5] } });
+    stubCharts(prisma);
+
+    await service.merge(systemAdmin, 'patient-1', 'patient-2', undefined, 'req-merge-1');
+
+    const record = prisma.patientMergeRecord.create.mock.calls[0][0].data;
+    expect(record).toMatchObject({
+      clinicId: 'clinic-1',
+      canonicalPatientId: 'patient-1',
+      sourcePatientId: 'patient-2',
+      sourcePatientCode: 'NKP-2026-000099',
+      tombstonePatientCode: 'NKP-2026-000099-M-PATIENT2',
+      portalLinkStrategy: 'CANONICAL',
+      inviteStrategy: 'MERGE',
+      mergedByUserId: 'sysadmin-1',
+      requestId: 'req-merge-1',
+    });
+    expect(JSON.parse(record.movedCountsJson).encounter).toBe(5);
+  });
+
+  it('keeps the audit event, and now says how much moved', async () => {
+    const { service, prisma, auditService } = createService({
+      relationCounts: { appointment: [0, 2] },
+    });
+    stubCharts(prisma);
+
+    await service.merge(systemAdmin, 'patient-1', 'patient-2', undefined, 'req-merge-1');
+
+    expect(auditService.logWrite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'PATIENT.MERGE',
+        entityType: 'Patient',
+        entityId: 'patient-1',
+        clinicId: 'clinic-1',
+        requestId: 'req-merge-1',
+      }),
+    );
+    const after = JSON.parse(auditService.logWrite.mock.calls[0][0].afterJson);
+    expect(after.movedCounts.appointment).toBe(2);
+    expect(after.sourcePatientCode).toBe('NKP-2026-000099');
+  });
+
+  it('refuses on a blocker, and hands back every blocker it found', async () => {
+    const { service, prisma, auditService } = createService();
+    prisma.patient.findUnique.mockImplementation(async (args: { where: { id: string } }) =>
+      args.where.id === 'patient-1'
+        ? canonicalChart()
+        : chart({
+            ...sourceChart(),
+            primaryClinicId: 'clinic-2',
+            primaryClinic: { ...CLINIC, id: 'clinic-2', name: 'Clinic Two' },
+          }),
+    );
+
+    await expect(service.merge(systemAdmin, 'patient-1', 'patient-2')).rejects.toMatchObject({
+      status: 409,
+      response: expect.objectContaining({
+        code: 'PATIENT_MERGE_BLOCKED',
+        recoveryAction: expect.stringContaining('duplicate review queue'),
+      }),
+    });
+
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(auditService.logWrite).not.toHaveBeenCalled();
+  });
+
+  it('refuses a preview taken before the charts changed', async () => {
+    const { service, prisma } = createService();
+    stubCharts(prisma);
+
+    await expect(
+      service.merge(systemAdmin, 'patient-1', 'patient-2', {
+        expectedFingerprint: '0000000000000000',
+      }),
+    ).rejects.toMatchObject({
+      status: 409,
+      response: expect.objectContaining({ code: 'PATIENT_MERGE_PREVIEW_STALE' }),
+    });
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('accepts the fingerprint the preview actually returned', async () => {
+    const { service, prisma } = createService();
+    stubCharts(prisma);
+    const preview = await service.evaluate(systemAdmin, 'patient-1', 'patient-2');
+
+    await expect(
+      service.merge(systemAdmin, 'patient-1', 'patient-2', {
+        expectedFingerprint: preview.fingerprint,
+      }),
+    ).resolves.toMatchObject({ success: true });
+  });
+
+  it('re-checks inside the transaction, so a merge that lands first still wins', async () => {
+    const { service, prisma } = createService();
+    let reads = 0;
+    prisma.patient.findUnique.mockImplementation(async (args: { where: { id: string } }) => {
+      reads += 1;
+      const merged = reads > 2; // the two evaluation reads pass, the in-transaction ones do not
+      if (args.where.id === 'patient-1') return canonicalChart();
+      return chart({
+        ...sourceChart(),
+        mergedIntoPatientId: merged ? 'patient-9' : null,
+      });
+    });
+
+    await expect(service.merge(systemAdmin, 'patient-1', 'patient-2')).rejects.toBeInstanceOf(
+      ConflictException,
+    );
+    expect(prisma.patient.update).not.toHaveBeenCalled();
+  });
+
+  it('is refused to anyone who is not a system administrator', async () => {
+    const { service, prisma } = createService();
+    stubCharts(prisma);
+    await expect(service.merge(director, 'patient-1', 'patient-2')).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+});

--- a/apps/api/src/patients/patient-merge.service.ts
+++ b/apps/api/src/patients/patient-merge.service.ts
@@ -365,44 +365,45 @@ export class PatientMergeService {
         });
       }
 
-      if (
-        strategies.inviteStrategy === 'CANONICAL' &&
-        portalRows.sourcePendingInviteIds.length > 0
-      ) {
+      // Cancel whichever side's unclaimed invitation the strategy gives up. Only PENDING rows are
+      // touched: a claimed or already-expired invitation is history, not a live offer.
+      const cancelledInviteIds =
+        strategies.inviteStrategy === 'CANONICAL'
+          ? portalRows.sourcePendingInviteIds
+          : strategies.inviteStrategy === 'SOURCE'
+            ? portalRows.canonicalPendingInviteIds
+            : [];
+      if (cancelledInviteIds.length > 0) {
         await tx.patientPortalInvite.updateMany({
-          where: { id: { in: portalRows.sourcePendingInviteIds } },
-          data: { patientId: canonical.id, status: 'CANCELLED', cancelledAt: mergedAt },
-        });
-      } else if (strategies.inviteStrategy === 'SOURCE') {
-        if (portalRows.canonicalPendingInviteIds.length > 0) {
-          await tx.patientPortalInvite.updateMany({
-            where: { id: { in: portalRows.canonicalPendingInviteIds } },
-            data: { status: 'CANCELLED', cancelledAt: mergedAt },
-          });
-        }
-        await tx.patientPortalInvite.updateMany({
-          where: { patientId: source.id },
-          data: { patientId: canonical.id },
-        });
-      } else {
-        await tx.patientPortalInvite.updateMany({
-          where: { patientId: source.id },
-          data: { patientId: canonical.id },
+          where: { id: { in: cancelledInviteIds } },
+          data: { status: 'CANCELLED', cancelledAt: mergedAt },
         });
       }
-      const movedInvites = await tx.patientPortalInvite.count({
-        where: { patientId: canonical.id },
-      });
-      counts.patientPortalInvite = movedInvites;
 
+      /*
+        Every invitation moves, whatever state it is in.
+
+        The CANONICAL branch used to repoint only the duplicate's PENDING invitations, so a
+        claimed or expired one stayed on the retired chart -- a record of a real exchange with
+        this patient that the surviving chart would then never show. Same defect as the seven
+        stranded relations above, in a table the original loop did touch.
+      */
+      const movedInvites = await tx.patientPortalInvite.updateMany({
+        where: { patientId: source.id },
+        data: { patientId: canonical.id },
+      });
+      counts.patientPortalInvite = movedInvites.count;
+
+      let carriedAliases = 0;
       if (source.codeAliases.length > 0) {
-        await tx.patientCodeAlias.createMany({
+        const created = await tx.patientCodeAlias.createMany({
           data: source.codeAliases.map((alias) => ({
             patientId: canonical.id,
             code: alias.code,
           })),
           skipDuplicates: true,
         });
+        carriedAliases = created.count;
         await tx.patientCodeAlias.deleteMany({ where: { patientId: source.id } });
       }
 
@@ -430,7 +431,9 @@ export class PatientMergeService {
         create: { patientId: canonical.id, code: sourceLegacyCode },
         update: { patientId: canonical.id },
       });
-      counts.patientCodeAlias = source.codeAliases.length + 1;
+      // Measured, not assumed: skipDuplicates means an alias the surviving chart already answered
+      // to is not inserted again, and a count that over-reports is worse than none.
+      counts.patientCodeAlias = carriedAliases + 1;
 
       if (retainedPortalUserId) {
         await tx.userClinicRole.upsert({

--- a/apps/api/src/patients/patient-merge.service.ts
+++ b/apps/api/src/patients/patient-merge.service.ts
@@ -1,0 +1,694 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { Prisma, UserRole, type PatientAccountLink } from '@prisma/client';
+import {
+  MERGE_RELATIONS,
+  duplicatePairKey,
+  evaluateDuplicatePair,
+  isMergeBlocked,
+  mergeFinding,
+  mergePreviewFingerprint,
+  type DuplicateConfidence,
+  type DuplicateMatchReason,
+  type MergeFinding,
+  type MergeRelationKey,
+} from '@nkwapa/db';
+import { AuditService } from '../audit/audit.service';
+import { isSystemAdmin, type ScopedRole } from '../auth/clinic-roles';
+import { PrismaService } from '../prisma/prisma.service';
+
+type TransactionClient = Prisma.TransactionClient;
+
+/** The caller, in the shape the admin and duplicate-review services already pass around. */
+export interface MergeActor {
+  userId: string;
+  roles: ScopedRole[];
+}
+
+export interface MergeStrategies {
+  portalLinkStrategy?: 'CANONICAL' | 'SOURCE';
+  inviteStrategy?: 'CANONICAL' | 'SOURCE' | 'MERGE';
+}
+
+const CHART_INCLUDE = {
+  codeAliases: true,
+  primaryClinic: {
+    select: {
+      id: true,
+      name: true,
+      isActive: true,
+      organizationId: true,
+      organization: { select: { name: true } },
+    },
+  },
+} satisfies Prisma.PatientInclude;
+
+type MergeChart = Prisma.PatientGetPayload<{ include: typeof CHART_INCLUDE }>;
+
+/** One relation, with what each side holds. */
+export interface MergeRelationCount {
+  key: MergeRelationKey;
+  label: string;
+  canonicalCount: number;
+  sourceCount: number;
+}
+
+export interface MergePortalOutlook {
+  canonicalLinked: boolean;
+  sourceLinked: boolean;
+  /** Which chart's app account keeps access, or `NONE` when neither chart has one. */
+  retains: 'CANONICAL' | 'SOURCE' | 'NONE';
+  canonicalPendingInvites: number;
+  sourcePendingInvites: number;
+  /** Pending invitations the chosen strategy cancels. */
+  invitesCancelled: number;
+}
+
+export interface PatientMergeEvaluation {
+  canonical: MergeChart;
+  source: MergeChart;
+  relations: MergeRelationCount[];
+  portal: MergePortalOutlook;
+  aliases: { carriedOver: string[]; added: string };
+  tombstonePatientCode: string;
+  duplicateSignal: {
+    score: number;
+    confidence: DuplicateConfidence;
+    reasons: DuplicateMatchReason[];
+  };
+  findings: MergeFinding[];
+  canMerge: boolean;
+  fingerprint: string;
+  strategies: Required<MergeStrategies>;
+  /** Rows the transaction needs. Internal; the preview payload does not carry them. */
+  portalRows: {
+    canonicalLink: PatientAccountLink | null;
+    sourceLink: PatientAccountLink | null;
+    canonicalPendingInviteIds: string[];
+    sourcePendingInviteIds: string[];
+  };
+}
+
+export interface PatientMergeResult {
+  success: true;
+  canonicalPatientId: string;
+  canonicalPatientCode: string;
+  mergedPatientId: string;
+  mergedPatientCodeAlias: string;
+  /** Rows moved per relation, keyed by `MERGE_RELATIONS`. */
+  movedCounts: Record<string, number>;
+}
+
+/**
+ * The delegate shape every relation in `MERGE_RELATIONS` satisfies.
+ *
+ * Indexing the Prisma client by a key from a shared constant is the whole point -- it is what
+ * makes it impossible for the preview to count a relation the transaction then fails to move --
+ * but the generated client has no index signature, so the cast is confined to this one helper.
+ */
+interface PatientScopedDelegate {
+  count(args: { where: { patientId: string } }): Promise<number>;
+  updateMany(args: {
+    where: { patientId: string };
+    data: { patientId: string };
+  }): Promise<{ count: number }>;
+}
+
+function relationDelegates(
+  client: PrismaService | TransactionClient,
+): Record<MergeRelationKey, PatientScopedDelegate> {
+  return client as unknown as Record<MergeRelationKey, PatientScopedDelegate>;
+}
+
+/**
+ * The code a retired chart is renamed to.
+ *
+ * `Patient.patientCode` is globally unique, so the retired chart cannot keep the code it is
+ * handing to the surviving one. The suffix makes the rename deterministic and readable by eye.
+ */
+export function buildMergedPatientCode(sourceCode: string, patientId: string): string {
+  const suffix = patientId.replace(/-/g, '').slice(0, 8).toUpperCase();
+  return `${sourceCode}-M-${suffix}`.slice(0, 32);
+}
+
+/**
+ * Merging two patient charts.
+ *
+ * Lifted out of `AdminService`, which had grown past a thousand lines of unrelated staff
+ * lifecycle work, so that the evaluation an operator is shown and the transaction that acts on it
+ * sit beside each other and cannot drift apart. `AdminService.mergePatients` still exists and
+ * delegates here, so `POST /admin/patients/merge` and its callers are unchanged.
+ *
+ * Every refusal is raised through `@nkwapa/db`'s finding vocabulary rather than as a bare string,
+ * so an operator reads the same wording whether they meet it in the preview or on submit.
+ */
+@Injectable()
+export class PatientMergeService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly auditService: AuditService,
+  ) {}
+
+  /**
+   * What a merge would do. Read-only, so it can be opened as often as an operator likes.
+   *
+   * System-admin only, matching the merge it describes: this reports how much clinical history
+   * sits on each chart, a wider identity view than the side-by-side comparison the duplicate
+   * review queue gives a clinic manager.
+   */
+  async evaluate(
+    actor: MergeActor,
+    canonicalPatientId: string,
+    sourcePatientId: string,
+    options?: MergeStrategies,
+  ): Promise<PatientMergeEvaluation> {
+    this.assertSystemAdmin(actor);
+
+    if (canonicalPatientId === sourcePatientId) {
+      throw new BadRequestException(this.refusal(mergeFinding('SAME_PATIENT')));
+    }
+
+    const [canonical, source] = await Promise.all([
+      this.prisma.patient.findUnique({
+        where: { id: canonicalPatientId },
+        include: CHART_INCLUDE,
+      }),
+      this.prisma.patient.findUnique({ where: { id: sourcePatientId }, include: CHART_INCLUDE }),
+    ]);
+
+    if (!canonical || !source) {
+      throw new NotFoundException(this.refusal(mergeFinding('PATIENT_NOT_FOUND')));
+    }
+
+    return this.evaluateCharts(canonical, source, options);
+  }
+
+  /**
+   * Consolidate the duplicate into the canonical chart.
+   *
+   * Refuses on any blocker the evaluation raised, and refuses a stale `expectedFingerprint` so an
+   * operator cannot commit against a preview that a concurrent edit has made untrue. Everything
+   * that changes happens in one transaction, including the record of what changed.
+   */
+  async merge(
+    actor: MergeActor,
+    canonicalPatientId: string,
+    sourcePatientId: string,
+    options?: MergeStrategies & { expectedFingerprint?: string },
+    requestId?: string,
+  ): Promise<PatientMergeResult> {
+    const evaluation = await this.evaluate(actor, canonicalPatientId, sourcePatientId, options);
+
+    const blockers = evaluation.findings.filter((finding) => finding.severity === 'BLOCK');
+    if (blockers.length > 0) {
+      throw new ConflictException(this.refusal(blockers[0], evaluation.findings));
+    }
+
+    if (options?.expectedFingerprint && options.expectedFingerprint !== evaluation.fingerprint) {
+      throw new ConflictException({
+        code: 'PATIENT_MERGE_PREVIEW_STALE',
+        message: 'One of these charts changed after the preview was taken.',
+        recoveryAction: 'Close this and preview the merge again before continuing.',
+      });
+    }
+
+    const { canonical, source, portalRows, strategies } = evaluation;
+    const mergedAt = new Date();
+    const sourceLegacyCode = source.patientCode;
+
+    // Preserved verbatim from the original implementation: an explicit SOURCE strategy wins, and
+    // otherwise the surviving chart's own account is kept before the duplicate's.
+    const retainedPortalLink =
+      strategies.portalLinkStrategy === 'SOURCE' && portalRows.sourceLink
+        ? portalRows.sourceLink
+        : (portalRows.canonicalLink ?? portalRows.sourceLink ?? null);
+    const retainedPortalUser = retainedPortalLink
+      ? await this.prisma.user.findUnique({
+          where: { keycloakSub: retainedPortalLink.keycloakSub },
+          select: { id: true },
+        })
+      : null;
+    const retainedPortalUserId =
+      strategies.portalLinkStrategy === 'SOURCE' && source.portalUserId
+        ? source.portalUserId
+        : (canonical.portalUserId ?? source.portalUserId ?? retainedPortalUser?.id ?? null);
+
+    const movedCounts = await this.prisma.$transaction(async (tx) => {
+      await this.assertStillMergeable(tx, canonical, source);
+
+      const counts: Record<string, number> = {};
+      const delegates = relationDelegates(tx);
+
+      /*
+        Driven by the shared list rather than a hand-written sequence of updateMany calls.
+
+        The original moved eight relations and silently left seven behind -- clinical notes,
+        medical history, medication and pharmacy records among them -- so a merged chart carried
+        notes whose encounter pointed at the surviving record while the note itself still pointed
+        at the retired one. Iterating MERGE_RELATIONS is what makes adding a relation to the
+        preview and forgetting to move it impossible.
+      */
+      for (const relation of MERGE_RELATIONS) {
+        const { count } = await delegates[relation.key].updateMany({
+          where: { patientId: source.id },
+          data: { patientId: canonical.id },
+        });
+        counts[relation.key] = count;
+      }
+
+      // A chart already merged into the duplicate must follow it, or its alias chain terminates
+      // at a retired record.
+      const rechained = await tx.patient.updateMany({
+        where: { mergedIntoPatientId: source.id },
+        data: { mergedIntoPatientId: canonical.id },
+      });
+      counts.mergedSourcePatients = rechained.count;
+
+      // A decision about "are these two the same person" is answered by the merge itself. The
+      // queue recomputes candidates from live charts and excludes retired ones, so any pair still
+      // worth reviewing resurfaces against the surviving chart on its own.
+      const reviews = await tx.patientDuplicateReview.deleteMany({
+        where: { OR: [{ patientAId: source.id }, { patientBId: source.id }] },
+      });
+      counts.patientDuplicateReview = reviews.count;
+
+      await tx.patientAccountLink.deleteMany({
+        where: { patientId: { in: [canonical.id, source.id] } },
+      });
+      if (retainedPortalLink) {
+        await tx.patientAccountLink.create({
+          data: { patientId: canonical.id, keycloakSub: retainedPortalLink.keycloakSub },
+        });
+      }
+
+      if (
+        strategies.inviteStrategy === 'CANONICAL' &&
+        portalRows.sourcePendingInviteIds.length > 0
+      ) {
+        await tx.patientPortalInvite.updateMany({
+          where: { id: { in: portalRows.sourcePendingInviteIds } },
+          data: { patientId: canonical.id, status: 'CANCELLED', cancelledAt: mergedAt },
+        });
+      } else if (strategies.inviteStrategy === 'SOURCE') {
+        if (portalRows.canonicalPendingInviteIds.length > 0) {
+          await tx.patientPortalInvite.updateMany({
+            where: { id: { in: portalRows.canonicalPendingInviteIds } },
+            data: { status: 'CANCELLED', cancelledAt: mergedAt },
+          });
+        }
+        await tx.patientPortalInvite.updateMany({
+          where: { patientId: source.id },
+          data: { patientId: canonical.id },
+        });
+      } else {
+        await tx.patientPortalInvite.updateMany({
+          where: { patientId: source.id },
+          data: { patientId: canonical.id },
+        });
+      }
+      const movedInvites = await tx.patientPortalInvite.count({
+        where: { patientId: canonical.id },
+      });
+      counts.patientPortalInvite = movedInvites;
+
+      if (source.codeAliases.length > 0) {
+        await tx.patientCodeAlias.createMany({
+          data: source.codeAliases.map((alias) => ({
+            patientId: canonical.id,
+            code: alias.code,
+          })),
+          skipDuplicates: true,
+        });
+        await tx.patientCodeAlias.deleteMany({ where: { patientId: source.id } });
+      }
+
+      await tx.patient.update({
+        where: { id: canonical.id },
+        data: { portalUserId: retainedPortalUserId },
+      });
+
+      await tx.patient.update({
+        where: { id: source.id },
+        data: {
+          patientCode: evaluation.tombstonePatientCode,
+          portalUserId: null,
+          mergedIntoPatientId: canonical.id,
+          mergedAt,
+          mergedByUserId: actor.userId,
+        },
+      });
+
+      // Upsert, not create. `PatientCodeAlias.code` is globally unique, and the surviving chart
+      // may already answer to this code from an earlier merge of the same pair's history; a bare
+      // create turned that into a raw Prisma error with no recoverable wording.
+      await tx.patientCodeAlias.upsert({
+        where: { code: sourceLegacyCode },
+        create: { patientId: canonical.id, code: sourceLegacyCode },
+        update: { patientId: canonical.id },
+      });
+      counts.patientCodeAlias = source.codeAliases.length + 1;
+
+      if (retainedPortalUserId) {
+        await tx.userClinicRole.upsert({
+          where: {
+            userId_clinicId_role: {
+              userId: retainedPortalUserId,
+              clinicId: canonical.primaryClinicId,
+              role: UserRole.PATIENT,
+            },
+          },
+          create: {
+            userId: retainedPortalUserId,
+            clinicId: canonical.primaryClinicId,
+            role: UserRole.PATIENT,
+          },
+          update: {},
+        });
+      }
+
+      await tx.patientMergeRecord.create({
+        data: {
+          clinicId: canonical.primaryClinicId,
+          canonicalPatientId: canonical.id,
+          sourcePatientId: source.id,
+          sourcePatientCode: sourceLegacyCode,
+          tombstonePatientCode: evaluation.tombstonePatientCode,
+          portalLinkStrategy: strategies.portalLinkStrategy,
+          inviteStrategy: strategies.inviteStrategy,
+          movedCountsJson: JSON.stringify(counts),
+          warningCodesJson: JSON.stringify(
+            evaluation.findings
+              .filter((finding) => finding.severity === 'WARN')
+              .map((finding) => finding.code),
+          ),
+          mergedByUserId: actor.userId,
+          mergedAt,
+          requestId: requestId ?? null,
+        },
+      });
+
+      return counts;
+    });
+
+    await this.auditService.logWrite({
+      clinicId: canonical.primaryClinicId,
+      actorUserId: actor.userId,
+      action: 'PATIENT.MERGE',
+      entityType: 'Patient',
+      entityId: canonical.id,
+      beforeJson: JSON.stringify({
+        canonicalPatientId: canonical.id,
+        sourcePatientId: source.id,
+        sourcePatientCode: sourceLegacyCode,
+      }),
+      afterJson: JSON.stringify({
+        canonicalPatientId: canonical.id,
+        sourcePatientId: source.id,
+        sourcePatientCode: sourceLegacyCode,
+        retainedPortalLinkKeycloakSub: retainedPortalLink?.keycloakSub ?? null,
+        retainedPortalUserId,
+        // What was actually moved, so a consolidated chart can be reconciled from the audit trail
+        // alone rather than only from PatientMergeRecord.
+        movedCounts,
+      }),
+      requestId,
+    });
+
+    return {
+      success: true,
+      canonicalPatientId: canonical.id,
+      canonicalPatientCode: canonical.patientCode,
+      mergedPatientId: source.id,
+      mergedPatientCodeAlias: sourceLegacyCode,
+      movedCounts,
+    };
+  }
+
+  private async evaluateCharts(
+    canonical: MergeChart,
+    source: MergeChart,
+    options?: MergeStrategies,
+  ): Promise<PatientMergeEvaluation> {
+    const strategies: Required<MergeStrategies> = {
+      portalLinkStrategy: options?.portalLinkStrategy ?? 'CANONICAL',
+      inviteStrategy: options?.inviteStrategy ?? 'MERGE',
+    };
+
+    const counts = relationDelegates(this.prisma);
+    const [
+      relations,
+      canonicalLink,
+      sourceLink,
+      canonicalInvites,
+      sourceInvites,
+      canonicalOpenPharmacy,
+      sourceOpenPharmacy,
+      aliasCollisions,
+      priorReview,
+    ] = await Promise.all([
+      Promise.all(
+        MERGE_RELATIONS.map(async (relation): Promise<MergeRelationCount> => {
+          const [canonicalCount, sourceCount] = await Promise.all([
+            counts[relation.key].count({ where: { patientId: canonical.id } }),
+            counts[relation.key].count({ where: { patientId: source.id } }),
+          ]);
+          return { key: relation.key, label: relation.label, canonicalCount, sourceCount };
+        }),
+      ),
+      this.prisma.patientAccountLink.findUnique({ where: { patientId: canonical.id } }),
+      this.prisma.patientAccountLink.findUnique({ where: { patientId: source.id } }),
+      this.prisma.patientPortalInvite.findMany({ where: { patientId: canonical.id } }),
+      this.prisma.patientPortalInvite.findMany({ where: { patientId: source.id } }),
+      this.prisma.patientPharmacyPreference.count({
+        where: { patientId: canonical.id, effectiveTo: null },
+      }),
+      this.prisma.patientPharmacyPreference.count({
+        where: { patientId: source.id, effectiveTo: null },
+      }),
+      this.prisma.patientCodeAlias.findMany({
+        where: {
+          code: { in: [source.patientCode, ...source.codeAliases.map((alias) => alias.code)] },
+          patientId: { notIn: [canonical.id, source.id] },
+        },
+        select: { code: true },
+      }),
+      this.prisma.patientDuplicateReview.findUnique({
+        where: { pairKey: duplicatePairKey(canonical.id, source.id) },
+        select: { status: true, note: true },
+      }),
+    ]);
+
+    const canonicalPending = canonicalInvites.filter((invite) => invite.status === 'PENDING');
+    const sourcePending = sourceInvites.filter((invite) => invite.status === 'PENDING');
+
+    const retains: MergePortalOutlook['retains'] =
+      strategies.portalLinkStrategy === 'SOURCE' && sourceLink
+        ? 'SOURCE'
+        : canonicalLink
+          ? 'CANONICAL'
+          : sourceLink
+            ? 'SOURCE'
+            : 'NONE';
+
+    // CANONICAL keeps the surviving chart's invitation and cancels the duplicate's, SOURCE does
+    // the reverse, and MERGE carries the duplicate's across and cancels nothing.
+    const invitesCancelled =
+      strategies.inviteStrategy === 'CANONICAL'
+        ? sourcePending.length
+        : strategies.inviteStrategy === 'SOURCE'
+          ? canonicalPending.length
+          : 0;
+
+    const duplicateSignal = evaluateDuplicatePair(
+      toDuplicateInput(canonical),
+      toDuplicateInput(source),
+    );
+
+    const findings: MergeFinding[] = [];
+
+    if (canonical.mergedIntoPatientId) findings.push(mergeFinding('CANONICAL_ALREADY_MERGED'));
+    if (source.mergedIntoPatientId) findings.push(mergeFinding('SOURCE_ALREADY_MERGED'));
+
+    if (canonical.primaryClinicId !== source.primaryClinicId) {
+      findings.push(
+        mergeFinding(
+          'CROSS_CLINIC',
+          `${canonical.primaryClinic.name} and ${source.primaryClinic.name}`,
+        ),
+      );
+    } else if (!canonical.primaryClinic.isActive) {
+      findings.push(mergeFinding('CLINIC_INACTIVE', canonical.primaryClinic.name));
+    }
+
+    if (aliasCollisions.length > 0) {
+      findings.push(
+        mergeFinding('ALIAS_CODE_COLLISION', aliasCollisions.map((alias) => alias.code).join(', ')),
+      );
+    }
+
+    if (canonicalOpenPharmacy > 0 && sourceOpenPharmacy > 0) {
+      // Enforced by PatientPharmacyPreference_one_open_per_patient_key, a partial unique index.
+      // Without this check the whole transaction rolls back on a constraint the operator has no
+      // way to read, part-way through an action they were told would succeed.
+      findings.push(mergeFinding('OPEN_PHARMACY_PREFERENCE_CONFLICT'));
+    }
+
+    const twoAccounts =
+      canonicalLink != null &&
+      sourceLink != null &&
+      canonicalLink.keycloakSub !== sourceLink.keycloakSub;
+
+    if (twoAccounts && !options?.portalLinkStrategy) {
+      // Two different people can sign in to these two charts. Keeping one silently locks the
+      // other out of a record they have been using, so the choice has to be made deliberately.
+      findings.push(mergeFinding('PORTAL_LINK_CONFLICT'));
+    }
+    if (twoAccounts) findings.push(mergeFinding('PORTAL_ACCOUNT_RETIRED'));
+
+    if (invitesCancelled > 0) {
+      findings.push(
+        mergeFinding(
+          'PENDING_INVITES_CANCELLED',
+          `${invitesCancelled} invitation${invitesCancelled === 1 ? '' : 's'}`,
+        ),
+      );
+    }
+
+    if (duplicateSignal.confidence === 'LOW') findings.push(mergeFinding('WEAK_DUPLICATE_SIGNAL'));
+
+    const canonicalTotal = relations.reduce((total, row) => total + row.canonicalCount, 0);
+    const sourceTotal = relations.reduce((total, row) => total + row.sourceCount, 0);
+    if (sourceTotal > canonicalTotal) {
+      findings.push(
+        mergeFinding('SOURCE_HAS_MORE_HISTORY', `${sourceTotal} records against ${canonicalTotal}`),
+      );
+    }
+
+    if (priorReview?.status === 'DISMISSED') {
+      findings.push(
+        mergeFinding('DUPLICATE_PAIR_PREVIOUSLY_DISMISSED', priorReview.note ?? undefined),
+      );
+    }
+
+    return {
+      canonical,
+      source,
+      relations,
+      portal: {
+        canonicalLinked: canonicalLink != null,
+        sourceLinked: sourceLink != null,
+        retains,
+        canonicalPendingInvites: canonicalPending.length,
+        sourcePendingInvites: sourcePending.length,
+        invitesCancelled,
+      },
+      aliases: {
+        carriedOver: source.codeAliases.map((alias) => alias.code),
+        added: source.patientCode,
+      },
+      tombstonePatientCode: buildMergedPatientCode(source.patientCode, source.id),
+      duplicateSignal,
+      findings,
+      canMerge: !isMergeBlocked(findings),
+      fingerprint: mergePreviewFingerprint({
+        canonicalPatientId: canonical.id,
+        sourcePatientId: source.id,
+        canonicalUpdatedAt: canonical.updatedAt,
+        sourceUpdatedAt: source.updatedAt,
+        canonicalPatientCode: canonical.patientCode,
+        sourcePatientCode: source.patientCode,
+        counts: Object.fromEntries(
+          relations.flatMap((row) => [
+            [`${row.key}:canonical`, row.canonicalCount],
+            [`${row.key}:source`, row.sourceCount],
+          ]),
+        ),
+      }),
+      strategies,
+      portalRows: {
+        canonicalLink,
+        sourceLink,
+        canonicalPendingInviteIds: canonicalPending.map((invite) => invite.id),
+        sourcePendingInviteIds: sourcePending.map((invite) => invite.id),
+      },
+    };
+  }
+
+  /**
+   * The three conditions that must still hold at commit time.
+   *
+   * The evaluation reads a snapshot taken before the transaction opened, and the preview widens
+   * that window further by putting a person's reading time inside it. Re-reading the full
+   * evaluation here would hold locks for thirty more queries; these three are the ones a
+   * concurrent merge or a clinic transfer can actually invalidate.
+   */
+  private async assertStillMergeable(
+    tx: TransactionClient,
+    canonical: MergeChart,
+    source: MergeChart,
+  ) {
+    const [freshCanonical, freshSource] = await Promise.all([
+      tx.patient.findUnique({
+        where: { id: canonical.id },
+        select: { mergedIntoPatientId: true, primaryClinicId: true },
+      }),
+      tx.patient.findUnique({
+        where: { id: source.id },
+        select: { mergedIntoPatientId: true, primaryClinicId: true },
+      }),
+    ]);
+
+    if (!freshCanonical || !freshSource) {
+      throw new NotFoundException(this.refusal(mergeFinding('PATIENT_NOT_FOUND')));
+    }
+    if (freshCanonical.mergedIntoPatientId) {
+      throw new ConflictException(this.refusal(mergeFinding('CANONICAL_ALREADY_MERGED')));
+    }
+    if (freshSource.mergedIntoPatientId) {
+      throw new ConflictException(this.refusal(mergeFinding('SOURCE_ALREADY_MERGED')));
+    }
+    if (freshCanonical.primaryClinicId !== freshSource.primaryClinicId) {
+      throw new ConflictException(this.refusal(mergeFinding('CROSS_CLINIC')));
+    }
+  }
+
+  private assertSystemAdmin(actor: MergeActor) {
+    if (!isSystemAdmin(actor.roles)) {
+      throw new ForbiddenException({
+        code: 'PATIENT_MERGE_FORBIDDEN',
+        message: 'Only System Admin can merge patient records',
+        recoveryAction:
+          'Record what you found in the duplicate review queue, and ask a system administrator to consolidate the charts.',
+      });
+    }
+  }
+
+  /** A refusal, in the shape `ApiExceptionFilter` turns into a coded error body. */
+  private refusal(finding: MergeFinding, findings: MergeFinding[] = [finding]) {
+    return {
+      code: 'PATIENT_MERGE_BLOCKED',
+      message: finding.label,
+      recoveryAction: finding.recovery,
+      details: { blockers: findings.filter((entry) => entry.severity === 'BLOCK') },
+    };
+  }
+}
+
+function toDuplicateInput(chart: MergeChart) {
+  return {
+    id: chart.id,
+    firstName: chart.firstName,
+    lastName: chart.lastName,
+    dob: chart.dob,
+    phoneE164: chart.phoneE164,
+    email: chart.email,
+    nationalIdHash: chart.nationalIdHash,
+    nationalIdType: chart.nationalIdType,
+    nationalIdLast4: chart.nationalIdLast4,
+  };
+}

--- a/apps/api/src/patients/patient-merge.service.ts
+++ b/apps/api/src/patients/patient-merge.service.ts
@@ -94,6 +94,52 @@ export interface PatientMergeEvaluation {
   };
 }
 
+/**
+ * One chart, in the shape the duplicate review queue already publishes.
+ *
+ * Deliberately identical to `DuplicateCandidatePatient` so the web app's `buildComparisonRows`
+ * renders a merge preview and a duplicate candidate with the same code. Two field-by-field
+ * comparisons of two patient charts that disagree about how to show a date of birth would be a
+ * worse outcome than either one alone.
+ */
+export interface MergePreviewPatient {
+  id: string;
+  patientCode: string;
+  firstName: string;
+  lastName: string;
+  dob: string | null;
+  sex: string;
+  phoneE164: string | null;
+  email: string | null;
+  nationalIdType: string | null;
+  nationalIdLast4: string | null;
+  portalLinked: boolean;
+  createdAt: string;
+  updatedAt: string;
+  clinic: { id: string; name: string; organizationId: string; organizationName: string };
+}
+
+export interface PatientMergePreview {
+  generatedAt: string;
+  canonical: MergePreviewPatient;
+  source: MergePreviewPatient;
+  duplicateSignal: {
+    score: number;
+    confidence: DuplicateConfidence;
+    reasons: DuplicateMatchReason[];
+  };
+  relations: MergeRelationCount[];
+  portal: MergePortalOutlook;
+  aliases: { carriedOver: string[]; added: string };
+  tombstonePatientCode: string;
+  blockers: MergeFinding[];
+  warnings: MergeFinding[];
+  canMerge: boolean;
+  /** Echo this back on the merge so a stale panel cannot be acted on. */
+  fingerprint: string;
+  strategies: Required<MergeStrategies>;
+}
+
 export interface PatientMergeResult {
   success: true;
   canonicalPatientId: string;
@@ -186,6 +232,39 @@ export class PatientMergeService {
     }
 
     return this.evaluateCharts(canonical, source, options);
+  }
+
+  /**
+   * The read-only panel an operator reads before committing.
+   *
+   * A projection of `evaluate`, with the raw rows the transaction needs left behind. Recomputed
+   * on every call rather than stored: a preview that could go stale without saying so is the
+   * thing this endpoint exists to prevent, and `fingerprint` is how a client proves it acted on
+   * what it was shown.
+   */
+  async preview(
+    actor: MergeActor,
+    canonicalPatientId: string,
+    sourcePatientId: string,
+    options?: MergeStrategies,
+  ): Promise<PatientMergePreview> {
+    const evaluation = await this.evaluate(actor, canonicalPatientId, sourcePatientId, options);
+
+    return {
+      generatedAt: new Date().toISOString(),
+      canonical: toPreviewPatient(evaluation.canonical),
+      source: toPreviewPatient(evaluation.source),
+      duplicateSignal: evaluation.duplicateSignal,
+      relations: evaluation.relations,
+      portal: evaluation.portal,
+      aliases: evaluation.aliases,
+      tombstonePatientCode: evaluation.tombstonePatientCode,
+      blockers: evaluation.findings.filter((finding) => finding.severity === 'BLOCK'),
+      warnings: evaluation.findings.filter((finding) => finding.severity === 'WARN'),
+      canMerge: evaluation.canMerge,
+      fingerprint: evaluation.fingerprint,
+      strategies: evaluation.strategies,
+    };
   }
 
   /**
@@ -677,6 +756,30 @@ export class PatientMergeService {
       details: { blockers: findings.filter((entry) => entry.severity === 'BLOCK') },
     };
   }
+}
+
+function toPreviewPatient(chart: MergeChart): MergePreviewPatient {
+  return {
+    id: chart.id,
+    patientCode: chart.patientCode,
+    firstName: chart.firstName,
+    lastName: chart.lastName,
+    dob: chart.dob ? chart.dob.toISOString() : null,
+    sex: chart.sex,
+    phoneE164: chart.phoneE164,
+    email: chart.email,
+    nationalIdType: chart.nationalIdType,
+    nationalIdLast4: chart.nationalIdLast4,
+    portalLinked: chart.portalUserId !== null,
+    createdAt: chart.createdAt.toISOString(),
+    updatedAt: chart.updatedAt.toISOString(),
+    clinic: {
+      id: chart.primaryClinic.id,
+      name: chart.primaryClinic.name,
+      organizationId: chart.primaryClinic.organizationId,
+      organizationName: chart.primaryClinic.organization.name,
+    },
+  };
 }
 
 function toDuplicateInput(chart: MergeChart) {

--- a/apps/api/src/patients/patient.module.ts
+++ b/apps/api/src/patients/patient.module.ts
@@ -5,6 +5,7 @@ import { ConsentModule } from '../consents/consent.module';
 import { EncounterModule } from '../encounters/encounter.module';
 import { PatientDuplicateRepository } from './patient-duplicate.repository';
 import { PatientDuplicateService } from './patient-duplicate.service';
+import { PatientMergeService } from './patient-merge.service';
 import { PatientRepository } from './patient.repository';
 import { PatientService } from './patient.service';
 import { PatientsController } from './patients.controller';
@@ -21,8 +22,9 @@ import { PatientsController } from './patients.controller';
     PatientService,
     PatientDuplicateRepository,
     PatientDuplicateService,
+    PatientMergeService,
   ],
   controllers: [PatientsController],
-  exports: [PatientService, PatientRepository, PatientDuplicateService],
+  exports: [PatientService, PatientRepository, PatientDuplicateService, PatientMergeService],
 })
 export class PatientModule {}

--- a/apps/web/app/(workspace)/clinics/[clinicId]/patients/[patientId]/page.tsx
+++ b/apps/web/app/(workspace)/clinics/[clinicId]/patients/[patientId]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState, type ChangeEvent } from 'react';
-import { useParams, useRouter } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { useAuth } from '@/lib/auth-context';
 import { useBootstrap } from '@/lib/bootstrap-context';
@@ -32,6 +32,7 @@ import type { PortalAccess } from '@/lib/portal-invite';
 import { MedicationReconciliationPanel } from '@/components/patients/MedicationReconciliationPanel';
 import { DiabetesHistoryPanel } from '@/components/patients/DiabetesHistoryPanel';
 import { ResidentialLocationSummary } from '@/components/patients/ResidentialLocationSummary';
+import { MergePatientDialog } from '@/components/patients/MergePatientDialog';
 import { PatientClinicalNotesPanel } from '@/components/clinical-notes/PatientClinicalNotesPanel';
 import { PatientChartTabs } from '@/components/patients/chart/PatientChartTabs';
 import { PatientChartOverview } from '@/components/patients/chart/PatientChartOverview';
@@ -98,19 +99,10 @@ interface PatientWithEncounters {
   consentStatus?: ConsentStatusItem[];
 }
 
-interface PatientRegistryCandidate {
-  id: string;
-  patientCode: string;
-  firstName: string;
-  lastName: string;
-  phoneE164?: string | null;
-  email?: string | null;
-  nationalIdLast4?: string | null;
-}
-
 function PatientChartWorkspace() {
   const params = useParams();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const clinicId = params.clinicId as string;
   const patientId = params.patientId as string;
   const getToken = useAuth();
@@ -144,11 +136,9 @@ function PatientChartWorkspace() {
   const [portalLinkSaving, setPortalLinkSaving] = useState(false);
   const [portalLinkError, setPortalLinkError] = useState<string | null>(null);
   const [mergeOpen, setMergeOpen] = useState(false);
-  const [mergeQuery, setMergeQuery] = useState('');
-  const [mergeCandidates, setMergeCandidates] = useState<PatientRegistryCandidate[]>([]);
-  const [mergeCandidateId, setMergeCandidateId] = useState('');
-  const [mergeSaving, setMergeSaving] = useState(false);
-  const [mergeError, setMergeError] = useState<string | null>(null);
+  // Set from ?merge=, so the duplicate review queue can hand a decided pair straight to the
+  // preview instead of making an operator search for a chart they were just looking at.
+  const [mergeSourceId, setMergeSourceId] = useState<string | null>(null);
   const [allUsers, setAllUsers] = useState<
     Array<{
       id: string;
@@ -407,46 +397,26 @@ function PatientChartWorkspace() {
   }, [fetchPatient]);
 
   useEffect(() => {
+    const requested = searchParams.get('merge');
+    if (!requested || requested === patientId) return;
+    setMergeSourceId(requested);
+    setMergeOpen(true);
+    // Strip it straight away. A reload should not silently reopen an irreversible flow, and the
+    // address bar should describe the chart rather than a half-made decision about it.
+    const next = new URLSearchParams(searchParams.toString());
+    next.delete('merge');
+    router.replace(
+      `/clinics/${clinicId}/patients/${patientId}${next.size > 0 ? `?${next.toString()}` : ''}`,
+      { scroll: false },
+    );
+  }, [clinicId, patientId, router, searchParams]);
+
+  useEffect(() => {
     if (data?.patient.id && data.patient.id !== patientId) {
       setSuccess('This patient record was merged. Opening the canonical chart.');
       router.replace(`/clinics/${clinicId}/patients/${data.patient.id}`);
     }
   }, [clinicId, data?.patient.id, patientId, router]);
-
-  useEffect(() => {
-    if (!mergeOpen || !getToken) {
-      return;
-    }
-
-    const timeoutId = window.setTimeout(
-      async () => {
-        try {
-          const response = await apiFetch(
-            `/clinics/${encodeURIComponent(clinicId)}/patients?page=1&pageSize=8&q=${encodeURIComponent(mergeQuery)}`,
-            {
-              getToken,
-              activeClinicId: clinicId,
-            },
-          );
-          if (!response.ok) {
-            throw new Error(await readApiError(response));
-          }
-
-          const payload = (await response.json()) as {
-            items: PatientRegistryCandidate[];
-          };
-          setMergeCandidates(payload.items.filter((candidate) => candidate.id !== patientId));
-        } catch (requestError) {
-          setMergeError(
-            requestError instanceof Error ? requestError.message : String(requestError),
-          );
-        }
-      },
-      mergeQuery.trim() ? 250 : 0,
-    );
-
-    return () => window.clearTimeout(timeoutId);
-  }, [clinicId, getToken, mergeOpen, mergeQuery, patientId]);
 
   const researchConsent = data?.consentStatus?.find(
     (c) => c.consentType === 'RESEARCH_DEIDENTIFIED',
@@ -538,40 +508,6 @@ function PatientChartWorkspace() {
       setError(checkInErr instanceof Error ? checkInErr.message : 'Failed to check in patient');
     } finally {
       setLoading(false);
-    }
-  };
-
-  const handleMergeSubmit = async () => {
-    if (!getToken || !mergeCandidateId) {
-      return;
-    }
-
-    setMergeSaving(true);
-    setMergeError(null);
-
-    try {
-      const response = await apiFetch('/admin/patients/merge', {
-        method: 'POST',
-        body: JSON.stringify({
-          canonicalPatientId: patientId,
-          sourcePatientId: mergeCandidateId,
-          portalLinkStrategy: 'CANONICAL',
-          inviteStrategy: 'MERGE',
-        }),
-        getToken,
-        skipClinicHeader: true,
-      });
-      if (!response.ok) {
-        throw new Error(await readApiError(response));
-      }
-
-      setMergeOpen(false);
-      setSuccess('Duplicate patient record merged into this chart successfully.');
-      fetchPatient();
-    } catch (requestError) {
-      setMergeError(requestError instanceof Error ? requestError.message : String(requestError));
-    } finally {
-      setMergeSaving(false);
     }
   };
 
@@ -802,27 +738,23 @@ function PatientChartWorkspace() {
                           <CardHeader>
                             <h2 className="text-lg font-semibold">Duplicate repair</h2>
                             <p className="text-sm text-muted-foreground">
-                              Merge a duplicate patient record into this canonical chart while
-                              preserving clinical history.
+                              Fold a duplicate record into this chart, keeping every visit, note and
+                              consent.
                             </p>
                           </CardHeader>
                           <CardContent className="space-y-3">
                             <p className="rounded-lg border border-border bg-background p-4 text-sm text-muted-foreground">
                               Use this only when two patient rows represent the same real person in
-                              the same clinic.
+                              the same clinic. You will see exactly what moves before anything
+                              changes.
                             </p>
                             <Button
                               variant="outline"
                               size="sm"
-                              onClick={() => {
-                                setMergeOpen(true);
-                                setMergeError(null);
-                                setMergeQuery('');
-                                setMergeCandidateId('');
-                              }}
+                              onClick={() => setMergeOpen(true)}
                               className="w-full"
                             >
-                              Merge duplicate into this chart
+                              Preview a merge into this chart
                             </Button>
                           </CardContent>
                         </Card>
@@ -928,66 +860,23 @@ function PatientChartWorkspace() {
                       </DialogContent>
                     </Dialog>
 
-                    <Dialog open={mergeOpen} onOpenChange={setMergeOpen}>
-                      <DialogContent>
-                        <DialogHeader>
-                          <DialogTitle>Merge duplicate patient</DialogTitle>
-                        </DialogHeader>
-                        <div className="space-y-4 py-4">
-                          {mergeError ? (
-                            <InlineNotice tone="error">{mergeError}</InlineNotice>
-                          ) : null}
-                          <p className="text-sm text-muted-foreground">
-                            The current chart stays canonical. Search for the duplicate patient
-                            record you want to merge into {patient.patientCode}.
-                          </p>
-                          <Input
-                            value={mergeQuery}
-                            onChange={(event: ChangeEvent<HTMLInputElement>) =>
-                              setMergeQuery(event.target.value)
-                            }
-                            placeholder="Search duplicate by name, code, phone, or alias"
-                          />
-                          <div className="max-h-72 space-y-2 overflow-y-auto rounded-lg border border-border/80 bg-background/75 p-2">
-                            {mergeCandidates.map((candidate) => (
-                              <button
-                                key={candidate.id}
-                                type="button"
-                                onClick={() => setMergeCandidateId(candidate.id)}
-                                className={`w-full rounded-lg border p-3 text-left transition ${
-                                  mergeCandidateId === candidate.id
-                                    ? 'border-primary bg-primary/5'
-                                    : 'border-border/70 bg-card hover:border-primary/40'
-                                }`}
-                              >
-                                <p className="font-medium text-foreground">
-                                  {candidate.firstName} {candidate.lastName}
-                                </p>
-                                <p className="mt-1 text-sm text-muted-foreground">
-                                  {candidate.patientCode}
-                                </p>
-                              </button>
-                            ))}
-                            {mergeCandidates.length === 0 ? (
-                              <p className="p-3 text-sm text-muted-foreground">
-                                Search to find another patient record in this clinic.
-                              </p>
-                            ) : null}
-                          </div>
-                        </div>
-                        <DialogFooter>
-                          <Button variant="outline" onClick={() => setMergeOpen(false)}>
-                            Cancel
-                          </Button>
-                          <Button
-                            onClick={() => void handleMergeSubmit()}
-                            disabled={!mergeCandidateId || mergeSaving}
-                          >
-                            {mergeSaving ? 'Merging...' : 'Merge duplicate'}
-                          </Button>
-                        </DialogFooter>
-                      </DialogContent>
-                    </Dialog>
+                    <MergePatientDialog
+                      open={mergeOpen}
+                      onOpenChange={(next) => {
+                        setMergeOpen(next);
+                        if (!next) setMergeSourceId(null);
+                      }}
+                      clinicId={clinicId}
+                      canonical={patient}
+                      initialSourcePatientId={mergeSourceId}
+                      getToken={getToken}
+                      onMerged={(message) => {
+                        setSuccess(message);
+                        setError(null);
+                        void fetchPatient();
+                      }}
+                      onError={setError}
+                    />
                   </div>
                 </PatientChartOverview>
               );

--- a/apps/web/components/admin/DuplicateReviewScreen.tsx
+++ b/apps/web/components/admin/DuplicateReviewScreen.tsx
@@ -22,7 +22,6 @@ import { dataGridSx } from '@/lib/datagrid-theme';
 import { readApiError } from '@/lib/ops';
 import { useAsyncResource } from '@/lib/use-async-resource';
 import {
-  buildComparisonRows,
   candidateStatus,
   confidenceBadgeVariant,
   DUPLICATE_CONFIDENCE_LABELS,
@@ -36,6 +35,7 @@ import {
   type DuplicateCandidatePage,
   type DuplicateReviewStatus,
 } from '@/lib/patient-duplicates';
+import { PatientComparisonTable } from '@/components/patients/PatientComparisonTable';
 import { ActiveFilterSummary } from '@/components/app-shell/ActiveFilterSummary';
 import { AppMetricCard } from '@/components/app-shell/AppMetricCard';
 import { AppPageHeader } from '@/components/app-shell/AppPageHeader';
@@ -832,7 +832,6 @@ function DuplicateComparisonSheet({
   if (!candidate) return null;
 
   const [left, right] = candidate.patients;
-  const rows = buildComparisonRows(left, right);
   const status = candidateStatus(candidate);
 
   return (
@@ -870,52 +869,11 @@ function DuplicateComparisonSheet({
             </InlineNotice>
           ) : null}
 
-          <div className="overflow-x-auto rounded-lg border border-border/70">
-            <table className="w-full min-w-[32rem] text-sm">
-              <caption className="sr-only">
-                Field by field comparison of the two patient charts
-              </caption>
-              <thead className="bg-muted">
-                <tr>
-                  <th scope="col" className="px-4 py-3 text-left font-medium text-foreground">
-                    Field
-                  </th>
-                  <th scope="col" className="px-4 py-3 text-left font-medium text-foreground">
-                    {left.patientCode}
-                  </th>
-                  <th scope="col" className="px-4 py-3 text-left font-medium text-foreground">
-                    {right.patientCode}
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {rows.map((row) => (
-                  <tr key={row.label} className="border-t border-border/70">
-                    <th
-                      scope="row"
-                      className="px-4 py-2.5 text-left font-normal text-muted-foreground"
-                    >
-                      {row.label}
-                    </th>
-                    {/*
-                      "Same" is a word, not only a colour. A matching row is the signal an
-                      operator acts on, and colour alone would not reach a screen reader or
-                      survive a monochrome print of the queue.
-                    */}
-                    <td className="px-4 py-2.5 text-foreground">{row.valueA}</td>
-                    <td className="px-4 py-2.5 text-foreground">
-                      <span className={row.matches ? 'font-medium' : undefined}>{row.valueB}</span>
-                      {row.matches ? (
-                        <span className="ml-2 text-xs uppercase tracking-wide text-success-ink">
-                          Same
-                        </span>
-                      ) : null}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+          <PatientComparisonTable
+            left={left}
+            right={right}
+            caption="Field by field comparison of the two patient charts"
+          />
 
           <div className="grid gap-2 sm:grid-cols-2">
             <Button asChild variant="outline">

--- a/apps/web/components/admin/DuplicateReviewScreen.tsx
+++ b/apps/web/components/admin/DuplicateReviewScreen.tsx
@@ -919,8 +919,13 @@ function DuplicateComparisonSheet({
             */}
             {candidate.mergeEligible ? (
               <Button asChild variant="outline" className="w-full">
-                <Link href={patientChartHref(left)}>
-                  Go to the merge flow on {left.patientCode}
+                {/*
+                  Carries the pair, so the chart opens straight into the merge preview rather
+                  than asking an operator to search again for the chart they were just reading.
+                  The preview is read-only; the merge still has its own confirmation there.
+                */}
+                <Link href={`${patientChartHref(left)}?merge=${encodeURIComponent(right.id)}`}>
+                  Preview merging {right.patientCode} into {left.patientCode}
                 </Link>
               </Button>
             ) : null}

--- a/apps/web/components/patients/MergePatientDialog.tsx
+++ b/apps/web/components/patients/MergePatientDialog.tsx
@@ -122,11 +122,17 @@ export function MergePatientDialog({
   const confirmFieldId = useId();
   const confirmInputRef = useRef<HTMLInputElement>(null);
 
-  // Reopening must not resume a half-finished decision about a different chart.
+  /*
+    Clearing happens on close, not on open.
+
+    Reopening must not resume a half-finished decision about a different chart, but doing the
+    reset when `open` becomes true races the user: the dialog body mounts and is typeable a frame
+    before an effect runs, so a fast typist -- or a test -- could get their first keystrokes wiped
+    by the reset that was meant to prepare the panel for them. Nothing is being typed while it is
+    closed, so that is where the clearing belongs.
+  */
   useEffect(() => {
-    if (!open) return;
-    setStep(initialSourcePatientId ? 'review' : 'choose');
-    setSourcePatientId(initialSourcePatientId ?? '');
+    if (open) return;
     setQuery('');
     setCandidates([]);
     setSearchError(null);
@@ -135,6 +141,13 @@ export function MergePatientDialog({
     setConfirmation('');
     setConfirmationError(null);
     setSubmitError(null);
+  }, [open]);
+
+  // Where to start. Neither field is one the operator can be mid-way through typing into.
+  useEffect(() => {
+    if (!open) return;
+    setStep(initialSourcePatientId ? 'review' : 'choose');
+    setSourcePatientId(initialSourcePatientId ?? '');
   }, [open, initialSourcePatientId]);
 
   useEffect(() => {

--- a/apps/web/components/patients/MergePatientDialog.tsx
+++ b/apps/web/components/patients/MergePatientDialog.tsx
@@ -1,0 +1,701 @@
+'use client';
+
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import { AlertTriangle, ArrowRight, Check, Search, ShieldAlert } from 'lucide-react';
+import { apiFetch, getErrorMessage, readApiError, type GetToken } from '@/lib/api';
+import {
+  confirmationMatches,
+  describeCount,
+  describePortalOutcome,
+  fetchMergePreview,
+  partitionRelations,
+  type MergeFinding,
+  type MergeInviteStrategy,
+  type MergePortalLinkStrategy,
+  type PatientMergePreview,
+} from '@/lib/patient-merge';
+import {
+  DUPLICATE_CONFIDENCE_LABELS,
+  confidenceBadgeVariant,
+  formatReasons,
+} from '@/lib/patient-duplicates';
+import { useAsyncResource } from '@/lib/use-async-resource';
+import { PatientComparisonTable } from '@/components/patients/PatientComparisonTable';
+import { ResourceState } from '@/components/feedback/ResourceState';
+import { InlineNotice } from '@/components/ops/OpsShared';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+export interface MergeCandidate {
+  id: string;
+  patientCode: string;
+  firstName: string;
+  lastName: string;
+  phoneE164?: string | null;
+  email?: string | null;
+  nationalIdLast4?: string | null;
+}
+
+type Step = 'choose' | 'review' | 'confirm';
+
+const STEP_ORDER: Step[] = ['choose', 'review', 'confirm'];
+
+const STEP_COPY: Record<Step, { title: string; description: string }> = {
+  choose: {
+    title: 'Find the duplicate chart',
+    description:
+      'Search for the other record of this same person. Nothing changes until you have read what the merge would do and confirmed it.',
+  },
+  review: {
+    title: 'Check what the merge would do',
+    description:
+      'This is a read-only summary of both charts. Nothing has changed yet, and closing this panel changes nothing.',
+  },
+  confirm: {
+    title: 'Confirm the merge',
+    description:
+      'This cannot be undone. The duplicate chart is retired and everything on it moves to this one.',
+  },
+};
+
+/**
+ * Choose a duplicate, read what merging it would do, then commit.
+ *
+ * Lifted out of the patient chart page, which held the whole flow inline as a search box and a
+ * button that merged two people's records with no confirmation and no destructive treatment --
+ * against the design system's own rule that an irreversible action needs a confirmation step
+ * naming what will change.
+ *
+ * The three steps are one Dialog rather than three, because each step is the same decision seen
+ * in more detail, and because a wizard that navigates away loses the chart the operator opened
+ * it from. The Dialog primitive already handles small screens; nothing here re-solves that.
+ */
+export function MergePatientDialog({
+  open,
+  onOpenChange,
+  clinicId,
+  canonical,
+  initialSourcePatientId,
+  getToken,
+  onMerged,
+  onError,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  clinicId: string;
+  canonical: MergeCandidate;
+  /** Pre-selects the duplicate, so the duplicate review queue can hand a pair straight over. */
+  initialSourcePatientId?: string | null;
+  getToken: GetToken | undefined;
+  onMerged: (message: string) => void;
+  onError: (message: string) => void;
+}) {
+  const [step, setStep] = useState<Step>('choose');
+  const [query, setQuery] = useState('');
+  const [candidates, setCandidates] = useState<MergeCandidate[]>([]);
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const [sourcePatientId, setSourcePatientId] = useState('');
+  const [portalLinkStrategy, setPortalLinkStrategy] = useState<MergePortalLinkStrategy | ''>('');
+  const [inviteStrategy, setInviteStrategy] = useState<MergeInviteStrategy>('MERGE');
+  const [confirmation, setConfirmation] = useState('');
+  const [confirmationError, setConfirmationError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const confirmFieldId = useId();
+  const confirmInputRef = useRef<HTMLInputElement>(null);
+
+  // Reopening must not resume a half-finished decision about a different chart.
+  useEffect(() => {
+    if (!open) return;
+    setStep(initialSourcePatientId ? 'review' : 'choose');
+    setSourcePatientId(initialSourcePatientId ?? '');
+    setQuery('');
+    setCandidates([]);
+    setSearchError(null);
+    setPortalLinkStrategy('');
+    setInviteStrategy('MERGE');
+    setConfirmation('');
+    setConfirmationError(null);
+    setSubmitError(null);
+  }, [open, initialSourcePatientId]);
+
+  useEffect(() => {
+    if (!open || step !== 'choose' || !getToken) return;
+    const timer = setTimeout(
+      () => {
+        void (async () => {
+          try {
+            const response = await apiFetch(
+              `/clinics/${encodeURIComponent(clinicId)}/patients?page=1&pageSize=8&q=${encodeURIComponent(query)}`,
+              { getToken, activeClinicId: clinicId },
+            );
+            if (!response.ok) throw new Error('Patient search failed');
+            const payload = (await response.json()) as { items: MergeCandidate[] };
+            setCandidates(payload.items.filter((candidate) => candidate.id !== canonical.id));
+            setSearchError(null);
+          } catch (error) {
+            setSearchError(getErrorMessage(error, 'Patient search could not be completed.'));
+          }
+        })();
+      },
+      query.trim() ? 250 : 0,
+    );
+    return () => clearTimeout(timer);
+  }, [canonical.id, clinicId, getToken, open, query, step]);
+
+  const previewEnabled = open && step !== 'choose' && sourcePatientId !== '' && !!getToken;
+
+  const preview = useAsyncResource<PatientMergePreview>({
+    resourceKey: [clinicId, canonical.id, sourcePatientId, portalLinkStrategy, inviteStrategy].join(
+      '|',
+    ),
+    enabled: previewEnabled,
+    errorMessage: 'The merge preview could not be loaded.',
+    fetcher: (token, signal) =>
+      fetchMergePreview(
+        {
+          clinicId,
+          canonicalPatientId: canonical.id,
+          sourcePatientId,
+          portalLinkStrategy: portalLinkStrategy || undefined,
+          inviteStrategy,
+        },
+        token,
+        signal,
+      ),
+  });
+
+  const data = preview.data;
+
+  const handleSubmit = useCallback(async () => {
+    if (!data || !getToken) return;
+    if (!confirmationMatches(confirmation, data.source.patientCode)) {
+      setConfirmationError(
+        `Type ${data.source.patientCode} to confirm you are retiring that chart.`,
+      );
+      confirmInputRef.current?.focus();
+      return;
+    }
+
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      const response = await apiFetch('/admin/patients/merge', {
+        method: 'POST',
+        body: JSON.stringify({
+          canonicalPatientId: canonical.id,
+          sourcePatientId: data.source.id,
+          portalLinkStrategy: data.strategies.portalLinkStrategy,
+          inviteStrategy: data.strategies.inviteStrategy,
+          // Proves the operator acted on the panel they were shown.
+          previewFingerprint: data.fingerprint,
+        }),
+        getToken,
+        skipClinicHeader: true,
+      });
+      if (!response.ok) throw await readApiError(response);
+      onOpenChange(false);
+      onMerged(
+        `${data.source.patientCode} was merged into ${canonical.patientCode}. Its old chart code now finds this record.`,
+      );
+    } catch (error) {
+      const message = getErrorMessage(error, 'The merge could not be completed.');
+      setSubmitError(message);
+      onError(message);
+      // The charts may have moved under the panel, so re-read rather than leaving a stale one up.
+      preview.refresh();
+    } finally {
+      setSubmitting(false);
+    }
+  }, [
+    canonical.id,
+    canonical.patientCode,
+    confirmation,
+    data,
+    getToken,
+    onError,
+    onMerged,
+    onOpenChange,
+    preview,
+  ]);
+
+  const stepIndex = STEP_ORDER.indexOf(step);
+  const copy = STEP_COPY[step];
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-3xl">
+        <DialogHeader>
+          <p className="text-eyebrow text-muted-foreground">
+            Step {stepIndex + 1} of {STEP_ORDER.length}
+          </p>
+          <DialogTitle>{copy.title}</DialogTitle>
+          <DialogDescription>{copy.description}</DialogDescription>
+        </DialogHeader>
+
+        {/*
+          One polite live region for the whole flow. Moving between steps changes the entire body
+          of the dialog, and a screen-reader user who tabbed into it would otherwise get no
+          indication that the ground moved.
+        */}
+        <span aria-live="polite" className="sr-only">
+          {`Step ${stepIndex + 1} of ${STEP_ORDER.length}. ${copy.title}.`}
+        </span>
+
+        <div className="space-y-4 py-2">
+          {submitError ? <InlineNotice tone="error">{submitError}</InlineNotice> : null}
+
+          {step === 'choose' ? (
+            <ChooseStep
+              canonical={canonical}
+              candidates={candidates}
+              query={query}
+              onQueryChange={setQuery}
+              error={searchError}
+              selectedId={sourcePatientId}
+              onSelect={setSourcePatientId}
+            />
+          ) : (
+            <ResourceState
+              state={preview}
+              errorTitle="The merge preview could not be loaded."
+              skeleton={<PreviewSkeleton />}
+            >
+              {(loaded) =>
+                step === 'review' ? (
+                  <ReviewStep
+                    preview={loaded}
+                    portalLinkStrategy={portalLinkStrategy}
+                    onPortalLinkStrategyChange={setPortalLinkStrategy}
+                    inviteStrategy={inviteStrategy}
+                    onInviteStrategyChange={setInviteStrategy}
+                  />
+                ) : (
+                  <ConfirmStep
+                    preview={loaded}
+                    canonicalPatientCode={canonical.patientCode}
+                    fieldId={confirmFieldId}
+                    inputRef={confirmInputRef}
+                    value={confirmation}
+                    error={confirmationError}
+                    onChange={(next) => {
+                      setConfirmation(next);
+                      if (confirmationError) setConfirmationError(null);
+                    }}
+                  />
+                )
+              }
+            </ResourceState>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => (step === 'choose' ? onOpenChange(false) : setStep(previousStep(step)))}
+            disabled={submitting}
+          >
+            {step === 'choose' ? 'Cancel' : 'Back'}
+          </Button>
+
+          {step === 'choose' ? (
+            <Button disabled={!sourcePatientId} onClick={() => setStep('review')}>
+              Preview the merge
+              <ArrowRight aria-hidden="true" className="ml-2 h-4 w-4" />
+            </Button>
+          ) : step === 'review' ? (
+            /*
+              Blocked shows no continue control at all rather than a disabled one. A disabled
+              button says "not now"; a refused merge needs the operator to go and do something
+              else, and the recovery line above says what.
+            */
+            data?.canMerge ? (
+              <Button onClick={() => setStep('confirm')}>
+                Continue
+                <ArrowRight aria-hidden="true" className="ml-2 h-4 w-4" />
+              </Button>
+            ) : null
+          ) : (
+            <Button
+              variant="destructive"
+              onClick={() => void handleSubmit()}
+              disabled={submitting || !data}
+            >
+              <ShieldAlert aria-hidden="true" className="mr-2 h-4 w-4" />
+              Merge and retire {data?.source.patientCode ?? 'the duplicate'}
+              {/* The label never changes size mid-press; the state goes to the live region. */}
+              <span aria-live="polite" className="sr-only">
+                {submitting ? 'Merging the two charts' : ''}
+              </span>
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function previousStep(step: Step): Step {
+  return step === 'confirm' ? 'review' : 'choose';
+}
+
+function PreviewSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      className="space-y-3 rounded-lg border border-border/70 p-4"
+    >
+      <span className="sr-only">Loading the merge preview</span>
+      {[0, 1, 2, 3, 4].map((line) => (
+        <div key={line} className="h-4 animate-pulse rounded bg-muted motion-reduce:animate-none" />
+      ))}
+    </div>
+  );
+}
+
+function ChooseStep({
+  canonical,
+  candidates,
+  query,
+  onQueryChange,
+  error,
+  selectedId,
+  onSelect,
+}: {
+  canonical: MergeCandidate;
+  candidates: MergeCandidate[];
+  query: string;
+  onQueryChange: (value: string) => void;
+  error: string | null;
+  selectedId: string;
+  onSelect: (id: string) => void;
+}) {
+  const searchId = useId();
+
+  return (
+    <div className="space-y-3">
+      {error ? <InlineNotice tone="error">{error}</InlineNotice> : null}
+
+      <InlineNotice tone="info" live={false}>
+        {canonical.patientCode} is the chart that survives. The record you pick here is the one that
+        gets retired.
+      </InlineNotice>
+
+      <div className="space-y-2">
+        <Label htmlFor={searchId}>Search this clinic&rsquo;s charts</Label>
+        <div className="relative">
+          <Search
+            aria-hidden="true"
+            className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+          />
+          <Input
+            id={searchId}
+            value={query}
+            onChange={(event) => onQueryChange(event.target.value)}
+            placeholder="Name, chart code, phone, or a retired code"
+            className="pl-9"
+          />
+        </div>
+      </div>
+
+      <ul className="max-h-72 space-y-2 overflow-y-auto rounded-lg border border-border/70 bg-background/75 p-2">
+        {candidates.map((candidate) => {
+          const selected = selectedId === candidate.id;
+          return (
+            <li key={candidate.id}>
+              <button
+                type="button"
+                aria-pressed={selected}
+                onClick={() => onSelect(candidate.id)}
+                className={`w-full rounded-lg border p-3 text-left transition-colors ${
+                  selected
+                    ? 'border-primary bg-primary/5'
+                    : 'border-border/70 bg-card hover:border-primary/40'
+                }`}
+              >
+                <span className="flex items-center justify-between gap-3">
+                  <span className="font-medium text-foreground">
+                    {candidate.firstName} {candidate.lastName}
+                  </span>
+                  {selected ? (
+                    <Check aria-hidden="true" className="h-4 w-4 shrink-0 text-primary" />
+                  ) : null}
+                </span>
+                <span className="mt-1 block text-sm tabular-nums text-muted-foreground">
+                  {candidate.patientCode}
+                  {candidate.phoneE164 ? ` · ${candidate.phoneE164}` : ''}
+                  {candidate.nationalIdLast4 ? ` · ID …${candidate.nationalIdLast4}` : ''}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+        {candidates.length === 0 ? (
+          <li className="p-3 text-sm text-muted-foreground">
+            {query.trim()
+              ? 'No other chart in this clinic matches that search.'
+              : 'Start typing to find the duplicate record.'}
+          </li>
+        ) : null}
+      </ul>
+    </div>
+  );
+}
+
+function FindingList({ findings, tone }: { findings: MergeFinding[]; tone: 'error' | 'warning' }) {
+  if (findings.length === 0) return null;
+
+  return (
+    <ul className="space-y-2">
+      {findings.map((finding) => (
+        <li key={finding.code}>
+          <InlineNotice tone={tone}>
+            <span className="flex gap-2">
+              <AlertTriangle aria-hidden="true" className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>
+                <span className="font-medium">{finding.label}</span>
+                {finding.detail ? <span className="opacity-90"> — {finding.detail}</span> : null}
+                {/* Every refusal names a next step; a blocker nobody can act on is a support call. */}
+                <span className="mt-1 block opacity-90">{finding.recovery}</span>
+              </span>
+            </span>
+          </InlineNotice>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function ReviewStep({
+  preview,
+  portalLinkStrategy,
+  onPortalLinkStrategyChange,
+  inviteStrategy,
+  onInviteStrategyChange,
+}: {
+  preview: PatientMergePreview;
+  portalLinkStrategy: MergePortalLinkStrategy | '';
+  onPortalLinkStrategyChange: (value: MergePortalLinkStrategy) => void;
+  inviteStrategy: MergeInviteStrategy;
+  onInviteStrategyChange: (value: MergeInviteStrategy) => void;
+}) {
+  const { moving, untouched, emptyCount, totalMoving } = useMemo(
+    () => partitionRelations(preview.relations),
+    [preview.relations],
+  );
+  const bothLinked = preview.portal.canonicalLinked && preview.portal.sourceLinked;
+  const portalFieldId = useId();
+  const inviteFieldId = useId();
+
+  return (
+    <div className="space-y-5">
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant={confidenceBadgeVariant(preview.duplicateSignal.confidence)}>
+          {DUPLICATE_CONFIDENCE_LABELS[preview.duplicateSignal.confidence]}
+        </Badge>
+        {preview.duplicateSignal.reasons.length > 0 ? (
+          <span className="text-sm text-muted-foreground">
+            {formatReasons(preview.duplicateSignal.reasons)}
+          </span>
+        ) : (
+          <span className="text-sm text-muted-foreground">
+            Nothing about these two charts matches automatically.
+          </span>
+        )}
+      </div>
+
+      <FindingList findings={preview.blockers} tone="error" />
+      <FindingList findings={preview.warnings} tone="warning" />
+
+      <PatientComparisonTable
+        left={preview.canonical}
+        right={preview.source}
+        leftLabel="Keeps"
+        rightLabel="Retired"
+        caption="Field by field comparison of the chart being kept and the chart being retired"
+      />
+
+      <section className="space-y-2">
+        <h3 className="text-base font-semibold text-foreground">What moves</h3>
+        {moving.length > 0 ? (
+          <dl className="divide-y divide-border/70 rounded-lg border border-border/70">
+            {moving.map((row) => (
+              <div key={row.key} className="flex items-baseline justify-between gap-4 px-4 py-2.5">
+                <dt className="text-sm text-muted-foreground">{row.label}</dt>
+                <dd className="text-sm tabular-nums text-foreground">
+                  <span className="font-medium">{describeCount(row.sourceCount, row.label)}</span>
+                  <span className="text-muted-foreground">
+                    {' '}
+                    joining {describeCount(row.canonicalCount, row.label)} already here
+                  </span>
+                </dd>
+              </div>
+            ))}
+          </dl>
+        ) : (
+          <p className="rounded-lg border border-border/70 bg-background/70 px-4 py-3 text-sm text-muted-foreground">
+            The duplicate chart holds no clinical records. Only its identity and chart code move.
+          </p>
+        )}
+        <p className="text-sm text-muted-foreground">
+          {totalMoving === 0
+            ? 'Nothing on the retired chart needs moving.'
+            : `${totalMoving} record${totalMoving === 1 ? '' : 's'} move in total.`}
+          {untouched.length > 0
+            ? ` ${untouched.length} kind${untouched.length === 1 ? '' : 's'} of record on ${preview.canonical.patientCode} are untouched.`
+            : ''}
+          {emptyCount > 0 ? ` ${emptyCount} kinds are empty on both charts.` : ''}
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h3 className="text-base font-semibold text-foreground">App access and invitations</h3>
+        <p className="text-sm text-muted-foreground">{describePortalOutcome(preview)}</p>
+
+        {bothLinked ? (
+          <div className="space-y-2">
+            <Label htmlFor={portalFieldId}>Which app account keeps access</Label>
+            <Select
+              value={portalLinkStrategy || 'CANONICAL'}
+              onValueChange={(value) =>
+                onPortalLinkStrategyChange(value as MergePortalLinkStrategy)
+              }
+            >
+              <SelectTrigger id={portalFieldId}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="CANONICAL">
+                  The account on {preview.canonical.patientCode}
+                </SelectItem>
+                <SelectItem value="SOURCE">The account on {preview.source.patientCode}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        ) : null}
+
+        {preview.portal.canonicalPendingInvites + preview.portal.sourcePendingInvites > 0 ? (
+          <div className="space-y-2">
+            <Label htmlFor={inviteFieldId}>Unclaimed invitations</Label>
+            <Select
+              value={inviteStrategy}
+              onValueChange={(value) => onInviteStrategyChange(value as MergeInviteStrategy)}
+            >
+              <SelectTrigger id={inviteFieldId}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="MERGE">Keep both, on the surviving chart</SelectItem>
+                <SelectItem value="CANONICAL">
+                  Keep this chart&rsquo;s, cancel the duplicate&rsquo;s
+                </SelectItem>
+                <SelectItem value="SOURCE">
+                  Keep the duplicate&rsquo;s, cancel this chart&rsquo;s
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        ) : null}
+      </section>
+
+      <section className="space-y-2">
+        <h3 className="text-base font-semibold text-foreground">Chart codes</h3>
+        <p className="text-sm text-muted-foreground">
+          Searching for <span className="font-medium text-foreground">{preview.aliases.added}</span>{' '}
+          will find {preview.canonical.patientCode} after the merge. The retired chart is renamed to{' '}
+          <span className="tabular-nums">{preview.tombstonePatientCode}</span>.
+          {preview.aliases.carriedOver.length > 0
+            ? ` ${preview.aliases.carriedOver.length} earlier code${
+                preview.aliases.carriedOver.length === 1 ? '' : 's'
+              } carry across too.`
+            : ''}
+        </p>
+      </section>
+    </div>
+  );
+}
+
+function ConfirmStep({
+  preview,
+  canonicalPatientCode,
+  fieldId,
+  inputRef,
+  value,
+  error,
+  onChange,
+}: {
+  preview: PatientMergePreview;
+  canonicalPatientCode: string;
+  fieldId: string;
+  inputRef: React.RefObject<HTMLInputElement>;
+  value: string;
+  error: string | null;
+  onChange: (value: string) => void;
+}) {
+  const { totalMoving } = partitionRelations(preview.relations);
+
+  return (
+    <div className="space-y-4">
+      <InlineNotice tone="warning" live={false}>
+        <span className="flex gap-2">
+          <ShieldAlert aria-hidden="true" className="mt-0.5 h-4 w-4 shrink-0" />
+          <span>
+            <span className="block font-medium">This cannot be undone.</span>
+            {preview.source.patientCode} stops being a chart anyone can open.{' '}
+            {totalMoving === 0
+              ? 'It holds no records to move.'
+              : `Its ${totalMoving} record${totalMoving === 1 ? '' : 's'} move to ${canonicalPatientCode}.`}{' '}
+            {describePortalOutcome(preview)}
+          </span>
+        </span>
+      </InlineNotice>
+
+      <div className="space-y-2">
+        <Label htmlFor={fieldId}>
+          Type {preview.source.patientCode} to confirm you are retiring that chart
+        </Label>
+        <Input
+          id={fieldId}
+          ref={inputRef}
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          placeholder={preview.source.patientCode}
+          autoComplete="off"
+          spellCheck={false}
+          aria-invalid={error ? true : undefined}
+          aria-describedby={error ? `${fieldId}-error` : undefined}
+          className="tabular-nums"
+        />
+        {error ? (
+          <p id={`${fieldId}-error`} role="alert" className="text-sm text-destructive">
+            {error}
+          </p>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            Typing the code is the last check that you are retiring the record you meant to.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/patients/MergePatientDialog.tsx
+++ b/apps/web/components/patients/MergePatientDialog.tsx
@@ -660,8 +660,14 @@ function ConfirmStep({
         <span className="flex gap-2">
           <ShieldAlert aria-hidden="true" className="mt-0.5 h-4 w-4 shrink-0" />
           <span>
-            <span className="block font-medium">This cannot be undone.</span>
-            {preview.source.patientCode} stops being a chart anyone can open.{' '}
+            {/*
+              The dialog description above already says the merge cannot be undone. Repeating it
+              here word for word teaches the reader to skim the notice; what belongs here is the
+              consequence for these two charts specifically.
+            */}
+            <span className="block font-medium">
+              {preview.source.patientCode} stops being a chart anyone can open.
+            </span>
             {totalMoving === 0
               ? 'It holds no records to move.'
               : `Its ${totalMoving} record${totalMoving === 1 ? '' : 's'} move to ${canonicalPatientCode}.`}{' '}

--- a/apps/web/components/patients/PatientComparisonTable.tsx
+++ b/apps/web/components/patients/PatientComparisonTable.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { buildComparisonRows, type DuplicateCandidatePatient } from '@/lib/patient-duplicates';
+
+/**
+ * Two patient charts, field by field.
+ *
+ * One table for the duplicate review queue and for the merge preview. They ask different
+ * questions -- "are these the same person" and "what happens if I say they are" -- but they ask
+ * it of the same eleven fields, and two implementations would eventually disagree about how to
+ * show a missing date of birth in exactly the place an operator is deciding whether two records
+ * describe one person.
+ */
+export function PatientComparisonTable({
+  left,
+  right,
+  caption,
+  leftLabel,
+  rightLabel,
+}: {
+  left: DuplicateCandidatePatient;
+  right: DuplicateCandidatePatient;
+  caption: string;
+  /** Overrides the column heading, where the chart's role matters more than its code. */
+  leftLabel?: string;
+  rightLabel?: string;
+}) {
+  const rows = buildComparisonRows(left, right);
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-border/70">
+      <table className="w-full min-w-[32rem] text-sm">
+        <caption className="sr-only">{caption}</caption>
+        <thead className="bg-muted">
+          <tr>
+            <th scope="col" className="px-4 py-3 text-left font-medium text-foreground">
+              Field
+            </th>
+            <th scope="col" className="px-4 py-3 text-left font-medium text-foreground">
+              {leftLabel ? (
+                <>
+                  <span className="block text-eyebrow text-muted-foreground">{leftLabel}</span>
+                  {left.patientCode}
+                </>
+              ) : (
+                left.patientCode
+              )}
+            </th>
+            <th scope="col" className="px-4 py-3 text-left font-medium text-foreground">
+              {rightLabel ? (
+                <>
+                  <span className="block text-eyebrow text-muted-foreground">{rightLabel}</span>
+                  {right.patientCode}
+                </>
+              ) : (
+                right.patientCode
+              )}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.label} className="border-t border-border/70">
+              <th scope="row" className="px-4 py-2.5 text-left font-normal text-muted-foreground">
+                {row.label}
+              </th>
+              {/*
+                "Same" is a word, not only a colour. A matching row is the signal an operator
+                acts on, and colour alone would not reach a screen reader or survive a
+                monochrome print.
+              */}
+              <td className="px-4 py-2.5 text-foreground">{row.valueA}</td>
+              <td className="px-4 py-2.5 text-foreground">
+                <span className={row.matches ? 'font-medium' : undefined}>{row.valueB}</span>
+                {row.matches ? (
+                  <span className="ml-2 text-xs uppercase tracking-wide text-success-ink">
+                    Same
+                  </span>
+                ) : null}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/e2e/patient-merge-preview.spec.js
+++ b/apps/web/e2e/patient-merge-preview.spec.js
@@ -1,0 +1,231 @@
+const { randomUUID } = require('crypto');
+const { test, expect } = require('@playwright/test');
+const AxeBuilder = require('@axe-core/playwright').default;
+
+const { storageStateFor } = require('../playwright/roles');
+
+/**
+ * The merge preview, and the confirmation in front of it.
+ *
+ * Every chart this suite acts on is created by the suite. Merging is irreversible, so a spec
+ * pointed at a seeded fixture destroys it: running against SEED_SAMPLE_DUPLICATES' Akua Boateng
+ * pair would take it out of the review queue permanently and break duplicate-review.spec.js on
+ * the next run against the same database. Creating a throwaway pair costs two form submissions
+ * and makes the suite re-runnable against a database it has already touched.
+ *
+ * What matters most here is what the preview promises. Merge is the one action in this product a
+ * person cannot undo from the product, and a panel that under-reported what it was about to do
+ * would look correct from the outside on the day it shipped.
+ */
+
+const DOB = '1991-03-08';
+
+/** Two charts for the same imaginary person, differing only in national ID. */
+async function createDuplicatePair(page) {
+  const run = randomUUID().replaceAll('-', '').slice(0, 10);
+  const charts = [];
+
+  for (const suffix of ['a', 'b']) {
+    await page.goto('/patients/new');
+    await page.getByLabel('First name', { exact: true }).fill('Merge');
+    await page.getByLabel('Last name', { exact: true }).fill(`E2E-${run}`);
+    await page.getByLabel('Date of birth').fill(DOB);
+    await page.getByLabel('National ID', { exact: true }).fill(`E2E-MERGE-${run}-${suffix}`);
+    await page.getByRole('button', { name: 'Create patient' }).click();
+    await page.waitForURL(/\/clinics\/[^/]+\/patients\/[^/]+/, { timeout: 20_000 });
+
+    const [, , clinicId, , patientId] = new URL(page.url()).pathname.split('/');
+    const code = await page
+      .getByText(/^NKP-\d{4}-\d{6}$/)
+      .first()
+      .innerText();
+    charts.push({ clinicId, patientId, code });
+  }
+
+  return { run, canonical: charts[0], duplicate: charts[1] };
+}
+
+/** Opens the merge dialog on a chart and returns it. */
+async function openMergeDialog(page, chart) {
+  await page.goto(`/clinics/${chart.clinicId}/patients/${chart.patientId}`);
+  await page.getByRole('button', { name: 'Preview a merge into this chart' }).click();
+  return page.getByRole('dialog');
+}
+
+/** Walks step one, landing on the preview. */
+async function selectDuplicate(dialog, run, duplicateCode) {
+  await dialog.getByLabel(/Search this clinic/).fill(`Merge E2E-${run}`);
+  await dialog.getByRole('button', { name: new RegExp(duplicateCode) }).click();
+  await dialog.getByRole('button', { name: 'Preview the merge' }).click();
+}
+
+test.describe('a system admin merging two charts', () => {
+  test.use({ storageState: storageStateFor('staff') });
+
+  test('shows what the merge would do before anything changes', async ({ page }) => {
+    const { run, canonical, duplicate } = await createDuplicatePair(page);
+    const dialog = await openMergeDialog(page, canonical);
+
+    // Step one says which chart survives, before a duplicate has even been picked.
+    await expect(dialog.getByText(`${canonical.code} is the chart that survives`)).toBeVisible();
+
+    await selectDuplicate(dialog, run, duplicate.code);
+
+    await expect(
+      dialog.getByRole('heading', { name: 'Check what the merge would do' }),
+    ).toBeVisible({ timeout: 20_000 });
+    // Read-only, and it says so.
+    await expect(dialog.getByText(/Nothing has changed yet/)).toBeVisible();
+
+    // The shared comparison table, located the same way duplicate-review.spec.js locates it.
+    await expect(dialog.getByRole('rowheader', { name: 'Date of birth' })).toBeVisible();
+    await expect(
+      dialog.getByRole('columnheader', { name: new RegExp(canonical.code) }),
+    ).toBeVisible();
+    await expect(
+      dialog.getByRole('columnheader', { name: new RegExp(duplicate.code) }),
+    ).toBeVisible();
+
+    // What moves, and which codes still find the record afterwards.
+    await expect(dialog.getByRole('heading', { name: 'What moves' })).toBeVisible();
+    await expect(dialog.getByRole('heading', { name: 'Chart codes' })).toBeVisible();
+    await expect(dialog.getByText(new RegExp(`Searching for.*${duplicate.code}`))).toBeVisible();
+
+    // A fresh chart has no app account, and the panel says so rather than staying silent.
+    await expect(dialog.getByText(/Neither chart has an app account/)).toBeVisible();
+
+    // Nothing has been written: both charts still open on their own.
+    await page.goto(`/clinics/${duplicate.clinicId}/patients/${duplicate.patientId}`);
+    await expect(page.getByText(duplicate.code).first()).toBeVisible({ timeout: 20_000 });
+  });
+
+  test('will not commit until the retiring chart code is typed back', async ({ page }) => {
+    const { run, canonical, duplicate } = await createDuplicatePair(page);
+    const dialog = await openMergeDialog(page, canonical);
+    await selectDuplicate(dialog, run, duplicate.code);
+
+    await dialog.getByRole('button', { name: 'Continue' }).click({ timeout: 20_000 });
+    await expect(dialog.getByRole('heading', { name: 'Confirm the merge' })).toBeVisible();
+    // The consequence is stated for these two charts specifically, not as a generic warning.
+    await expect(
+      dialog.getByText(`${duplicate.code} stops being a chart anyone can open.`),
+    ).toBeVisible();
+
+    // The surviving chart's code is not the one being retired.
+    await dialog.getByLabel(new RegExp(`Type ${duplicate.code}`)).fill(canonical.code);
+    await dialog.getByRole('button', { name: new RegExp(`Merge and retire`) }).click();
+    await expect(dialog.getByRole('alert')).toContainText(duplicate.code);
+
+    // Still on the confirmation, and the duplicate is still a chart.
+    await expect(dialog.getByRole('heading', { name: 'Confirm the merge' })).toBeVisible();
+    await page.goto(`/clinics/${duplicate.clinicId}/patients/${duplicate.patientId}`);
+    await expect(page.getByText(duplicate.code).first()).toBeVisible({ timeout: 20_000 });
+  });
+
+  test('retires the duplicate and leaves its code finding the surviving chart', async ({
+    page,
+  }) => {
+    const { run, canonical, duplicate } = await createDuplicatePair(page);
+    const dialog = await openMergeDialog(page, canonical);
+    await selectDuplicate(dialog, run, duplicate.code);
+
+    await dialog.getByRole('button', { name: 'Continue' }).click({ timeout: 20_000 });
+    await dialog.getByLabel(new RegExp(`Type ${duplicate.code}`)).fill(duplicate.code);
+    await dialog.getByRole('button', { name: new RegExp('Merge and retire') }).click();
+
+    await expect(page.getByText(new RegExp(`${duplicate.code} was merged into`))).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // The retired chart's own address now resolves to the surviving one, which is the promise
+    // the preview made about chart codes.
+    await page.goto(`/clinics/${duplicate.clinicId}/patients/${duplicate.patientId}`);
+    await page.waitForURL(`**/clinics/${canonical.clinicId}/patients/${canonical.patientId}`, {
+      timeout: 30_000,
+    });
+
+    // And previewing the same pair again refuses, with a reason and a next step.
+    const reopened = await openMergeDialog(page, canonical);
+    await reopened.getByLabel(/Search this clinic/).fill(duplicate.code);
+    await expect(reopened.getByText(/No other chart in this clinic matches/)).toBeVisible({
+      timeout: 20_000,
+    });
+  });
+
+  test('closing the panel changes nothing', async ({ page }) => {
+    const { run, canonical, duplicate } = await createDuplicatePair(page);
+    const dialog = await openMergeDialog(page, canonical);
+    await selectDuplicate(dialog, run, duplicate.code);
+    await expect(
+      dialog.getByRole('heading', { name: 'Check what the merge would do' }),
+    ).toBeVisible({ timeout: 20_000 });
+
+    await dialog.getByRole('button', { name: 'Back' }).click();
+    await page.keyboard.press('Escape');
+
+    await page.goto(`/clinics/${duplicate.clinicId}/patients/${duplicate.patientId}`);
+    await expect(page.getByText(duplicate.code).first()).toBeVisible({ timeout: 20_000 });
+  });
+
+  test('reads and operates at every width, and by keyboard', async ({ page }) => {
+    const { run, canonical, duplicate } = await createDuplicatePair(page);
+
+    /*
+      The preview is a dialog rather than a route, so the shared responsive and dark-mode sweeps
+      in responsive-migration.spec.js and dark-mode.spec.js cannot reach it. It is the densest
+      thing in the product -- a comparison table, a definition list and two selects -- so the same
+      contract is asserted here instead of assumed.
+    */
+    for (const width of [375, 768, 1024, 1440]) {
+      await page.setViewportSize({ width, height: 900 });
+      const dialog = await openMergeDialog(page, canonical);
+      await selectDuplicate(dialog, run, duplicate.code);
+      await expect(
+        dialog.getByRole('heading', { name: 'Check what the merge would do' }),
+      ).toBeVisible({ timeout: 20_000 });
+
+      // The wide comparison table scrolls inside its own container; the page never does.
+      const overflow = await page.evaluate(
+        () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+      );
+      expect(overflow, `horizontal overflow at ${width}px`).toBeLessThanOrEqual(1);
+
+      const violations = (
+        await new AxeBuilder({ page })
+          .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+          .analyze()
+      ).violations;
+      expect(
+        violations,
+        violations.map((v) => `${v.id} (${v.impact}): ${v.help}`).join('\n'),
+      ).toEqual([]);
+
+      await page.keyboard.press('Escape');
+    }
+
+    // Escape closes it, and the flow is reachable without a pointer.
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto(`/clinics/${canonical.clinicId}/patients/${canonical.patientId}`);
+    const trigger = page.getByRole('button', { name: 'Preview a merge into this chart' });
+    await trigger.focus();
+    await page.keyboard.press('Enter');
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(page.getByRole('dialog')).toHaveCount(0);
+  });
+});
+
+test.describe('a clinical role', () => {
+  test.use({ storageState: storageStateFor('doctor') });
+
+  test('is not offered the merge at all', async ({ page }) => {
+    await page.goto('/patients');
+    await expect(page.getByRole('heading', { name: /patient/i }).first()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // Duplicate repair is a system-admin card. A doctor holds neither PATIENT.MERGE nor
+    // PATIENT.DUPLICATE.REVIEW, and the API refuses the preview route independently.
+    await expect(page.getByRole('button', { name: /Preview a merge/ })).toHaveCount(0);
+  });
+});

--- a/apps/web/e2e/patient-merge-preview.spec.js
+++ b/apps/web/e2e/patient-merge-preview.spec.js
@@ -49,12 +49,21 @@ async function createDuplicatePair(page) {
 async function openMergeDialog(page, chart) {
   await page.goto(`/clinics/${chart.clinicId}/patients/${chart.patientId}`);
   await page.getByRole('button', { name: 'Preview a merge into this chart' }).click();
-  return page.getByRole('dialog');
+  const dialog = page.getByRole('dialog');
+  // Wait for the step, not just the dialog: typing into a panel that has not settled is how a
+  // real operator loses their first keystrokes, and the suite should not paper over that.
+  await expect(dialog.getByRole('heading', { name: 'Find the duplicate chart' })).toBeVisible({
+    timeout: 20_000,
+  });
+  return dialog;
 }
 
 /** Walks step one, landing on the preview. */
 async function selectDuplicate(dialog, run, duplicateCode) {
   await dialog.getByLabel(/Search this clinic/).fill(`Merge E2E-${run}`);
+  await expect(dialog.getByRole('button', { name: new RegExp(duplicateCode) })).toBeVisible({
+    timeout: 20_000,
+  });
   await dialog.getByRole('button', { name: new RegExp(duplicateCode) }).click();
   await dialog.getByRole('button', { name: 'Preview the merge' }).click();
 }

--- a/apps/web/lib/patient-merge.test.ts
+++ b/apps/web/lib/patient-merge.test.ts
@@ -1,0 +1,171 @@
+import {
+  confirmationMatches,
+  describeCount,
+  describePortalOutcome,
+  mergePreviewPath,
+  partitionRelations,
+  type MergeRelationCount,
+  type PatientMergePreview,
+} from './patient-merge';
+import { MERGE_BLOCKER_CODES, MERGE_FINDING_LABELS, MERGE_WARNING_CODES } from '@nkwapa/db';
+
+function relation(
+  key: string,
+  canonicalCount: number,
+  sourceCount: number,
+  label = key,
+): MergeRelationCount {
+  return { key, label, canonicalCount, sourceCount };
+}
+
+const chart = (patientCode: string) =>
+  ({ patientCode }) as unknown as PatientMergePreview['canonical'];
+
+describe('mergePreviewPath', () => {
+  it('asks the chart-scoped route about the duplicate', () => {
+    expect(
+      mergePreviewPath({
+        clinicId: 'clinic-1',
+        canonicalPatientId: 'patient-1',
+        sourcePatientId: 'patient-2',
+      }),
+    ).toBe('/clinics/clinic-1/patients/patient-1/merge-preview?sourcePatientId=patient-2');
+  });
+
+  it('carries a strategy only once one has been chosen', () => {
+    const path = mergePreviewPath({
+      clinicId: 'clinic-1',
+      canonicalPatientId: 'patient-1',
+      sourcePatientId: 'patient-2',
+      portalLinkStrategy: 'SOURCE',
+    });
+    expect(path).toContain('portalLinkStrategy=SOURCE');
+    expect(path).not.toContain('inviteStrategy');
+  });
+
+  it('escapes ids rather than pasting them into a path', () => {
+    expect(
+      mergePreviewPath({
+        clinicId: 'a/b',
+        canonicalPatientId: 'c d',
+        sourcePatientId: 'e&f',
+      }),
+    ).toBe('/clinics/a%2Fb/patients/c%20d/merge-preview?sourcePatientId=e%26f');
+  });
+});
+
+describe('partitionRelations', () => {
+  const relations = [
+    relation('encounter', 2, 3, 'Visits'),
+    relation('clinicalNote', 1, 0, 'Clinical notes'),
+    relation('appointment', 0, 0, 'Appointments'),
+    relation('reminder', 0, 4, 'Reminders and messages'),
+  ];
+
+  it('leads with what actually moves', () => {
+    expect(partitionRelations(relations).moving.map((row) => row.key)).toEqual([
+      'encounter',
+      'reminder',
+    ]);
+  });
+
+  it('keeps what the surviving chart already holds, which the merge does not touch', () => {
+    expect(partitionRelations(relations).untouched.map((row) => row.key)).toEqual(['clinicalNote']);
+  });
+
+  it('counts the rows nobody needs to read rather than printing them', () => {
+    // Fourteen rows of zero would bury the two that matter.
+    expect(partitionRelations(relations).emptyCount).toBe(1);
+  });
+
+  it('totals everything the merge would move', () => {
+    expect(partitionRelations(relations).totalMoving).toBe(7);
+  });
+
+  it('reports an entirely empty duplicate without claiming anything moves', () => {
+    const empty = partitionRelations([relation('encounter', 0, 0)]);
+    expect(empty.moving).toEqual([]);
+    expect(empty.totalMoving).toBe(0);
+  });
+});
+
+describe('describeCount', () => {
+  it('agrees about number', () => {
+    expect(describeCount(1, 'Visits')).toBe('1 visit');
+    expect(describeCount(3, 'Visits')).toBe('3 visits');
+    expect(describeCount(0, 'Visits')).toBe('0 visits');
+  });
+
+  it('leaves a label that is already singular alone', () => {
+    expect(describeCount(1, 'Medical history')).toBe('1 medical history');
+  });
+});
+
+describe('describePortalOutcome', () => {
+  const canonical = chart('NKP-1');
+  const source = chart('NKP-2');
+  const base = { canonicalPendingInvites: 0, sourcePendingInvites: 0, invitesCancelled: 0 };
+
+  it('says plainly when nobody is affected', () => {
+    expect(
+      describePortalOutcome({
+        canonical,
+        source,
+        portal: { ...base, canonicalLinked: false, sourceLinked: false, retains: 'NONE' },
+      }),
+    ).toContain('Neither chart has an app account');
+  });
+
+  it('names the account that loses access when there are two', () => {
+    const text = describePortalOutcome({
+      canonical,
+      source,
+      portal: { ...base, canonicalLinked: true, sourceLinked: true, retains: 'CANONICAL' },
+    });
+    expect(text).toContain('NKP-1');
+    expect(text).toContain('NKP-2 will no longer open this chart');
+  });
+
+  it('does not invent a loser when only one account exists', () => {
+    const text = describePortalOutcome({
+      canonical,
+      source,
+      portal: { ...base, canonicalLinked: false, sourceLinked: true, retains: 'SOURCE' },
+    });
+    expect(text).toContain('NKP-2');
+    expect(text).not.toContain('no longer');
+  });
+
+  it('never puts a strategy name on screen', () => {
+    for (const retains of ['CANONICAL', 'SOURCE', 'NONE'] as const) {
+      const text = describePortalOutcome({
+        canonical,
+        source,
+        portal: { ...base, canonicalLinked: true, sourceLinked: true, retains },
+      });
+      expect(text).not.toMatch(/CANONICAL|SOURCE|NONE/);
+    }
+  });
+});
+
+describe('confirmationMatches', () => {
+  it('accepts the code as displayed', () => {
+    expect(confirmationMatches('NKP-2026-000099', 'NKP-2026-000099')).toBe(true);
+  });
+
+  it('forgives case and surrounding space, but nothing else', () => {
+    expect(confirmationMatches('  nkp-2026-000099 ', 'NKP-2026-000099')).toBe(true);
+    expect(confirmationMatches('NKP-2026-00009', 'NKP-2026-000099')).toBe(false);
+    expect(confirmationMatches('', 'NKP-2026-000099')).toBe(false);
+    // The surviving chart's code is not the one being retired.
+    expect(confirmationMatches('NKP-2026-000001', 'NKP-2026-000099')).toBe(false);
+  });
+});
+
+describe('the finding copy the dialog renders', () => {
+  it('has a label for every code the API can send', () => {
+    for (const code of [...MERGE_BLOCKER_CODES, ...MERGE_WARNING_CODES]) {
+      expect(MERGE_FINDING_LABELS[code]).toBeTruthy();
+    }
+  });
+});

--- a/apps/web/lib/patient-merge.ts
+++ b/apps/web/lib/patient-merge.ts
@@ -1,0 +1,161 @@
+import {
+  MERGE_FINDING_LABELS,
+  MERGE_FINDING_RECOVERY,
+  type DuplicateConfidence,
+  type DuplicateMatchReason,
+  type MergeFindingCode,
+} from '@nkwapa/db';
+import { apiFetch, readApiError, type GetToken } from '@/lib/api';
+import type { DuplicateCandidatePatient } from '@/lib/patient-duplicates';
+
+export { MERGE_FINDING_LABELS, MERGE_FINDING_RECOVERY };
+export type { MergeFindingCode };
+
+export type MergePortalLinkStrategy = 'CANONICAL' | 'SOURCE';
+export type MergeInviteStrategy = 'CANONICAL' | 'SOURCE' | 'MERGE';
+
+export interface MergeFinding {
+  code: MergeFindingCode;
+  severity: 'BLOCK' | 'WARN';
+  label: string;
+  recovery: string;
+  detail?: string;
+}
+
+export interface MergeRelationCount {
+  key: string;
+  label: string;
+  canonicalCount: number;
+  sourceCount: number;
+}
+
+export interface MergePortalOutlook {
+  canonicalLinked: boolean;
+  sourceLinked: boolean;
+  retains: 'CANONICAL' | 'SOURCE' | 'NONE';
+  canonicalPendingInvites: number;
+  sourcePendingInvites: number;
+  invitesCancelled: number;
+}
+
+/**
+ * The preview payload.
+ *
+ * `canonical` and `source` are deliberately `DuplicateCandidatePatient`: the API publishes both
+ * charts in that exact shape so `buildComparisonRows` and `PatientComparisonTable` work here
+ * without a second mapping.
+ */
+export interface PatientMergePreview {
+  generatedAt: string;
+  canonical: DuplicateCandidatePatient;
+  source: DuplicateCandidatePatient;
+  duplicateSignal: {
+    score: number;
+    confidence: DuplicateConfidence;
+    reasons: DuplicateMatchReason[];
+  };
+  relations: MergeRelationCount[];
+  portal: MergePortalOutlook;
+  aliases: { carriedOver: string[]; added: string };
+  tombstonePatientCode: string;
+  blockers: MergeFinding[];
+  warnings: MergeFinding[];
+  canMerge: boolean;
+  fingerprint: string;
+  strategies: {
+    portalLinkStrategy: MergePortalLinkStrategy;
+    inviteStrategy: MergeInviteStrategy;
+  };
+}
+
+export interface MergePreviewRequest {
+  clinicId: string;
+  canonicalPatientId: string;
+  sourcePatientId: string;
+  portalLinkStrategy?: MergePortalLinkStrategy;
+  inviteStrategy?: MergeInviteStrategy;
+}
+
+export function mergePreviewPath(request: MergePreviewRequest): string {
+  const query = new URLSearchParams({ sourcePatientId: request.sourcePatientId });
+  if (request.portalLinkStrategy) query.set('portalLinkStrategy', request.portalLinkStrategy);
+  if (request.inviteStrategy) query.set('inviteStrategy', request.inviteStrategy);
+
+  return `/clinics/${encodeURIComponent(request.clinicId)}/patients/${encodeURIComponent(
+    request.canonicalPatientId,
+  )}/merge-preview?${query.toString()}`;
+}
+
+export async function fetchMergePreview(
+  request: MergePreviewRequest,
+  getToken: GetToken,
+  signal?: AbortSignal,
+): Promise<PatientMergePreview> {
+  const response = await apiFetch(mergePreviewPath(request), {
+    getToken,
+    signal,
+    activeClinicId: request.clinicId,
+  });
+  if (!response.ok) throw await readApiError(response);
+  return (await response.json()) as PatientMergePreview;
+}
+
+/**
+ * Relations with something to move, plus the ones the surviving chart already holds.
+ *
+ * An empty row is still information -- it says the duplicate has no notes, rather than leaving an
+ * operator to wonder whether notes were looked at -- but fourteen rows of zero buries the two
+ * that matter. Rows where both sides are empty are dropped and counted instead.
+ */
+export function partitionRelations(relations: MergeRelationCount[]): {
+  moving: MergeRelationCount[];
+  untouched: MergeRelationCount[];
+  emptyCount: number;
+  totalMoving: number;
+} {
+  const moving = relations.filter((row) => row.sourceCount > 0);
+  const untouched = relations.filter((row) => row.sourceCount === 0 && row.canonicalCount > 0);
+  return {
+    moving,
+    untouched,
+    emptyCount: relations.filter((row) => row.sourceCount === 0 && row.canonicalCount === 0).length,
+    totalMoving: relations.reduce((total, row) => total + row.sourceCount, 0),
+  };
+}
+
+/** "3 visits", "1 visit" — the count and its label, agreeing about number. */
+export function describeCount(count: number, label: string): string {
+  const singular = count === 1 ? label.replace(/s$/, '') : label;
+  return `${count} ${singular.toLowerCase()}`;
+}
+
+/**
+ * What the portal outcome means for the people involved.
+ *
+ * Written as a sentence about a person rather than a strategy name, because "CANONICAL" tells an
+ * operator nothing about who will still be able to sign in tomorrow.
+ */
+export function describePortalOutcome(
+  preview: Pick<PatientMergePreview, 'portal' | 'canonical' | 'source'>,
+): string {
+  const { portal, canonical, source } = preview;
+  if (portal.retains === 'NONE') {
+    return 'Neither chart has an app account, so nothing changes for the patient’s sign-in.';
+  }
+  const kept = portal.retains === 'CANONICAL' ? canonical : source;
+  const other = portal.retains === 'CANONICAL' ? source : canonical;
+  if (portal.canonicalLinked && portal.sourceLinked) {
+    return `The app account on ${kept.patientCode} keeps access. The one on ${other.patientCode} will no longer open this chart.`;
+  }
+  return `The app account on ${kept.patientCode} keeps access, and will now open the combined chart.`;
+}
+
+/**
+ * Whether the typed confirmation matches.
+ *
+ * Case and surrounding space are forgiven; nothing else is. The point is to make an operator read
+ * the code of the chart they are retiring, not to test their typing.
+ */
+export function confirmationMatches(typed: string, expected: string): boolean {
+  return typed.trim().toUpperCase() === expected.trim().toUpperCase();
+}

--- a/docs/specs/03_AUTH_AND_RBAC.md
+++ b/docs/specs/03_AUTH_AND_RBAC.md
@@ -91,12 +91,26 @@ read that value back.
 Duplicate review separates looking from acting:
 
 - `PATIENT.DUPLICATE.REVIEW`: system administrator, director, and manager
-- merging two charts stays system administrator only, via `POST /admin/patients/merge`
+- `PATIENT.MERGE`: system administrator only, and only through the wildcard
 
 The split is deliberate. Clinic administrators are the people who recognise the patients, so they
 triage the queue and record what they found; consolidating two records is irreversible and stays
 with the narrower role. Doctors and volunteers hold neither permission: the queue compares two
 charts side by side, which is a wider identity view than a clinical seat needs.
+
+`PATIENT.MERGE` is granted to no role in `ROLE_PERMISSIONS`. `SYSTEM_ADMIN` holds it through its
+`*` wildcard and nobody else can be given it, so adding it to a role's list would read as the
+policy change it is rather than as a refactor. It covers both the read-only preview and the merge
+itself. Before it existed, both sat behind `AdminController`'s class-level `CLINIC_MANAGE`, which a
+director and a manager both hold: they reached the service and were refused there. The refusal is
+now at the guard, and `PatientMergeService` still asserts the seat independently, because a
+boundary that depends on one layer is one refactor from not being a boundary.
+
+The chart-scoped preview at `GET /clinics/:clinicId/patients/:patientId/merge-preview` is scoped
+through `ClinicScopeGuard` as well. `PatientMergeRecord`, written by every executed merge, carries a
+non-null `clinicId` -- unlike `PatientDuplicateReview`, because merging cannot span two clinics --
+and its row level security policy is the ordinary `app.can_access_clinic` one, so clinic staff can
+read what was done to their own charts while only a system administrator can cause it.
 
 Scope follows the same rule as the staff roster. `GET /clinics/:clinicId/patients/duplicates` is
 clinic-scoped through `ClinicScopeGuard`; `GET /admin/patients/duplicates` covers every visible

--- a/docs/specs/06_PATIENTS_MODULE.md
+++ b/docs/specs/06_PATIENTS_MODULE.md
@@ -111,6 +111,40 @@ rather than blanked, so clinical note content never reaches a role without
 - the source chart points to the canonical chart instead of being deleted
 - the legacy patient code is stored as an alias for later lookup
 
+A read-only preview answers what the merge would do before anyone commits to it, at
+`GET /clinics/:clinicId/patients/:patientId/merge-preview`, with an all-clinics twin at
+`GET /admin/patients/merge/preview`. It reports both charts field by field, how many records of
+each kind move and how many the surviving chart already holds, what happens to the app account and
+any unclaimed invitation, which codes will still find the record afterwards, and everything that
+would stop or complicate the merge. It stores nothing and is recomputed on every call.
+
+Findings come in two severities, defined once in `packages/db/src/patient-merge.ts` and consumed by
+the API that raises them and the screen that renders them:
+
+- **blocked**: the same chart on both sides, a chart that has already been merged, two clinics, a
+  deactivated clinic, a chart code already recorded against a third record, both charts holding an
+  open preferred pharmacy, and two different app accounts with no choice made between them
+- **warned**: an app account that loses access, an invitation that gets cancelled, two charts that
+  do not look much alike, a duplicate holding more history than the chart being kept, and a pair
+  someone has already ruled out in the review queue
+
+Every finding carries plain-language wording and a next step, so a refusal can be acted on without
+support. A refused merge returns the same list under `details.blockers` with the code
+`PATIENT_MERGE_BLOCKED`.
+
+The merge moves every relation listed in `MERGE_RELATIONS`, and a test parses `schema.prisma` and
+fails if a model gains a `patientId` without either joining that list or being written into
+`MERGE_SPECIAL_CASE_MODELS` with a reason. Charts previously merged into the duplicate follow it,
+so no alias chain terminates at a retired record.
+
+The preview returns a fingerprint of the state it described. The merge accepts it and refuses a
+stale one with `PATIENT_MERGE_PREVIEW_STALE`, so an operator cannot commit against a panel that a
+concurrent edit has made untrue. The guards re-run inside the transaction as well.
+
+Every executed merge writes a `PatientMergeRecord` alongside its audit event, carrying the codes
+involved, the strategies chosen, and how many rows of each kind moved -- so a consolidated chart
+can be explained afterwards without database access.
+
 ### Longitudinal history
 
 - keeps stable records with append-only, auditable revisions
@@ -156,7 +190,7 @@ and Consent.
 
 ## Current Gaps
 
-- no dedicated duplicate review queue yet
-- no full cross-clinic patient consolidation workflow yet
+- no full cross-clinic patient consolidation workflow yet; the preview reports a cross-clinic
+  pair as blocked and points at the review queue instead
 - portal invites reach patients by email only; SMS delivery of an invitation is not wired,
   so a phone-only invite is passed on by hand from the copyable instructions on the chart

--- a/packages/db/index.ts
+++ b/packages/db/index.ts
@@ -66,6 +66,24 @@ export {
   type DuplicatePairEvaluation,
 } from './src/patient-duplicates';
 export {
+  MERGE_BLOCKER_CODES,
+  MERGE_FINDING_LABELS,
+  MERGE_FINDING_RECOVERY,
+  MERGE_RELATIONS,
+  MERGE_SPECIAL_CASE_MODELS,
+  MERGE_WARNING_CODES,
+  isMergeBlocked,
+  isMergeBlockerCode,
+  mergeFinding,
+  mergePreviewFingerprint,
+  type MergeBlockerCode,
+  type MergeFinding,
+  type MergeFindingCode,
+  type MergeFingerprintInput,
+  type MergeRelationKey,
+  type MergeWarningCode,
+} from './src/patient-merge';
+export {
   PATIENT_CHART_SECTION_IDS,
   PATIENT_CHART_SECTIONS,
   canAccessPatientChartSection,

--- a/packages/db/prisma/migrations/20260904120000_patient_merge_record/migration.sql
+++ b/packages/db/prisma/migrations/20260904120000_patient_merge_record/migration.sql
@@ -1,0 +1,91 @@
+-- What an executed patient merge actually moved.
+--
+-- Merging two charts is the only action in this product a person cannot undo from the product,
+-- and until now the only trace it left was three identifiers: "Patient".mergedIntoPatientId, a
+-- "PatientCodeAlias" row for the code the retired chart gave up, and an "AuditEvent" whose
+-- beforeJson repeats the same two ids. None of that says how much moved, so a merge that a
+-- clinic later queries -- "her visits are gone, what happened?" -- cannot be answered without
+-- someone reading the database by hand. That is the support call this table removes.
+--
+-- It is a record of an action, not a queue and not a workflow. Nothing reads it to decide
+-- anything; the preview is recomputed from live rows every time it is opened.
+
+-- 1. The table.
+--
+-- "clinicId" is NOT NULL, unlike the one on "PatientDuplicateReview". Noticing a suspected
+-- duplicate spans clinics; merging does not, because AdminService.mergePatients refuses two
+-- charts whose primaryClinicId differs. A merge therefore always has exactly one owning clinic,
+-- and the policy in step 4 is the ordinary clinic policy rather than the nullable-owner shape.
+--
+-- The counts land as JSON text, matching "ResearchExport".rowCountsJson and "AuditEvent"'s
+-- before/after columns rather than introducing this schema's first jsonb or text[] column. They
+-- are read back to be displayed to a person, never filtered on.
+CREATE TABLE "PatientMergeRecord" (
+    "id" UUID NOT NULL,
+    "clinicId" UUID NOT NULL,
+    "canonicalPatientId" UUID NOT NULL,
+    "sourcePatientId" UUID NOT NULL,
+    "sourcePatientCode" VARCHAR(32) NOT NULL,
+    "tombstonePatientCode" VARCHAR(32) NOT NULL,
+    "portalLinkStrategy" VARCHAR(16) NOT NULL,
+    "inviteStrategy" VARCHAR(16) NOT NULL,
+    "movedCountsJson" TEXT NOT NULL,
+    "warningCodesJson" TEXT,
+    "mergedByUserId" UUID NOT NULL,
+    "mergedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "requestId" VARCHAR(64),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PatientMergeRecord_pkey" PRIMARY KEY ("id")
+);
+
+-- 2. Indexes.
+--
+-- A chart is merged away exactly once: "Patient".mergedIntoPatientId is already set on the
+-- source when this row is written, and the merge refuses a chart that carries it. The unique
+-- constraint says so in the schema rather than relying on that ordering holding forever, and it
+-- makes a retried request idempotent instead of duplicating history.
+CREATE UNIQUE INDEX "PatientMergeRecord_sourcePatientId_key" ON "PatientMergeRecord"("sourcePatientId");
+
+-- "What has been merged in this clinic lately", which is the only listing this table has.
+CREATE INDEX "PatientMergeRecord_clinicId_mergedAt_idx" ON "PatientMergeRecord"("clinicId", "mergedAt");
+
+-- Reached from the surviving chart: "what was folded into this record".
+CREATE INDEX "PatientMergeRecord_canonicalPatientId_idx" ON "PatientMergeRecord"("canonicalPatientId");
+
+CREATE INDEX "PatientMergeRecord_mergedByUserId_idx" ON "PatientMergeRecord"("mergedByUserId");
+
+-- 3. Foreign keys.
+--
+-- Every reference cascades, matching "PatientDuplicateReview". A record explaining a merge
+-- between charts that no longer exist explains nothing, and the immutable trail of who did what
+-- is "AuditEvent"'s job -- that table is deliberately not referenced here, so removing a clinic
+-- never removes the audit event describing its merges.
+ALTER TABLE "PatientMergeRecord" ADD CONSTRAINT "PatientMergeRecord_clinicId_fkey" FOREIGN KEY ("clinicId") REFERENCES "Clinic"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "PatientMergeRecord" ADD CONSTRAINT "PatientMergeRecord_canonicalPatientId_fkey" FOREIGN KEY ("canonicalPatientId") REFERENCES "Patient"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "PatientMergeRecord" ADD CONSTRAINT "PatientMergeRecord_sourcePatientId_fkey" FOREIGN KEY ("sourcePatientId") REFERENCES "Patient"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "PatientMergeRecord" ADD CONSTRAINT "PatientMergeRecord_mergedByUserId_fkey" FOREIGN KEY ("mergedByUserId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- 4. Row level security.
+--
+-- ENABLE and FORCE are both declared here rather than left to a later sweep.
+-- 20260821120000_force_row_level_security exists because ENABLE alone did nothing for a year:
+-- the application connects as the role that owns these tables, and PostgreSQL exempts a table's
+-- owner from its own policies unless FORCE is set, so the policies were parsed and never
+-- applied. A new table that only ENABLEs is a new instance of that same bug.
+--
+-- app.can_access_clinic() already returns true for a system administrator, so the single
+-- disjunct covers both the only role that can write here and the clinic staff who may read what
+-- was done to their own charts.
+ALTER TABLE "PatientMergeRecord" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "PatientMergeRecord" FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "PatientMergeRecord_scope_policy" ON "PatientMergeRecord";
+CREATE POLICY "PatientMergeRecord_scope_policy" ON "PatientMergeRecord"
+FOR ALL
+USING (app.can_access_clinic("clinicId"))
+WITH CHECK (app.can_access_clinic("clinicId"));
+
+-- Grants are not repeated here. 20260821130000_add_application_database_role set default
+-- privileges on the public schema for nkwapa_app, so a table created after it is reachable
+-- without an explicit GRANT.

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -392,6 +392,7 @@ model Clinic {
   clinicalNotes             ClinicalNote[]
   clinicalNoteAddenda       ClinicalNoteAddendum[]
   duplicateReviews          PatientDuplicateReview[]
+  patientMergeRecords       PatientMergeRecord[]
 
   @@unique([organizationId, locationCode])
   @@index([organizationId])
@@ -441,6 +442,7 @@ model User {
   claimedPatientPortalInvites   PatientPortalInvite[]           @relation("PatientPortalInviteClaimedBy")
   mergedPatients                Patient[]                       @relation("PatientMergedBy")
   duplicateReviews              PatientDuplicateReview[]        @relation("PatientDuplicateReviewedBy")
+  patientMergeRecords           PatientMergeRecord[]            @relation("PatientMergeRecordMergedBy")
   conversationParticipants      ConversationParticipant[]
   sentMessages                  Message[]                       @relation("MessageSender")
   authoredHistoryRevisions      MedicalHistoryRevision[]        @relation("MedicalHistoryRevisionAuthor")
@@ -543,6 +545,8 @@ model Patient {
   clinicalNotes             ClinicalNote[]
   duplicateReviewsAsA       PatientDuplicateReview[]        @relation("PatientDuplicateReviewA")
   duplicateReviewsAsB       PatientDuplicateReview[]        @relation("PatientDuplicateReviewB")
+  mergeRecordsAsCanonical   PatientMergeRecord[]            @relation("PatientMergeRecordCanonical")
+  mergeRecordAsSource       PatientMergeRecord?             @relation("PatientMergeRecordSource")
 
   @@index([primaryClinicId])
   @@index([portalUserId])
@@ -840,7 +844,7 @@ model DiabetesScreening {
 
   notes String? @db.Text
 
-  collectedAt     DateTime @default(now())
+  collectedAt      DateTime @default(now())
   authoredByUserId String   @db.Uuid
 
   createdAt DateTime @default(now())
@@ -1019,10 +1023,10 @@ model PatientPortalInvite {
   createdAt       DateTime                  @default(now())
   updatedAt       DateTime                  @updatedAt
 
-  patient   Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
-  clinic    Clinic  @relation(fields: [clinicId], references: [id], onDelete: Cascade)
-  createdBy User    @relation("PatientPortalInviteCreatedBy", fields: [createdByUserId], references: [id], onDelete: Cascade)
-  claimedBy User?   @relation("PatientPortalInviteClaimedBy", fields: [claimedByUserId], references: [id], onDelete: SetNull)
+  patient   Patient    @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  clinic    Clinic     @relation(fields: [clinicId], references: [id], onDelete: Cascade)
+  createdBy User       @relation("PatientPortalInviteCreatedBy", fields: [createdByUserId], references: [id], onDelete: Cascade)
+  claimedBy User?      @relation("PatientPortalInviteClaimedBy", fields: [claimedByUserId], references: [id], onDelete: SetNull)
   reminders Reminder[]
 
   @@index([patientId, status])
@@ -1076,6 +1080,47 @@ model PatientDuplicateReview {
   @@index([clinicId, status])
   @@index([patientAId])
   @@index([patientBId])
+}
+
+/// What an executed merge moved, so a consolidated chart can be explained afterwards.
+///
+/// Written inside the same transaction as the merge. `clinicId` is NOT NULL because a merge is
+/// same-clinic by definition, which is what makes its row level security policy the ordinary
+/// clinic one rather than the nullable-owner shape `PatientDuplicateReview` needs.
+model PatientMergeRecord {
+  id       String @id @default(uuid()) @db.Uuid
+  clinicId String @db.Uuid
+
+  canonicalPatientId String @db.Uuid
+  sourcePatientId    String @unique @db.Uuid
+
+  /// The code the retired chart answered to, now an alias on the surviving one.
+  sourcePatientCode    String @db.VarChar(32)
+  /// What the retired chart's own code was rewritten to, so it stops colliding.
+  tombstonePatientCode String @db.VarChar(32)
+
+  portalLinkStrategy String @db.VarChar(16)
+  inviteStrategy     String @db.VarChar(16)
+
+  /// Rows moved per relation, keyed by MERGE_RELATIONS. Displayed, never filtered on.
+  movedCountsJson  String  @db.Text
+  /// The warning codes the operator was shown and committed anyway.
+  warningCodesJson String? @db.Text
+
+  mergedByUserId String   @db.Uuid
+  mergedAt       DateTime @default(now())
+  requestId      String?  @db.VarChar(64)
+
+  createdAt DateTime @default(now())
+
+  clinic           Clinic  @relation(fields: [clinicId], references: [id], onDelete: Cascade)
+  canonicalPatient Patient @relation("PatientMergeRecordCanonical", fields: [canonicalPatientId], references: [id], onDelete: Cascade)
+  sourcePatient    Patient @relation("PatientMergeRecordSource", fields: [sourcePatientId], references: [id], onDelete: Cascade)
+  mergedBy         User    @relation("PatientMergeRecordMergedBy", fields: [mergedByUserId], references: [id], onDelete: Cascade)
+
+  @@index([clinicId, mergedAt])
+  @@index([canonicalPatientId])
+  @@index([mergedByUserId])
 }
 
 model PatientMeasurement {

--- a/packages/db/src/patient-merge-record-schema.spec.ts
+++ b/packages/db/src/patient-merge-record-schema.spec.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('patient merge record migration', () => {
+  const migration = readFileSync(
+    resolve(__dirname, '../prisma/migrations/20260904120000_patient_merge_record/migration.sql'),
+    'utf8',
+  );
+
+  const schema = readFileSync(resolve(__dirname, '../prisma/schema.prisma'), 'utf8');
+
+  it('records one row per retired chart, and only one', () => {
+    // A chart is merged away exactly once. Without the constraint a retried request writes a
+    // second history for the same event.
+    expect(migration).toContain(
+      'CREATE UNIQUE INDEX "PatientMergeRecord_sourcePatientId_key" ON "PatientMergeRecord"("sourcePatientId")',
+    );
+  });
+
+  it('owns the merge by a clinic, because a merge cannot span two', () => {
+    expect(migration).toContain('"clinicId" UUID NOT NULL');
+    // The nullable-owner shape PatientDuplicateReview needs would be wrong here: noticing a
+    // suspected duplicate spans clinics, merging one does not.
+    expect(migration).not.toContain('"clinicId" UUID,');
+  });
+
+  it('keeps the counts that make a merge explainable afterwards', () => {
+    expect(migration).toContain('"movedCountsJson" TEXT NOT NULL');
+    expect(migration).toContain('"sourcePatientCode" VARCHAR(32) NOT NULL');
+    expect(migration).toContain('"tombstonePatientCode" VARCHAR(32) NOT NULL');
+  });
+
+  it('cascades every reference so no record outlives what it describes', () => {
+    for (const column of ['clinicId', 'canonicalPatientId', 'sourcePatientId', 'mergedByUserId']) {
+      expect(migration).toContain(`"PatientMergeRecord_${column}_fkey"`);
+    }
+    expect(migration.match(/ON DELETE CASCADE/g)).toHaveLength(4);
+  });
+
+  it('does not reference AuditEvent, so the immutable trail survives a cascade', () => {
+    expect(migration).not.toContain('REFERENCES "AuditEvent"');
+  });
+
+  it('enables and forces row level security in this file rather than a later sweep', () => {
+    expect(migration).toContain('ALTER TABLE "PatientMergeRecord" ENABLE ROW LEVEL SECURITY;');
+    expect(migration).toContain('ALTER TABLE "PatientMergeRecord" FORCE ROW LEVEL SECURITY;');
+  });
+
+  it('scopes rows to the clinic that owns the merge', () => {
+    expect(migration).toContain(
+      'CREATE POLICY "PatientMergeRecord_scope_policy" ON "PatientMergeRecord"',
+    );
+    expect(migration).toContain('USING (app.can_access_clinic("clinicId"))');
+    expect(migration).toContain('WITH CHECK (app.can_access_clinic("clinicId"))');
+  });
+
+  it('is declared in the Prisma schema with the same shape', () => {
+    expect(schema).toContain('model PatientMergeRecord {');
+    expect(schema).toContain('sourcePatientId    String @unique @db.Uuid');
+    expect(schema).toContain('@@index([clinicId, mergedAt])');
+  });
+});

--- a/packages/db/src/patient-merge.spec.ts
+++ b/packages/db/src/patient-merge.spec.ts
@@ -1,0 +1,162 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import {
+  MERGE_BLOCKER_CODES,
+  MERGE_FINDING_LABELS,
+  MERGE_FINDING_RECOVERY,
+  MERGE_RELATIONS,
+  MERGE_SPECIAL_CASE_MODELS,
+  MERGE_WARNING_CODES,
+  isMergeBlocked,
+  isMergeBlockerCode,
+  mergeFinding,
+  mergePreviewFingerprint,
+  type MergeFindingCode,
+  type MergeFingerprintInput,
+} from './patient-merge';
+
+const ALL_CODES: MergeFindingCode[] = [...MERGE_BLOCKER_CODES, ...MERGE_WARNING_CODES];
+
+function fingerprintInput(overrides: Partial<MergeFingerprintInput> = {}): MergeFingerprintInput {
+  return {
+    canonicalPatientId: 'a0000000-0000-4000-8000-000000000001',
+    sourcePatientId: 'a0000000-0000-4000-8000-000000000002',
+    canonicalUpdatedAt: new Date('2026-09-04T10:00:00.000Z'),
+    sourceUpdatedAt: new Date('2026-09-04T11:00:00.000Z'),
+    canonicalPatientCode: 'NKP-2026-000001',
+    sourcePatientCode: 'NKP-2026-000099',
+    counts: { encounter: 3, appointment: 1 },
+    ...overrides,
+  };
+}
+
+describe('merge findings', () => {
+  it.each(ALL_CODES)('gives %s a plain-language label and a next step', (code) => {
+    expect(MERGE_FINDING_LABELS[code]).toBeTruthy();
+    expect(MERGE_FINDING_RECOVERY[code]).toBeTruthy();
+    // A refusal an operator cannot act on sends them to support, which is what the preview is
+    // supposed to make unnecessary.
+    expect(MERGE_FINDING_RECOVERY[code].length).toBeGreaterThan(20);
+  });
+
+  it.each(ALL_CODES)('never renders the code %s as its own label', (code) => {
+    expect(MERGE_FINDING_LABELS[code]).not.toContain(code);
+    expect(MERGE_FINDING_LABELS[code]).not.toMatch(/^[A-Z_]+$/);
+  });
+
+  it('separates the two severities', () => {
+    for (const code of MERGE_BLOCKER_CODES) {
+      expect(isMergeBlockerCode(code)).toBe(true);
+      expect(mergeFinding(code).severity).toBe('BLOCK');
+    }
+    for (const code of MERGE_WARNING_CODES) {
+      expect(isMergeBlockerCode(code)).toBe(false);
+      expect(mergeFinding(code).severity).toBe('WARN');
+    }
+  });
+
+  it('carries a detail only when one was given', () => {
+    expect(mergeFinding('CROSS_CLINIC')).not.toHaveProperty('detail');
+    expect(mergeFinding('CROSS_CLINIC', 'Kumasi and Accra').detail).toBe('Kumasi and Accra');
+  });
+
+  it('is blocked by one blocker among any number of warnings', () => {
+    const warnings = MERGE_WARNING_CODES.map((code) => mergeFinding(code));
+    expect(isMergeBlocked(warnings)).toBe(false);
+    expect(isMergeBlocked([...warnings, mergeFinding('CROSS_CLINIC')])).toBe(true);
+    expect(isMergeBlocked([])).toBe(false);
+  });
+});
+
+describe('the relations a merge moves', () => {
+  const schema = readFileSync(resolve(__dirname, '../prisma/schema.prisma'), 'utf8');
+
+  /** Every model with its own `patientId` column, read from the schema rather than a list. */
+  function patientScopedModels(): string[] {
+    const models: string[] = [];
+    for (const match of schema.matchAll(/^model (\w+) \{([\s\S]*?)^\}/gm)) {
+      const [, name, body] = match;
+      if (/^\s+patientId\s/m.test(body)) models.push(name);
+    }
+    return models;
+  }
+
+  /** `patientConsent` -> `PatientConsent`, matching Prisma's delegate naming. */
+  function modelNameFor(key: string): string {
+    return key.charAt(0).toUpperCase() + key.slice(1);
+  }
+
+  it('finds the patient-scoped models to check', () => {
+    const models = patientScopedModels();
+    expect(models.length).toBeGreaterThan(10);
+    expect(models).toContain('ClinicalNote');
+    expect(models).toContain('PatientPharmacyPreference');
+  });
+
+  /*
+    The regression this file exists for.
+
+    A model that gains a `patientId` and is not moved leaves clinical records on a chart that
+    normal browsing excludes, which is how `ClinicalNote`, `MedicalHistoryRecord` and four others
+    came to be stranded by the original merge. Failing here is cheaper than finding out from a
+    patient whose notes went missing.
+  */
+  it('moves or explicitly exempts every model carrying a patientId', () => {
+    const moved = new Set(MERGE_RELATIONS.map((relation) => modelNameFor(relation.key)));
+    const unaccounted = patientScopedModels().filter(
+      (model) => !moved.has(model) && !(model in MERGE_SPECIAL_CASE_MODELS),
+    );
+    expect(unaccounted).toEqual([]);
+  });
+
+  it('documents why each exempt model is exempt', () => {
+    for (const [model, reason] of Object.entries(MERGE_SPECIAL_CASE_MODELS)) {
+      expect(schema).toContain(`model ${model} {`);
+      expect(reason.length).toBeGreaterThan(30);
+    }
+  });
+
+  it('gives every relation a distinct key and an operator-facing label', () => {
+    const keys = MERGE_RELATIONS.map((relation) => relation.key);
+    expect(new Set(keys).size).toBe(keys.length);
+    for (const relation of MERGE_RELATIONS) {
+      expect(relation.label).not.toMatch(/^[a-z]/);
+      expect(relation.label).not.toContain('patient');
+    }
+  });
+});
+
+describe('the preview fingerprint', () => {
+  it('does not depend on the order the counts were collected in', () => {
+    const forwards = mergePreviewFingerprint(
+      fingerprintInput({ counts: { encounter: 3, appointment: 1 } }),
+    );
+    const backwards = mergePreviewFingerprint(
+      fingerprintInput({ counts: { appointment: 1, encounter: 3 } }),
+    );
+    expect(forwards).toBe(backwards);
+  });
+
+  it('reads a date and its ISO string as the same instant', () => {
+    expect(
+      mergePreviewFingerprint(fingerprintInput({ canonicalUpdatedAt: '2026-09-04T10:00:00.000Z' })),
+    ).toBe(mergePreviewFingerprint(fingerprintInput()));
+  });
+
+  it.each([
+    ['a chart was edited', { sourceUpdatedAt: new Date('2026-09-04T11:00:01.000Z') }],
+    ['a record was added', { counts: { encounter: 4, appointment: 1 } }],
+    ['a record was removed', { counts: { encounter: 3 } }],
+    ['a chart code changed', { sourcePatientCode: 'NKP-2026-000100' }],
+    ['the direction was reversed', { canonicalPatientId: 'a0000000-0000-4000-8000-000000000002' }],
+  ])('changes when %s', (_case, overrides: Partial<MergeFingerprintInput>) => {
+    expect(mergePreviewFingerprint(fingerprintInput(overrides))).not.toBe(
+      mergePreviewFingerprint(fingerprintInput()),
+    );
+  });
+
+  it('is short enough to travel in a request body', () => {
+    expect(mergePreviewFingerprint(fingerprintInput())).toMatch(/^[0-9a-f]{16}$/);
+  });
+});

--- a/packages/db/src/patient-merge.ts
+++ b/packages/db/src/patient-merge.ts
@@ -1,0 +1,243 @@
+/**
+ * What a patient merge would do, in one place both sides can read.
+ *
+ * Merging two charts is the only action in this product that cannot be undone from the product.
+ * The API computes a preview with these definitions and executes the merge from the same list;
+ * the web app labels the preview with them. Keeping the relation list, the refusal codes and the
+ * operator-facing wording in one module is what stops a preview from promising something the
+ * transaction does not do -- which, for an irreversible action, is worse than having no preview.
+ *
+ * Nothing here talks to a database or reads a Prisma client. It is a description of the merge,
+ * and it is deliberately importable from a browser bundle.
+ */
+
+/**
+ * The relations the merge repoints wholesale, keyed by Prisma model delegate.
+ *
+ * Every one of these is a plain `updateMany({ where: { patientId: source }, data: { patientId:
+ * canonical } })`. Three further tables carrying `patientId` are absent on purpose and are listed
+ * in `MERGE_SPECIAL_CASE_MODELS`, because what happens to them depends on a choice the operator
+ * makes rather than on the merge alone.
+ *
+ * `patient-merge.spec.ts` parses `schema.prisma` and fails if a model gains a `patientId` without
+ * appearing in one of those two lists. A relation that is silently left behind puts clinical
+ * records on a chart nobody browses, which is exactly the defect this list exists to prevent.
+ */
+export const MERGE_RELATIONS = [
+  { key: 'encounter', label: 'Visits' },
+  { key: 'patientConsent', label: 'Consent records' },
+  { key: 'clinicalNote', label: 'Clinical notes' },
+  { key: 'medicalHistoryRecord', label: 'Medical history entries' },
+  { key: 'patientMedicationRecord', label: 'Medication lists' },
+  { key: 'medicationReconciliationEvent', label: 'Medication reviews' },
+  { key: 'patientPharmacyRecord', label: 'Pharmacy records' },
+  { key: 'patientPharmacyPreference', label: 'Preferred pharmacy periods' },
+  { key: 'patientMeasurement', label: 'Measurements' },
+  { key: 'patientSelfReport', label: 'Patient-reported updates' },
+  { key: 'patientCheckIn', label: 'Clinic check-ins' },
+  { key: 'appointment', label: 'Appointments' },
+  { key: 'appointmentRequest', label: 'Appointment requests' },
+  { key: 'reminder', label: 'Reminders and messages' },
+] as const satisfies readonly { key: string; label: string }[];
+
+export type MergeRelationKey = (typeof MERGE_RELATIONS)[number]['key'];
+
+/**
+ * Prisma models that carry `patientId` but are not moved by the loop above, with the reason.
+ *
+ * The same shape `rls-coverage.spec.ts` uses for its bootstrap exemptions: an exemption has to be
+ * written down and justified before the test will accept it.
+ */
+export const MERGE_SPECIAL_CASE_MODELS: Record<string, string> = {
+  PatientAccountLink:
+    'One row per chart by unique constraint, so the two are collapsed into one according to the portal link strategy rather than moved.',
+  PatientPortalInvite:
+    'A pending invitation on the losing chart is cancelled rather than carried across, and which chart loses depends on the invite strategy.',
+  PatientCodeAlias:
+    'Aliases move, and the source chart contributes one further alias for the code it is giving up, so the count is not a plain repoint.',
+};
+
+/** Refusals. Any one of these means the merge does not run. */
+export const MERGE_BLOCKER_CODES = [
+  'SAME_PATIENT',
+  'PATIENT_NOT_FOUND',
+  'CANONICAL_ALREADY_MERGED',
+  'SOURCE_ALREADY_MERGED',
+  'CROSS_CLINIC',
+  'CLINIC_INACTIVE',
+  'ALIAS_CODE_COLLISION',
+  'OPEN_PHARMACY_PREFERENCE_CONFLICT',
+  'PORTAL_LINK_CONFLICT',
+] as const;
+
+export type MergeBlockerCode = (typeof MERGE_BLOCKER_CODES)[number];
+
+/** Consequences worth reading before committing, none of which stops the merge. */
+export const MERGE_WARNING_CODES = [
+  'PORTAL_ACCOUNT_RETIRED',
+  'PENDING_INVITES_CANCELLED',
+  'WEAK_DUPLICATE_SIGNAL',
+  'SOURCE_HAS_MORE_HISTORY',
+  'DUPLICATE_PAIR_PREVIOUSLY_DISMISSED',
+] as const;
+
+export type MergeWarningCode = (typeof MERGE_WARNING_CODES)[number];
+
+export type MergeFindingCode = MergeBlockerCode | MergeWarningCode;
+
+/**
+ * What each finding means, in the words a clinic operator would use.
+ *
+ * The design system forbids system vocabulary on screen, so no enum value is ever rendered. These
+ * read as statements about the two charts rather than as error names.
+ */
+export const MERGE_FINDING_LABELS: Record<MergeFindingCode, string> = {
+  SAME_PATIENT: 'This is the same chart on both sides',
+  PATIENT_NOT_FOUND: 'One of these charts no longer exists',
+  CANONICAL_ALREADY_MERGED: 'The chart you are keeping has already been merged into another one',
+  SOURCE_ALREADY_MERGED: 'The duplicate chart has already been merged into another one',
+  CROSS_CLINIC: 'These charts belong to different clinics',
+  CLINIC_INACTIVE: 'The clinic that owns these charts is no longer active',
+  ALIAS_CODE_COLLISION: 'The duplicate chart’s code is already recorded against another chart',
+  OPEN_PHARMACY_PREFERENCE_CONFLICT: 'Both charts have a current preferred pharmacy',
+  PORTAL_LINK_CONFLICT: 'Each chart is linked to a different app account',
+  PORTAL_ACCOUNT_RETIRED: 'One app account will lose access to this chart',
+  PENDING_INVITES_CANCELLED: 'A portal invitation that has not been used yet will be cancelled',
+  WEAK_DUPLICATE_SIGNAL: 'These two charts do not look much alike',
+  SOURCE_HAS_MORE_HISTORY: 'The duplicate chart holds more history than the one you are keeping',
+  DUPLICATE_PAIR_PREVIOUSLY_DISMISSED: 'Someone already decided these are two different people',
+};
+
+/**
+ * What to do about it.
+ *
+ * Every finding names a next step, because a refusal an operator cannot act on sends them to
+ * support, and being able to decide without support is the whole point of the preview.
+ */
+export const MERGE_FINDING_RECOVERY: Record<MergeFindingCode, string> = {
+  SAME_PATIENT: 'Choose a different chart as the duplicate.',
+  PATIENT_NOT_FOUND: 'Reload the chart and search for the duplicate again.',
+  CANONICAL_ALREADY_MERGED:
+    'Open the chart it was merged into and start again from there, since that is now the surviving record.',
+  SOURCE_ALREADY_MERGED:
+    'Its records already live on another chart. Open that chart to check whether anything is still outstanding.',
+  CROSS_CLINIC:
+    'Charts can only be merged inside one clinic. Record the pair in the duplicate review queue and raise it with both clinics.',
+  CLINIC_INACTIVE: 'Reactivate the clinic before consolidating any of its charts.',
+  ALIAS_CODE_COLLISION:
+    'Another chart already answers to this code. Ask a system administrator to check which chart is meant to hold it before merging.',
+  OPEN_PHARMACY_PREFERENCE_CONFLICT:
+    'End the preferred pharmacy period on the duplicate chart, then preview the merge again.',
+  PORTAL_LINK_CONFLICT:
+    'Choose which app account keeps access. The other account will no longer be able to open this chart.',
+  PORTAL_ACCOUNT_RETIRED:
+    'Tell the patient which sign-in still works, or invite them again after the merge.',
+  PENDING_INVITES_CANCELLED: 'Send a fresh invitation from the surviving chart after the merge.',
+  WEAK_DUPLICATE_SIGNAL:
+    'Compare the two charts field by field before continuing, and stop if anything but the name differs.',
+  SOURCE_HAS_MORE_HISTORY:
+    'Consider merging the other way round, so the fuller chart is the one that survives.',
+  DUPLICATE_PAIR_PREVIOUSLY_DISMISSED:
+    'Check the note left on that decision in the duplicate review queue before overriding it.',
+};
+
+/** One finding, as the preview and the refused merge both report it. */
+export interface MergeFinding {
+  code: MergeFindingCode;
+  severity: 'BLOCK' | 'WARN';
+  label: string;
+  recovery: string;
+  /** Anything that makes the finding concrete: a chart code, a count, a clinic name. */
+  detail?: string;
+}
+
+export function isMergeBlockerCode(code: MergeFindingCode): code is MergeBlockerCode {
+  return (MERGE_BLOCKER_CODES as readonly string[]).includes(code);
+}
+
+/** Build a finding, taking its severity and copy from the tables above rather than a call site. */
+export function mergeFinding(code: MergeFindingCode, detail?: string): MergeFinding {
+  return {
+    code,
+    severity: isMergeBlockerCode(code) ? 'BLOCK' : 'WARN',
+    label: MERGE_FINDING_LABELS[code],
+    recovery: MERGE_FINDING_RECOVERY[code],
+    ...(detail ? { detail } : {}),
+  };
+}
+
+export function isMergeBlocked(findings: readonly MergeFinding[]): boolean {
+  return findings.some((finding) => finding.severity === 'BLOCK');
+}
+
+/**
+ * The state of both charts, reduced to the things a merge decision depends on.
+ *
+ * Anything that changes one of these fields changes what the merge would do, so a preview taken
+ * before the change must not be actionable afterwards.
+ */
+export interface MergeFingerprintInput {
+  canonicalPatientId: string;
+  sourcePatientId: string;
+  canonicalUpdatedAt: Date | string;
+  sourceUpdatedAt: Date | string;
+  canonicalPatientCode: string;
+  sourcePatientCode: string;
+  /** Counts by relation key. Order is irrelevant; the digest sorts before hashing. */
+  counts: Record<string, number>;
+}
+
+function toIsoInstant(value: Date | string): string {
+  const date = value instanceof Date ? value : new Date(value);
+  const time = date.getTime();
+  return Number.isNaN(time) ? String(value) : new Date(time).toISOString();
+}
+
+/**
+ * FNV-1a, run twice with different offset bases and concatenated.
+ *
+ * Deliberately not `node:crypto`: this module is imported by a browser bundle, and the digest is a
+ * staleness token rather than a secret -- it never needs to resist an attacker, only to change
+ * when the two charts do. Two 32-bit passes give a 16-character token, which is short enough to
+ * travel in a request body and wide enough that an accidental collision is not a real risk.
+ */
+function stableDigest(value: string): string {
+  const bases = [0x811c9dc5, 0x01000193];
+  return bases
+    .map((base) => {
+      let hash = base;
+      for (let index = 0; index < value.length; index += 1) {
+        hash ^= value.charCodeAt(index);
+        hash = Math.imul(hash, 0x01000193) >>> 0;
+      }
+      return hash.toString(16).padStart(8, '0');
+    })
+    .join('');
+}
+
+/**
+ * A token identifying the exact state the preview described.
+ *
+ * The merge endpoint accepts it and refuses if it no longer matches, so an operator cannot commit
+ * a merge against a preview that a concurrent edit, a portal claim or another merge has made
+ * untrue. Without it the preview widens the window between reading and acting rather than closing
+ * it.
+ */
+export function mergePreviewFingerprint(input: MergeFingerprintInput): string {
+  const counts = Object.keys(input.counts)
+    .sort()
+    .map((key) => `${key}=${input.counts[key]}`)
+    .join(',');
+
+  return stableDigest(
+    [
+      input.canonicalPatientId,
+      input.sourcePatientId,
+      input.canonicalPatientCode,
+      input.sourcePatientCode,
+      toIsoInstant(input.canonicalUpdatedAt),
+      toIsoInstant(input.sourceUpdatedAt),
+      counts,
+    ].join('|'),
+  );
+}


### PR DESCRIPTION
# Patient identity: merge preview and safety checks

Closes #8.

## Why

Merging two patient charts is the only action in this product that a person cannot undo from
the product. Until now it was a search box and a plain primary button: no preview, no
confirmation step, no destructive treatment. `docs/design-system/MASTER.md` §9 already said merge
is destructive and "requires a confirmation step naming what will change" — that dialog named
nothing.

Building the preview turned up three defects behind it, all of which are fixed here.

### 1. The merge stranded clinical records on the retired chart

It repointed eight relations and silently left seven behind: `ClinicalNote`,
`MedicalHistoryRecord`, `PatientMedicationRecord`, `MedicationReconciliationEvent`,
`PatientPharmacyRecord`, `PatientPharmacyPreference` and `PatientDuplicateReview`.

`ClinicalNote.encounterId` travels with the encounter, which did move, while `ClinicalNote.patientId`
did not — so a consolidated chart ended up holding notes whose two owners disagreed about whose
they were, and whose content the surviving chart's own notes tab never showed.

### 2. Two constraints could fail a merge halfway through

`patientCodeAlias.create` was a bare insert on a globally `@unique` column, surfacing as a raw
Prisma error. And `PatientPharmacyPreference_one_open_per_patient_key` is a partial unique index
allowing one open preferred pharmacy per patient, so moving a second one rolled the whole
transaction back on a constraint the operator had no way to read.

### 3. A merge could not be explained afterwards

The `PATIENT.MERGE` audit event's `beforeJson` carried three identifiers and no counts, so
"her visits are gone, what happened?" could not be answered without reading the database by hand.

## What changed

### A read-only preview

`GET /clinics/:clinicId/patients/:patientId/merge-preview`, with an all-clinics twin at
`GET /admin/patients/merge/preview` — the same pair of surfaces the duplicate review queue
already uses.

It reports both charts field by field, how many records of each kind move and how many the
surviving chart already holds, what happens to the app account and any unclaimed invitation,
which chart codes will still find the record afterwards, and everything that would stop or
complicate the merge. It stores nothing and is recomputed on every call.

The payload publishes both charts in exactly `DuplicateCandidatePatient`'s shape, so the existing
`buildComparisonRows` renders a merge preview and a duplicate candidate with one piece of code
rather than two that could disagree about how to show a missing date of birth. The national ID
itself never appears — only its last four digits.

### Findings, with a next step each

Defined once in `packages/db/src/patient-merge.ts` and consumed by the API that raises them and
the screen that renders them.

**Blocked:** the same chart on both sides · a chart already merged (either side) · two clinics ·
a deactivated clinic · a chart code already recorded against a third record · both charts holding
an open preferred pharmacy · two different app accounts with no choice made between them.

**Warned:** an app account that loses access · an invitation that gets cancelled · two charts that
do not look much alike · a duplicate holding more history than the chart being kept · a pair
someone already ruled out in the review queue.

Every one carries plain-language wording and a recovery line, so a refusal can be acted on without
support — which is the issue's success metric. A refused merge returns the same list under
`details.blockers` with code `PATIENT_MERGE_BLOCKED`; previously every merge exception threw a bare
string and collapsed to `REQUEST_FAILED`.

Cross-clinic consolidation stays refused, per the issue's non-goal. The preview reports it as a
blocker and points at the review queue, rather than the pair simply being absent.

### A merge that cannot drift from its preview

The move loop is driven by `MERGE_RELATIONS`, the same list the preview counts. A test parses
`schema.prisma` and fails if a model gains a `patientId` without either joining that list or being
written into `MERGE_SPECIAL_CASE_MODELS` with a reason — so this class of defect cannot recur
silently. A second test checks every key against generated `Prisma.ModelName`, because the loop
reaches the delegates through a cast and a typo there would compile cleanly and throw mid-merge.

Also: charts already merged into the duplicate now follow it, so no alias chain terminates at a
retired record; the alias insert is an upsert; and the guards re-run inside the transaction, where
they previously read a snapshot taken before it opened and never looked again.

The preview returns a fingerprint of the state it described. The merge accepts it and refuses a
stale one with `PATIENT_MERGE_PREVIEW_STALE`, so an operator cannot commit against a panel a
concurrent edit has made untrue — otherwise a preview *widens* the read-to-act window rather than
closing it.

### `PatientMergeRecord`

New table, written in the same transaction as the merge: both chart codes, the code the retired
chart was renamed to, the strategies chosen, and per-relation moved counts. `clinicId` is NOT NULL
— unlike `PatientDuplicateReview`'s, because noticing a duplicate spans clinics and merging one
does not — so its row level security policy is the ordinary `app.can_access_clinic` one. `ENABLE`
and `FORCE` RLS are declared in the migration itself. The audit event's `afterJson` now carries
the same counts.

### `PATIENT.MERGE`

Granted to no role. `SYSTEM_ADMIN` holds it through its `*` wildcard and nobody else can be given
it, so adding it to a role's list would read as the policy change it is. Both merge routes carry
it, which lifts them off `AdminController`'s class-level `CLINIC_MANAGE` — a director or manager
previously reached the service and was refused there; they are now refused at the guard, with
`PatientMergeService` still asserting the seat independently.

### The UI

Three steps in one dialog, extracted out of the 1,118-line chart page into
`components/patients/MergePatientDialog.tsx`:

1. **Choose the duplicate** — the existing debounced registry search, saying up front which chart
   survives.
2. **Review** — the shared comparison table, what moves, who keeps their sign-in, which codes still
   find the record, and every finding with its recovery line.
3. **Confirm** — names the consequence for these two charts specifically, requires the retiring
   chart's code typed back, behind a `destructive` button.

A blocked merge shows **no** continue control rather than a disabled one: a disabled button says
"not now", whereas a refused merge needs the operator to go and do something else, and the
recovery line says what.

Reads go through `useAsyncResource` + `ResourceState`, so a slow clinic connection gets the agreed
five states rather than a blank panel. Step changes announce through a polite live region, the
confirm field carries `aria-invalid` and a `role="alert"` message, and the commit button keeps its
label while saving with the state in an `sr-only` live region (§11's rule against a control that
resizes under the pointer).

The duplicate review queue's merge link now carries `?merge=<id>`, so a pair someone has just
decided about opens straight into its preview instead of asking them to search again for the chart
they were reading. The chart page consumes the parameter once and strips it — a reload should not
silently reopen an irreversible flow.

### Shared, not duplicated

`PatientComparisonTable` is lifted out of `DuplicateComparisonSheet` unchanged and used by both
screens, keeping the semantic table, the sr-only caption, the `scope` attributes the e2e suite
locates rows by, and the word "Same" beside a match rather than colour alone. `isSystemAdmin` moves
to `clinic-roles.ts`; the copies in `clinic.service`, `clinics-admin.controller`, `auth.controller`
and `prisma-rls.interceptor` are the same expression and should follow, but are on no path this
change touches.

The chart page loses 200 lines, six pieces of state, a debounced search effect and a submit handler.

## Verification

Run against a real stack, not only mocked:

- **The live endpoint**, with row level security enforced for `nkwapa_app`: the preview returns its
  full payload; `SAME_PATIENT` → 400, a doctor → 403 **at the guard**, a stale fingerprint → 409,
  a re-merge of an already-merged pair → 409 with its recovery line. The merge then executed, and
  Postgres confirmed the source retired with its tombstone code and attribution, the
  `PatientMergeRecord` row written, the alias resolving the old code to the surviving chart, and
  `movedCounts` in the audit event.
- **The migration** applies from empty against a throwaway database, comes up with RLS enabled and
  forced and its policy attached, and `prisma migrate diff` reports **no drift** on the new table.
  (Eleven tables do drift there; all pre-date this change and are the raw-SQL index detail
  `DATABASE_SETUP.md` documents.)
- **All 14 relation keys plus the five hand-handled models** resolve to real Prisma delegates on a
  live client.
- `npm run lint --workspaces` (`--max-warnings 0`), `prettier --check .`, `npm run typecheck
  --workspaces`, `npm run build --workspaces`, `npm run security:scan`, `npm run security:audit`.
- **Unit tests:** API 78 suites / 1,165 tests; web 26 / 238; db 20 / 297 (+26 skipped integration
  specs CI runs behind env flags). New: 60 in `patient-merge.service.spec.ts`, 6 in
  `patient-merge.controller.spec.ts`, 43 in `packages/db/src/patient-merge.spec.ts`, 17 in
  `lib/patient-merge.test.ts`, plus the migration schema spec. The six pre-existing merge guards
  had **no** test before this; they do now.
- **`tenant-isolation.integration.spec.ts`** (the RLS gate CI runs with `RUN_TENANT_ISOLATION_TESTS=1`
  against the unprivileged `nkwapa_app` role): 13/13.
- **E2E: 140/140**, the whole suite, on a fresh database with the CI e2e job's environment. The new
  suite includes zero axe violations and no horizontal overflow at 375 / 768 / 1024 / 1440 with the
  dialog open, and keyboard open/close; verified separately under `--repeat-each=2 --workers=2`
  (16/16) after a real flake was traced to a component defect — see below.

Every chart the e2e suite acts on, it creates. Pointing a merge spec at a seeded fixture destroys
it: running against the Akua Boateng pair would take it out of the review queue permanently and
break `duplicate-review.spec.js` on the next run against the same database.

### Four defects the verification found

- **The dialog cleared what was being typed into it.** State was reset when `open` became true, but
  the body mounts and is typeable a frame before that effect runs, so the first keystrokes into the
  search box could be wiped — the panel would appear to ignore what someone had typed. Clearing now
  happens on close, where nothing is being typed. Found only by running the suite alongside the
  rest; in isolation it passed every time.
- **The confirmation repeated itself.** "This cannot be undone." appeared verbatim in both the
  dialog description and the warning immediately below it, which teaches a reader to skim the
  notice. It now names the consequence for these two charts.
- **The merge record counted the wrong invitations.** It stored a `count()` of everything on the
  surviving chart *after* the merge, including invitations that were always there. In a record
  whose only purpose is explaining what a merge did, a number that over-reports is worse than none.
  The alias count had the same shape of error — computed as "every source alias, plus one", while
  `createMany` runs with `skipDuplicates`. Both are measured now.
- **The `CANONICAL` invite strategy stranded invitations too.** It repointed only the duplicate's
  `PENDING` rows, so a claimed or expired invitation — a record of a real exchange with the patient
  — stayed on the retired chart. The same defect as the seven relations, in a table the original
  loop *did* touch. Everything moves now; cancelling still applies only to unclaimed offers.

### Not caused by this branch

An unconfigured local run fails a scattered set of specs that have nothing to do with this work,
and both causes are worth recording because neither is visible from the failure message:

- **Rate limiting.** The suite is one user hammering the app, and `/auth/whoami` has a 60/minute
  budget; a long run exhausts it and then fails whichever spec is running, with 429s across
  unrelated routes. CI's e2e job raises the four `RATE_LIMIT_*` values for exactly this reason. Cost
  12 failures across `responsive-migration`, `portal`, `role-access` and others.
- **Email.** Without `EMAIL_PROVIDER=nodemailer` the API runs the fake provider, and without
  `EMAIL_DELIVERABILITY_ALLOWED_DOMAINS=nkwapa.local` portal invites refuse the seeded `.local`
  addresses, because they verify MX first. CI sets both. Cost 3 failures.

With the CI environment exported, and against a fresh database: **140/140**.

One further note for reviewers running this locally: `portal-invite-lifecycle.spec.js` consumes its
seeded invitation the same way the appointment specs consume theirs, so it fails on a second run
against the same database. The new merge suite does not have this property, because it creates
every chart it touches.

## Acceptance criteria

| Criterion | Where |
| --- | --- |
| Operators can preview a merge before execution | Both preview routes; three-step dialog |
| Preview lists preserved, moved, blocked and aliased data | `relations` (both sides), `portal`, `aliases`, `tombstonePatientCode`, `blockers`/`warnings` |
| Unsafe merges return structured errors with recovery guidance | `PATIENT_MERGE_BLOCKED` + `details.blockers`, each with a recovery line; `PATIENT_MERGE_PREVIEW_STALE` |
| Existing merge behaviour remains covered by tests | Original assertions preserved; 1 merge test → 60 |
| Final merge stays audited | `PATIENT.MERGE` audit event retained and enriched, plus `PatientMergeRecord` |

## Migration note

Adds `20260904120000_patient_merge_record`. `npm run db:migrate:deploy` before deploying the API,
which CI and `deploy.yml` already do.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GV4Yonr7QkBKEgaQwbwPZ
