### PR TITLE
Patient identity: browser coverage for the portal claim flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,13 @@ jobs:
       E2E_PATIENT_PASSWORD: NkwapaPatient!23
       E2E_PATIENT_NAME: E2E Patient
       E2E_PATIENT_EMAIL: e2e.patient@nkwapa.local
+      # The same patient one step earlier: invited, not yet linked. A claimed account is
+      # redirected off /claim-record, so the claim page had no identity that could reach it.
+      E2E_CLAIMANT_SUB: 00000000-0000-4000-8000-000000000047
+      E2E_CLAIMANT_USERNAME: e2e.claimant
+      E2E_CLAIMANT_PASSWORD: NkwapaClaimant!23
+      E2E_CLAIMANT_NAME: E2E Claimant
+      E2E_CLAIMANT_EMAIL: e2e.claimant@nkwapa.local
       MAILPIT_BASE_URL: http://localhost:8025
       # The API sends through Mailpit rather than the fake provider, so this job is the
       # only place the real nodemailer path is exercised before staging. No SMTP_USER or
@@ -337,6 +344,12 @@ jobs:
           SEED_SAMPLE_APPOINTMENTS: ${{ env.SEED_SAMPLE_APPOINTMENTS }}
           SEED_SAMPLE_DUPLICATES: ${{ env.SEED_SAMPLE_DUPLICATES }}
           SEED_SAMPLE_IDENTITY: ${{ env.SEED_SAMPLE_IDENTITY }}
+          # No SEED_E2E_CLAIMANT_SUB on purpose. Keycloak does not always honour the requested
+          # user id, so the provisioning step writes the real one back over E2E_CLAIMANT_SUB
+          # through GITHUB_ENV, and the seed falls back to it -- the same path the other four
+          # identities take. Passing the requested id here would pin the stale value.
+          SEED_E2E_CLAIMANT_EMAIL: ${{ env.E2E_CLAIMANT_EMAIL }}
+          SEED_E2E_CLAIMANT_NAME: ${{ env.E2E_CLAIMANT_NAME }}
           SEED_E2E_STAFF_NAME: ${{ env.E2E_STAFF_NAME }}
           SEED_E2E_STAFF_EMAIL: ${{ env.E2E_STAFF_EMAIL }}
           SEED_E2E_DOCTOR_NAME: ${{ env.E2E_DOCTOR_NAME }}

--- a/apps/web/app/(workspace)/claim-record/page.tsx
+++ b/apps/web/app/(workspace)/claim-record/page.tsx
@@ -124,8 +124,25 @@ export default function ClaimRecordPage() {
   };
 
   return (
+    /*
+      This route renders outside both shells on purpose -- a claimant holds no clinic and no roles,
+      so neither AppLayout nor PortalLayout applies to it. The landmark and the skip link came with
+      those shells, which left the one page a patient works through alone as the only route in the
+      product with no `main` element and nothing to skip the header with. Both are restored here
+      rather than by wrapping the page in a shell it does not belong in.
+    */
     <div className="bg-clinical-grid min-h-screen px-4 py-10 md:px-6">
-      <div className="mx-auto flex max-w-5xl flex-col gap-6">
+      <a
+        href="#main-content"
+        className="sr-only focus-visible:not-sr-only focus-visible:absolute focus-visible:left-4 focus-visible:top-4 focus-visible:z-50 focus-visible:rounded-lg focus-visible:bg-background focus-visible:px-4 focus-visible:py-3 focus-visible:text-sm focus-visible:font-medium focus-visible:shadow-sm focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        Skip to main content
+      </a>
+      <main
+        id="main-content"
+        tabIndex={-1}
+        className="mx-auto flex max-w-5xl flex-col gap-6 focus-visible:outline-none"
+      >
         <Card className="overflow-hidden rounded-xl border-border bg-card shadow-sm">
           <CardContent className="grid gap-0 lg:grid-cols-[1.15fr_0.85fr]">
             <section className="relative overflow-hidden px-6 py-8 md:px-10 md:py-10">
@@ -356,7 +373,7 @@ export default function ClaimRecordPage() {
             </section>
           </CardContent>
         </Card>
-      </div>
+      </main>
     </div>
   );
 }

