### PR TITLE
E2E: stop one mail spec clearing the inbox another is waiting on

### DIFF
--- a/apps/web/e2e/forgot-password.spec.js
+++ b/apps/web/e2e/forgot-password.spec.js
@@ -7,7 +7,8 @@ const { clearMailpitInbox, findMessageTo, messageContent } = require('../playwri
 const resetEmail = process.env.E2E_RESET_EMAIL || 'e2e.reset@nkwapa.local';
 
 test('forgot password sends a Keycloak reset email to Mailpit', async ({ page }) => {
-  await clearMailpitInbox();
+  // Scoped to this suite's own address: the inbox is shared with the other mail spec.
+  await clearMailpitInbox(resetEmail);
 
   await page.goto('/login?next=%2Fdashboard');
   await page

--- a/apps/web/e2e/notifications-email.spec.js
+++ b/apps/web/e2e/notifications-email.spec.js
@@ -15,7 +15,8 @@ const inviteEmail = process.env.SEED_E2E_CLAIM_EMAIL || 'e2e.claim@nkwapa.local'
  */
 test.describe('portal invite email', () => {
   test('reaches a real SMTP inbox and is recorded in the ledger', async ({ page }) => {
-    await clearMailpitInbox();
+    // Scoped to this suite's own address: the inbox is shared with the other mail spec.
+    await clearMailpitInbox(inviteEmail);
 
     await page.goto('/patients');
     await expect(page.locator('#main-content')).toBeVisible({ timeout: 30_000 });

--- a/apps/web/playwright/mailpit.js
+++ b/apps/web/playwright/mailpit.js
@@ -1,9 +1,12 @@
 /**
  * Mailpit helpers.
  *
- * Two suites now assert on real mail — Keycloak's password reset and the app's own
- * portal invite — and they poll the same inbox in the same way. Kept here rather than
- * copied so a change to the Mailpit API is a single edit.
+ * Two suites assert on real mail — Keycloak's password reset and the app's own portal invite —
+ * and they poll the same inbox in the same way. Kept here rather than copied so a change to the
+ * Mailpit API is a single edit.
+ *
+ * One inbox, shared by every worker. Playwright runs these files on two workers, so anything that
+ * touches the whole inbox is acting on state another spec is in the middle of using.
  */
 const mailpitBaseUrl = process.env.MAILPIT_BASE_URL || 'http://localhost:8025';
 
@@ -15,8 +18,31 @@ async function mailpitFetch(path, options) {
   return response;
 }
 
-async function clearMailpitInbox() {
-  await mailpitFetch('/api/v1/messages', { method: 'DELETE' });
+/**
+ * Remove the messages a spec is about to assert on, and only those.
+ *
+ * This used to delete the entire inbox. Mailpit is shared global state and Playwright runs spec
+ * files on two workers, so a blanket clear could land between another spec's send and its poll,
+ * taking the message it was waiting for. That spec then failed on a timeout naming an email
+ * address, thirty seconds from anything that could explain it, and passed on the retry -- so it
+ * read as an infrastructure hiccup rather than a race, and surfaced only when a change to the
+ * file set happened to pair the two suites on different workers.
+ *
+ * Scoping by recipient removes the interaction: each suite owns its own address. Deliberately
+ * `DELETE /api/v1/search` rather than collecting ids and calling `DELETE /api/v1/messages` --
+ * that endpoint treats an empty id list as "delete everything", so a scoped clear that matched
+ * nothing would silently become the blanket clear this is replacing.
+ */
+async function clearMailpitInbox(recipient) {
+  if (!recipient) {
+    throw new Error(
+      'clearMailpitInbox requires a recipient: clearing the whole inbox races other specs.',
+    );
+  }
+
+  await mailpitFetch(`/api/v1/search?query=${encodeURIComponent(`to:${recipient}`)}`, {
+    method: 'DELETE',
+  });
 }
 
 /**


### PR DESCRIPTION
## The bug

`clearMailpitInbox()` deleted **every** message in Mailpit:

```js
await mailpitFetch('/api/v1/messages', { method: 'DELETE' });
```

Two spec files call it — `notifications-email.spec.js` and `forgot-password.spec.js` — Mailpit is
shared global state, and `playwright.config.js` runs spec files across two workers. So a blanket
clear could land between the other suite's send and its poll and take the message it was waiting
for.

The victim then failed on a thirty-second timeout naming an email address, with nothing near the
failure to explain it, and **passed on the retry**. That reads as an infrastructure hiccup rather
than a race, which is why it went unnoticed for so long.

## Why now

Whether it fires depends on which files happen to share a worker, so adding a spec file *anywhere*
in the suite can surface or hide it. #109 added one, and `notifications-email` went flaky on that
branch while being green on `release/dev` — same code, different scheduling.

Worth being precise: this is not a new bug and #109 did not cause it. It is a latent race that
changes in the file set shuffle in and out of view, and it will keep resurfacing as the suite
grows.

## The fix

Each suite clears only its own recipient, which removes the interaction rather than making it less
likely.

Deliberately `DELETE /api/v1/search?query=to:<address>` rather than collecting ids and calling
`DELETE /api/v1/messages`: **that endpoint treats an empty id list as "delete everything"**, so a
scoped clear that happened to match nothing would silently become the blanket clear this replaces.
Confirmed against the running container — a probe with `{"IDs":[]}` wiped the inbox.

Calling `clearMailpitInbox()` with no recipient now throws rather than falling back to the old
behaviour, so the unsafe form cannot come back by accident.

## Verification

Against Mailpit v1.20.7, the version `infra/nkwapa/docker-compose.yml` pins:

- sent three messages, two recipients; scoped-deleted one address; the other survived
- both mail specs together on two workers — the exact pairing that races — pass
- full suite: **143 passed, no failures, no flaky**

## Note for the reviewer

The scoped delete relies on Mailpit's search syntax (`to:<address>`). If the pinned Mailpit version
is ever bumped, that query is the thing to re-check — a search that silently matched nothing would
now leave stale messages rather than deleting the inbox, which fails safe but could confuse a
`findMessageTo` assertion that expects a clean start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Ym9jDrHeE3mAf43TVFRjN
