### PR TITLE
CI: drop the two build artifacts nothing consumes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,10 +385,3 @@ jobs:
 
       - name: Build all workspaces
         run: npm run build --workspaces --if-present
-
-      - name: Upload API build
-        uses: actions/upload-artifact@v4
-        with:
-          name: api-build
-          path: apps/api/dist/
-          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,10 +392,3 @@ jobs:
           name: api-build
           path: apps/api/dist/
           retention-days: 7
-
-      - name: Upload Web build
-        uses: actions/upload-artifact@v4
-        with:
-          name: web-build
-          path: apps/web/.next/
-          retention-days: 7


### PR DESCRIPTION
Closes #107.

## What

Removes both artifact uploads from the CI `build` job. Fourteen lines, no other change.

## The web one was never uploading anything

`actions/upload-artifact` has excluded hidden files and directories by default since v4.4.0, and
`apps/web/.next/` is dotted, so every file in it was skipped:

```
##[warning]No files were found with the provided path: apps/web/.next/. No artifacts will be uploaded.
```

The tell was the asymmetry inside a single job — `apps/api/dist/` uploaded fine at 719 KB while
`apps/web/.next/` produced only a warning. Same action, same run, one path hidden and one not.
Listing artifacts on a completed run showed `api-build`, `playwright-artifacts` and
`coverage-reports`, with `web-build` absent entirely. It stayed invisible because
`if-no-files-found` defaults to `warn`, so a missing artifact never failed the job.

Deleted rather than fixed with `include-hidden-files: true`, because a `.next` directory is not
portable between machines. Had it been uploading all along it still would not have been usable as a
deployable artifact. If one is ever wanted, `output: 'standalone'` is the shape to build, and that
is a different change with a real consumer behind it.

## The API one was real, and equally unread

719 KB of `apps/api/dist/` on every push, retained for seven days, downloaded by nobody:

- no `download-artifact` step anywhere in `.github/`
- `api-build` appears exactly once in the repository, at its own definition
- Vercel runs its own `vercel build`; the Render API deploy is a webhook that builds from source

## What the build job still does

It gates on all five other jobs and proves that a clean `npm ci` followed by a full workspace build
succeeds — which is the thing worth knowing at the end of a run. `next build` and `nest build` both
still run there, and a compile failure still fails CI. This removes uploads, not builds.

The artifacts that are actually read when something fails, `coverage-reports` and
`playwright-artifacts`, belong to the `test` and `e2e` jobs and are untouched.

## Verification

- `npx prettier --check .github/workflows/ci.yml`
- YAML parses; the `build` job retains checkout, setup-node, `npm ci`, Prisma generate, build
  `@nkwapa/db`, and `Build all workspaces`, and keeps `needs: [lint, typecheck, test, security, e2e]`
- CI on this PR exercises the change directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Ym9jDrHeE3mAf43TVFRjN