--- a/apps/web/e2e/patient-claim.spec.js
+++ b/apps/web/e2e/patient-claim.spec.js
@@ -1,0 +1,162 @@
+const { test, expect } = require('@playwright/test');
+const AxeBuilder = require('@axe-core/playwright').default;
+
+const { storageStateFor } = require('../playwright/roles');
+
+test.use({ storageState: storageStateFor('claimant') });
+
+/**
+ * Claiming a patient record, as the patient.
+ *
+ * The one identity workflow nobody walks a patient through: no staff member beside them, no clinic
+ * able to see what they saw. It also hands over a whole medical record, so every check here is
+ * either "the right person gets in" or "the wrong person is turned away with something they can
+ * act on".
+ *
+ * This needed an identity the suite did not have. `patient` is seeded already linked to a record,
+ * and `SyncWithAuth` redirects any account holding a record away from /claim-record -- so the page
+ * could not be reached at all. `claimant` is that same patient one step earlier: invited, no link,
+ * no roles. `SEED_SAMPLE_IDENTITY` stages it and puts it back to unclaimed on every seed, because
+ * a successful claim is not reversible from the product.
+ *
+ * Order matters in this file. The refusals run first and change nothing; the successful claim runs
+ * last because it consumes the invitation and links the account for good.
+ */
+
+const CLAIMABLE_DOB = '1993-08-19';
+
+const patientCodeField = (page) => page.getByRole('textbox', { name: 'Patient code', exact: true });
+const dobField = (page) => page.getByLabel('Date of birth');
+
+/** The claim form, with the patient code the invitation is for. */
+async function openClaimForm(page) {
+  await page.goto('/claim-record');
+  await expect(
+    page.getByRole('heading', { name: /claim your existing patient record/i }),
+  ).toBeVisible({
+    timeout: 30_000,
+  });
+
+  // Role-scoped, not getByLabel: the invitation radio's accessible name contains "Patient code
+  // on file: NKP-...", so a substring match on the label resolves to two elements.
+  const code = patientCodeField(page);
+  await expect(code).toBeVisible({ timeout: 30_000 });
+  // The invitation names the record, and the form offers its code as the placeholder. Reading it
+  // rather than hard-coding one keeps the spec working against any seeded database.
+  const patientCode = await code.getAttribute('placeholder');
+  expect(patientCode).toMatch(/^NKP-\d{4}-\d{6}$/);
+
+  return { patientCode };
+}
+
+async function submitClaim(page, { patientCode, dob }) {
+  await patientCodeField(page).fill(patientCode);
+  await dobField(page).fill(dob);
+  await page.getByRole('button', { name: /claim patient record/i }).click();
+}
+
+test.describe('a patient holding an invitation', () => {
+  test('is routed to the claim page and told which record it is for', async ({ page }) => {
+    /*
+      Not a redirect the spec asks for: an account with no roles and a live invitation is *held*
+      on this route by SyncWithAuth. Landing anywhere else means claim onboarding stopped being
+      computed, which strands every newly invited patient on a screen they have no access to.
+    */
+    await page.goto('/dashboard');
+    await page.waitForURL(/\/claim-record/, { timeout: 30_000 });
+
+    await expect(
+      page.getByRole('heading', { name: /claim your existing patient record/i }),
+    ).toBeVisible();
+    await expect(page.getByText(/verify your record/i)).toBeVisible();
+  });
+
+  test('is refused a patient code belonging to another record, and told what to check', async ({
+    page,
+  }) => {
+    await openClaimForm(page);
+    await submitClaim(page, { patientCode: 'NKP-2026-999999', dob: CLAIMABLE_DOB });
+
+    await expect(page.getByText(/patient code does not match/i)).toBeVisible({ timeout: 30_000 });
+    // The recovery, on its own line. A refusal a patient cannot act on ends with them phoning a
+    // clinic that cannot see what they saw.
+    await expect(page.getByText(/check the code on your patient card/i)).toBeVisible();
+    // Still on the form, still unclaimed.
+    await expect(page.getByRole('button', { name: /claim patient record/i })).toBeVisible();
+  });
+
+  test('is refused a date of birth that does not match, separately from the code', async ({
+    page,
+  }) => {
+    const { patientCode } = await openClaimForm(page);
+    await submitClaim(page, { patientCode, dob: '1980-01-01' });
+
+    await expect(page.getByText(/date of birth does not match/i)).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByText(/as the clinic recorded it/i)).toBeVisible();
+    /*
+      The two refusals are distinct on purpose. A single "those details are wrong" would be kinder
+      to write and worse to act on, and telling the patient which half to re-check is the whole
+      difference between fixing it themselves and calling the clinic.
+    */
+    await expect(page.getByText(/patient code does not match/i)).toHaveCount(0);
+  });
+
+  test('reads without accessibility violations', async ({ page }) => {
+    await openClaimForm(page);
+
+    const results = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      .analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test('is operable by keyboard, and offers a way past the header', async ({ page }) => {
+    await openClaimForm(page);
+
+    // The skip link is the first thing in the tab order and hidden until focused. This route
+    // renders outside both app shells, so it had neither a skip link nor a main landmark.
+    await page.keyboard.press('Tab');
+    const skip = page.getByRole('link', { name: /skip to main content/i });
+    await expect(skip).toBeFocused();
+    await expect(page.locator('#main-content')).toBeVisible();
+
+    await patientCodeField(page).focus();
+    await page.keyboard.type('NKP-2026-999999');
+    await page.keyboard.press('Tab');
+    await expect(dobField(page)).toBeFocused();
+  });
+
+  test('reads at every supported width', async ({ page }) => {
+    for (const width of [375, 768, 1024, 1440]) {
+      await page.setViewportSize({ width, height: 900 });
+      await openClaimForm(page);
+
+      const overflow = await page.evaluate(
+        () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+      );
+      expect(overflow, `horizontal overflow at ${width}px`).toBeLessThanOrEqual(1);
+    }
+  });
+
+  /*
+    Last, and only once.
+
+    A successful claim links the account, stamps portalUserId, grants a PATIENT role and settles
+    the invitation, none of which the product can undo. Every test above runs against an unclaimed
+    account, so this one goes at the end; `SEED_SAMPLE_IDENTITY` puts it all back on the next seed.
+  */
+  test('claims the record and lands in the portal', async ({ page }) => {
+    const { patientCode } = await openClaimForm(page);
+    await submitClaim(page, { patientCode, dob: CLAIMABLE_DOB });
+
+    await page.waitForURL(/\/portal/, { timeout: 60_000 });
+    await expect(page.getByRole('heading', { name: /your care snapshot/i }).first()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // And the claim route stops being this account's home, because it now holds a record.
+    await page.goto('/claim-record');
+    await page.waitForURL((url) => !url.pathname.startsWith('/claim-record'), { timeout: 30_000 });
+  });
+});

--- a/apps/web/playwright/roles.js
+++ b/apps/web/playwright/roles.js
@@ -13,6 +13,10 @@ const path = require('path');
  * spec used to run as staff, so roughly 2,900 lines of migrated portal screens were never once
  * loaded by the suite. The seed links it to a real patient record through `Patient.portalUserId`,
  * which is what makes the portal show a chart rather than "ask your clinic to link this account".
+ *
+ * `claimant` is that same patient one step earlier: invited, not yet linked. The two cannot be one
+ * identity, because the link is what decides where the account is allowed to be -- a claimed
+ * account is redirected off /claim-record, so the claim page had no identity that could reach it.
  */
 const AUTH_DIR = path.join(__dirname, '.auth');
 
@@ -38,6 +42,17 @@ const ROLES = {
     password: process.env.E2E_PATIENT_PASSWORD || 'NkwapaPatient!23',
     // A patient-only account has no workspace dashboard; sign-in lands on the portal.
     landingUrl: '/portal',
+  },
+  claimant: {
+    storageState: path.join(AUTH_DIR, 'claimant.json'),
+    username: process.env.E2E_CLAIMANT_USERNAME || 'e2e.claimant',
+    password: process.env.E2E_CLAIMANT_PASSWORD || 'NkwapaClaimant!23',
+    /*
+      Holds an invitation and nothing else -- no record link, no roles. `SyncWithAuth` sends any
+      account in that state to /claim-record and holds it there, so this identity cannot land
+      anywhere else, and `patient` cannot land here: a claimed record is redirected away.
+    */
+    landingUrl: '/claim-record',
   },
 };
 

--- a/docs/USER_TESTING_GUIDE.md
+++ b/docs/USER_TESTING_GUIDE.md
@@ -109,6 +109,7 @@ is the part that genuinely needs a person.
 | Every way a claim is refused, and the four ways it is accepted  | `patient-portal/patient-claim.spec.ts`                              |
 | Canonical chart redirects, including a merge chain and a cycle  | `patients/patient.repository.spec.ts`                               |
 | A refused merge, and the redirect banner, in a browser          | `e2e/patient-identity.spec.js`, `e2e/patient-merge-preview.spec.js` |
+| Claiming a record, refused and accepted, as the patient         | `e2e/patient-claim.spec.js`                                         |
 
 640 is in the width list because it is what 1280 becomes at 200% zoom.
 
@@ -255,12 +256,14 @@ reach is naming the same chart twice.
 Run as the patient, not as staff. Every refusal must say what to do next; a refusal a patient
 cannot act on ends with them phoning a clinic that cannot see what they saw.
 
-- [ ] a valid claim links the account and lands on `/portal`
+`e2e/patient-claim.spec.js` now signs in as an invited, unclaimed account and covers the routing,
+both detail mismatches, the skip link and keyboard order, four widths, axe, and a real claim. What
+is left below is what that spec cannot reach: states needing a second account, a lapsed
+invitation, or a chart the claim form cannot be pointed at.
+
 - [ ] "E2E By Phone" can be claimed from an account whose number matches and whose email does not
 - [ ] "E2E No Birthday" is refused, and says to ask clinic staff to add the date of birth — not to
       try again
-- [ ] a wrong patient code and a wrong date of birth are each refused separately, and neither
-      refusal reveals whether the other was right
 - [ ] an account that was never invited is refused on identity before the code is even considered
 - [ ] an expired invitation names the date it expired
 - [ ] a cancelled invitation says the clinic cancelled it
@@ -268,10 +271,14 @@ cannot act on ends with them phoning a clinic that cannot see what they saw.
 - [ ] a record already connected to another sign-in is refused rather than taken over
 - [ ] the old patient code from a merged chart still claims the surviving record
 
+**Fixture note:** a successful claim links the account for good. `SEED_SAMPLE_IDENTITY` clears the
+link, the role, the `portalUserId` and the settled invitation on every seed, so re-running
+`npm run db:seed` puts the claimant back rather than leaving it spent.
+
 ### Widths and keyboard
 
-- [ ] 375 / 768 / 1024 / 1440 and 200% zoom: the duplicate queue, the merge panel and the claim
-      form never scroll sideways
+- [ ] 375 / 768 / 1024 / 1440 and 200% zoom: the duplicate queue and the merge panel never scroll
+      sideways (the claim form is covered by `e2e/patient-claim.spec.js`)
 - [ ] the merge panel is fully operable by keyboard, including both steps and the confirmation
 - [ ] a refusal on the claim form is announced, not only shown
 

--- a/docs/USER_TESTING_GUIDE.md
+++ b/docs/USER_TESTING_GUIDE.md
@@ -138,6 +138,15 @@ The two `patient request triage` specs consume the pending requests they act on,
 any second run against the same database, and re-seeding does not put them back. Reset them the way
 section 1 describes, or expect exactly those two failures and check that nothing else moved.
 
+`e2e/patient-claim.spec.js` consumes its fixture too, for a reason no reset can avoid: a claim
+links the account permanently, and after one the identity is redirected off `/claim-record` and
+every test in the file fails at the first assertion. Unlike the triage specs, `npm run db:seed`
+**does** put this one back — `SEED_SAMPLE_IDENTITY` clears the link, the role, the `portalUserId`
+and the settled invitation on every run. So: re-seed between local runs of that file, and if you
+see all seven of its tests fail together, re-seed before reading any of them as a real failure.
+
+CI is unaffected either way, since it seeds once into a fresh database and runs once.
+
 ---
 
 ## 4. Global Smoke Test

--- a/docs/specs/13_PATIENT_IDENTITY_RELEASE_GATE.md
+++ b/docs/specs/13_PATIENT_IDENTITY_RELEASE_GATE.md
@@ -89,6 +89,7 @@ operator inferred it from a disabled button further down.
 | Claim onboarding in `whoami`                                               | `apps/api/src/auth/auth.controller.spec.ts`                                           |
 | The table against the code and the published matrix                        | `apps/api/src/patients/patient-identity-matrix.spec.ts`                               |
 | A refused merge and the redirect banner, in a browser                      | `apps/web/e2e/patient-identity.spec.js`, `apps/web/e2e/patient-merge-preview.spec.js` |
+| Claiming a record in a browser, refused and accepted                       | `apps/web/e2e/patient-claim.spec.js`                                                  |
 
 ## Test data requirements
 
@@ -96,22 +97,24 @@ operator inferred it from a disabled button further down.
 
 `SEED_SAMPLE_IDENTITY=true` stages what using the product cannot produce:
 
-| Fixture                                                                         | Why it cannot be made by hand                                                       |
-| ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| "E2E Retired" already merged into "E2E Merged", with the alias and merge record | A merge is irreversible, so producing this state destroys whatever it was made from |
-| "E2E Keep Blocked" / "E2E Duplicate Blocked", colliding with "E2E Collision"    | An alias collision takes SQL to arrange                                             |
-| "E2E No Birthday", live invitation, no date of birth                            | The registry will not create a chart in this state                                  |
-| "E2E By Phone", phone-only invitation                                           | Nothing else seeds one, and it is the ordinary case for a patient with no email     |
+| Fixture                                                                         | Why it cannot be made by hand                                                              |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| "E2E Retired" already merged into "E2E Merged", with the alias and merge record | A merge is irreversible, so producing this state destroys whatever it was made from        |
+| "E2E Keep Blocked" / "E2E Duplicate Blocked", colliding with "E2E Collision"    | An alias collision takes SQL to arrange                                                    |
+| "E2E No Birthday", live invitation, no date of birth                            | The registry will not create a chart in this state                                         |
+| "E2E By Phone", phone-only invitation                                           | Nothing else seeds one, and it is the ordinary case for a patient with no email            |
+| "E2E Claimable", plus a roleless `e2e.claimant` account holding its invitation  | The only state that can reach `/claim-record`; a linked account is redirected away from it |
 
 Both flags are set on the CI e2e job. Each chart is guarded on its globally unique national ID
 hash, so re-seeding is a no-op.
 
 ## Residual risks
 
-- **The claim flow has no browser coverage.** The seeded portal identity is already claimed, so it
-  is redirected away from `/claim-record`, and covering the flow end to end needs a second
-  unclaimed Keycloak identity that the e2e setup does not have. Every branch is covered at the
-  service and controller level, and section 6b of the user testing guide covers it by hand.
+- **The claim flow's browser coverage is partial.** `e2e/patient-claim.spec.js` signs in as an
+  invited, unclaimed identity and covers routing, both detail mismatches, the skip link, keyboard
+  order, four widths, axe, and a real claim. The states one account cannot reach -- a phone-only
+  match, a lapsed or cancelled invitation, a record already linked elsewhere -- stay in section 6b
+  as manual checks and are covered at the service level.
 - **Cross-clinic consolidation is still refused outright**, and the queue marks such pairs as not
   mergeable. That is the next ticket, not a gap here.
 - **`listPendingInvitesForUser` has no route and no test.** It duplicates the onboarding query with

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -500,6 +500,89 @@ async function seedIdentityFixtures(
     });
     console.log(`Seeded a claim edge-case invitation for ${chart.patient.patientCode}.`);
   }
+
+  /*
+    The account that can actually reach /claim-record.
+
+    Deliberately roleless: `whoami` computes claim onboarding only when a user holds no roles at
+    all, and `SyncWithAuth` routes on that answer. Give this user a clinic role and it stops being
+    a claimant -- it lands on a dashboard instead, and the page under test becomes unreachable
+    again. There is no `PatientAccountLink` and no `portalUserId` for the same reason.
+  */
+  const claimantSub = process.env.SEED_E2E_CLAIMANT_SUB ?? process.env.E2E_CLAIMANT_SUB;
+  const claimantEmail =
+    process.env.SEED_E2E_CLAIMANT_EMAIL ??
+    process.env.E2E_CLAIMANT_EMAIL ??
+    'e2e.claimant@nkwapa.local';
+
+  if (claimantSub) {
+    const claimantName = process.env.SEED_E2E_CLAIMANT_NAME ?? 'E2E Claimant';
+    const [firstName, ...lastNameParts] = claimantName.trim().split(/\s+/);
+    await prisma.user.upsert({
+      where: { keycloakSub: claimantSub },
+      update: { email: claimantEmail, isActive: true },
+      create: {
+        keycloakSub: claimantSub,
+        displayName: claimantName,
+        firstName: firstName || 'E2E',
+        lastName: lastNameParts.join(' ') || 'Claimant',
+        email: claimantEmail,
+        isActive: true,
+      },
+    });
+
+    const unclaimed = await ensureChart({
+      firstName: 'E2E',
+      lastName: 'Claimable',
+      dob: new Date('1993-08-19'),
+      sex: Sex.FEMALE,
+      phoneE164: '+233201234555',
+      email: claimantEmail,
+      nationalId: 'GH-E2E-CLAIMABLE-770024',
+    });
+
+    /*
+      Put the claimant back to unclaimed, every time.
+
+      A successful claim is not reversible from the product: it links the account, stamps
+      `portalUserId`, grants a PATIENT role and settles the invitation. Leave any of that in place
+      and the fixture is single-use -- the second run signs in, gets redirected off /claim-record
+      because the account already holds a record, and every assertion in the spec fails for a
+      reason that has nothing to do with the code under test.
+
+      That is the trap the appointment fixtures already fall into, and it is written up in the
+      testing guide as something to work around. Worth not repeating: a fixture re-seeding cannot
+      restore is a fixture that silently expires.
+    */
+    await prisma.patientAccountLink.deleteMany({ where: { patientId: unclaimed.patient.id } });
+    await prisma.patient.updateMany({
+      where: { id: unclaimed.patient.id },
+      data: { portalUserId: null },
+    });
+    await prisma.userClinicRole.deleteMany({
+      where: { user: { keycloakSub: claimantSub }, role: UserRole.PATIENT },
+    });
+
+    const live = await prisma.patientPortalInvite.findFirst({
+      where: { patientId: unclaimed.patient.id, status: PatientPortalInviteStatus.PENDING },
+    });
+    if (!live) {
+      await prisma.patientPortalInvite.create({
+        data: {
+          patientId: unclaimed.patient.id,
+          clinicId,
+          status: PatientPortalInviteStatus.PENDING,
+          email: claimantEmail,
+          phoneE164: null,
+          createdByUserId: ownerUserId,
+          expiresAt: daysFromNow(14),
+        },
+      });
+      console.log(
+        `Seeded a claimable invitation for ${unclaimed.patient.patientCode} against ${claimantEmail}.`,
+      );
+    }
+  }
 }
 
 async function main() {

--- a/scripts/create-keycloak-e2e-user.mjs
+++ b/scripts/create-keycloak-e2e-user.mjs
@@ -67,6 +67,38 @@ const patientUser = {
   displayName: process.env.E2E_PATIENT_NAME || 'E2E Patient',
 };
 
+/**
+ * A patient who has been invited and has not claimed yet.
+ *
+ * Distinct from `patientUser`, which the seed links to a record through `Patient.portalUserId`.
+ * That link is exactly what makes it useless here: an account with a claimed record is redirected
+ * away from /claim-record, so the page could not be reached by any identity the suite had. This
+ * one holds no link and no roles, which is the state `whoami` answers with PATIENT_CLAIM_REQUIRED.
+ */
+const claimantUser = {
+  id: process.env.E2E_CLAIMANT_SUB || '00000000-0000-4000-8000-000000000047',
+  username: process.env.E2E_CLAIMANT_USERNAME || 'e2e.claimant',
+  password: process.env.E2E_CLAIMANT_PASSWORD || 'NkwapaClaimant!23',
+  email: process.env.E2E_CLAIMANT_EMAIL || 'e2e.claimant@nkwapa.local',
+  displayName: process.env.E2E_CLAIMANT_NAME || 'E2E Claimant',
+};
+
+/**
+ * Every identity the suite signs in as, keyed by the name the rest of the tooling uses.
+ *
+ * A table rather than five parallel sequences of upsert / env / output / summary lines, which is
+ * what this was: adding an identity meant remembering four places, and forgetting one of them
+ * failed somewhere other than where the mistake was.
+ */
+const identities = {
+  staff: staffUser,
+  reset: resetUser,
+  doctor: doctorUser,
+  volunteer: volunteerUser,
+  patient: patientUser,
+  claimant: claimantUser,
+};
+
 function splitName(displayName) {
   const [firstName, ...lastNameParts] = displayName.trim().split(/\s+/);
   return {
@@ -278,62 +310,21 @@ async function appendGithubOutput(name, value) {
 
 async function main() {
   const accessToken = await getAdminAccessToken();
-  const staffUserId = await upsertUser(accessToken, staffUser);
-  const resetUserId = await upsertUser(accessToken, resetUser);
-  const doctorUserId = await upsertUser(accessToken, doctorUser);
-  const volunteerUserId = await upsertUser(accessToken, volunteerUser);
-  const patientUserId = await upsertUser(accessToken, patientUser);
-  await appendGithubEnv('E2E_STAFF_SUB', staffUserId);
-  await appendGithubEnv('E2E_RESET_SUB', resetUserId);
-  await appendGithubEnv('E2E_DOCTOR_SUB', doctorUserId);
-  await appendGithubEnv('E2E_VOLUNTEER_SUB', volunteerUserId);
-  await appendGithubEnv('E2E_PATIENT_SUB', patientUserId);
-  await appendGithubOutput('staff-user-id', staffUserId);
-  await appendGithubOutput('reset-user-id', resetUserId);
-  await appendGithubOutput('doctor-user-id', doctorUserId);
-  await appendGithubOutput('volunteer-user-id', volunteerUserId);
-  await appendGithubOutput('patient-user-id', patientUserId);
+  const summary = { realm, keycloakBaseUrl };
 
-  console.log(
-    JSON.stringify(
-      {
-        realm,
-        keycloakBaseUrl,
-        staff: {
-          requestedUserId: staffUser.id,
-          userId: staffUserId,
-          username: staffUser.username,
-          email: staffUser.email,
-        },
-        reset: {
-          requestedUserId: resetUser.id,
-          userId: resetUserId,
-          username: resetUser.username,
-          email: resetUser.email,
-        },
-        doctor: {
-          requestedUserId: doctorUser.id,
-          userId: doctorUserId,
-          username: doctorUser.username,
-          email: doctorUser.email,
-        },
-        volunteer: {
-          requestedUserId: volunteerUser.id,
-          userId: volunteerUserId,
-          username: volunteerUser.username,
-          email: volunteerUser.email,
-        },
-        patient: {
-          requestedUserId: patientUser.id,
-          userId: patientUserId,
-          username: patientUser.username,
-          email: patientUser.email,
-        },
-      },
-      null,
-      2,
-    ),
-  );
+  for (const [role, user] of Object.entries(identities)) {
+    const userId = await upsertUser(accessToken, user);
+    await appendGithubEnv(`E2E_${role.toUpperCase()}_SUB`, userId);
+    await appendGithubOutput(`${role}-user-id`, userId);
+    summary[role] = {
+      requestedUserId: user.id,
+      userId,
+      username: user.username,
+      email: user.email,
+    };
+  }
+
+  console.log(JSON.stringify(summary, null, 2));
 }
 
 main().catch((error) => {


### PR DESCRIPTION
Closes #105.

## Why there was no coverage

The claim page had no browser coverage because no identity could reach it. The suite's `patient` is
seeded already linked to a record, and `SyncWithAuth` redirects any account holding a record away
from `/claim-record` — so the one identity that looked right was the one guaranteed to be sent
elsewhere.

`claimant` is that same patient one step earlier: invited, no link, no roles. Roleless is
load-bearing rather than incidental — `whoami` computes claim onboarding only when a user holds no
roles at all, so granting this account a clinic role would send it to a dashboard and make the page
unreachable again.

## What investigating it found first

**`/claim-record` had no `main` landmark and no skip link.** It renders outside both shells on
purpose (a claimant has no clinic and no roles, so neither `AppLayout` nor `PortalLayout` applies),
but the landmark and skip link came *with* those shells. That left the one page a patient works
through with no staff beside them as the only route in the product with neither — a keyboard or
screen-reader user had nothing to skip with, on a form asking for a patient code and date of birth.

It also blocked the harness: `auth.setup.js` waits for `#main-content` after sign-in, so a claimant
could not have been authenticated by the existing helper at all. One fix, two problems.

## The spec

Seven tests, in `apps/web/e2e/patient-claim.spec.js`:

- the routing that *holds* an invited account on the page — landing anywhere else means claim
  onboarding stopped being computed, which strands every newly invited patient
- a wrong patient code and a wrong date of birth, asserted **separately**, each with the recovery
  line it names. A single "those details are wrong" would be kinder to write and worse to act on
- axe, across WCAG 2.0/2.1 A and AA
- the skip link is first in the tab order, and the field order is sane
- 375 / 768 / 1024 / 1440 with no horizontal overflow
- last, a real claim that links the account and lands in the portal

## The fixture puts itself back

A successful claim links the account, stamps `portalUserId`, grants a `PATIENT` role and settles
the invitation — none of which the product can undo. `SEED_SAMPLE_IDENTITY` now clears all four
rather than guarding on their absence, so `npm run db:seed` restores the claimant.

Without that, this spec passes exactly once against any given database. That is the trap the
appointment fixtures already fall into, written up in the testing guide as something to work
around, and it seemed worth not repeating: a fixture re-seeding cannot restore is a fixture that
silently expires.

Verified by running the suite, re-seeding, and running it again — 12 passed both times.

## One thing that would have broken CI silently

**Keycloak does not always honour a requested user id.** Provisioning `e2e.claimant` asked for
`…047` and got `f4943d47-…` back. The script already writes the real id over `E2E_CLAIMANT_SUB`
through `GITHUB_ENV`, and the seed reads it from there, exactly as the other four identities do —
so the CI seed step deliberately does **not** pass `SEED_E2E_CLAIMANT_SUB`. Pinning the requested
id there would have seeded a user nobody can sign in as, and the failure would have surfaced as
seven unrelated-looking assertion errors.

## Also

`scripts/create-keycloak-e2e-user.mjs` had five parallel upsert / env / output / summary sequences.
Adding a sixth identity meant remembering four separate places, and missing one fails somewhere
other than the mistake. Now one table.

## Docs

Seven checks move from §6b's manual list into §3's automation table. The release gate's largest
residual risk shrinks from "no browser coverage" to a named list of states one account cannot reach
— a phone-only match, a lapsed or cancelled invitation, a record already linked elsewhere — which
stay manual and are covered at the service level.

§3 also gains the re-seed note, because seven tests failing at once looks nothing like its cause.

## Verification

```
npm run test --workspaces --if-present -- --coverage --ci   # api 1288, web 242, db 290
npm run typecheck && npm run lint --workspaces && npx prettier --check .
```

Playwright: full suite green at **150 passed** against restored fixtures, with the rate-limit
ceilings CI sets. The two pre-existing consumed-fixture specs were reset first by the documented
procedure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Ym9jDrHeE3mAf43TVFRjN
