### PR TITLE
Organization rollout: zone-aware policy and filters

### DIFF
--- a/IMPLEMENTATION_STATUS.md
+++ b/IMPLEMENTATION_STATUS.md
@@ -79,7 +79,7 @@ nkwapa/
 
 1. Keycloak owns identity, password hashing, session expiry, password reset, and brute-force protection.
 2. Nkwapa owns authorization through `UserClinicRole`, effective permissions, clinic context, and RLS-scoped data access.
-3. `Organization -> Clinic(Location)` is the current tenant model. `Clinic.zoneCode` exists for future zone-aware rollups, not current RBAC.
+3. `Organization -> Clinic(Location)` is the current tenant model. `Clinic.zoneCode` is a reporting and filtering dimension, never a permission scope.
 4. Clinic-scoped HTTP traffic is expected to run through the request-scoped Prisma RLS context.
 5. `/auth/whoami` remains the frontend bootstrap contract for memberships, active clinic, permissions, and onboarding state.
 6. The API returns structured error envelopes with request IDs and recovery actions instead of raw exception payloads.
@@ -100,7 +100,8 @@ nkwapa/
 | Effective permission computation | ✅     | 100% | Union across roles, `*` wildcard for SYSTEM_ADMIN |
 | Disabled-user handling           | ✅     | 100% | `isActive` flag on User model                     |
 | Patient claim onboarding state   | ✅     | 100% | Returned by `/auth/whoami`                        |
-| Zone-scoped RBAC                 | ❌     | 0%   | `zoneCode` reserved in schema, policies deferred  |
+| Zone reporting filters           | ✅     | 100% | Filter on registry, network overview, roster      |
+| Zone-scoped RBAC                 | ❌     | 0%   | Deliberately not built; zone is a filter in V1    |
 | Organization-level permissions   | ❌     | 0%   | Org model exists, admin UI still clinic-first     |
 
 ### Data Isolation & Infrastructure
@@ -294,7 +295,7 @@ through one encounter. Those are listed in `docs/USER_TESTING_GUIDE.md` section 
 
 2. 🚀 **Extend org-aware administration** - Organization dashboards, clinic roster views, org-level filters.
 
-3. 🚀 **Finish zone-aware access** - Promote `zoneCode` from schema reserve to real access/reporting policy.
+3. 🚀 **Org-level reporting** - Give directors cross-clinic rollups; zone filters already exist to slice them.
 
 4. 🚀 **Deepen patient identity** - Duplicate review queue, stronger match heuristics, cross-clinic consolidation.
 

--- a/apps/api/src/auth/auth.controller.spec.ts
+++ b/apps/api/src/auth/auth.controller.spec.ts
@@ -40,13 +40,15 @@ describe('AuthController', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // One clinic zoned and one not, so the contract is exercised on both branches rather than
+    // on a value that happens to be present everywhere.
     clinicService.findByIds.mockResolvedValue([
-      { id: 'clinic-1', name: 'Test Clinic', region: 'Greater Accra' },
-      { id: 'clinic-2', name: 'Second Clinic', region: 'Ashanti' },
+      { id: 'clinic-1', name: 'Test Clinic', region: 'Greater Accra', zoneCode: 'coastal' },
+      { id: 'clinic-2', name: 'Second Clinic', region: 'Ashanti', zoneCode: null },
     ]);
     clinicService.listActiveSwitchableClinics.mockResolvedValue([
-      { id: 'clinic-2', name: 'Second Clinic', region: 'Ashanti' },
-      { id: 'clinic-1', name: 'Test Clinic', region: 'Greater Accra' },
+      { id: 'clinic-2', name: 'Second Clinic', region: 'Ashanti', zoneCode: null },
+      { id: 'clinic-1', name: 'Test Clinic', region: 'Greater Accra', zoneCode: 'coastal' },
     ]);
     prisma.user.findUnique.mockResolvedValue({
       email: 'test@example.com',
@@ -79,11 +81,13 @@ describe('AuthController', () => {
       {
         clinicId: 'clinic-1',
         clinicName: 'Test Clinic',
+        zoneCode: 'coastal',
         roles: ['MANAGER'],
       },
       {
         clinicId: 'clinic-2',
         clinicName: 'Second Clinic',
+        zoneCode: null,
         roles: ['VOLUNTEER'],
       },
     ]);
@@ -91,10 +95,12 @@ describe('AuthController', () => {
       {
         clinicId: 'clinic-2',
         clinicName: 'Second Clinic',
+        zoneCode: null,
       },
       {
         clinicId: 'clinic-1',
         clinicName: 'Test Clinic',
+        zoneCode: 'coastal',
       },
     ]);
     expect(response.effectiveRolesForActiveClinic).toEqual([
@@ -106,8 +112,8 @@ describe('AuthController', () => {
 
   it('lets global system admins with no clinic roles switch to any active clinic', async () => {
     clinicService.listActiveSwitchableClinics.mockResolvedValue([
-      { id: 'clinic-2', name: 'Second Clinic', region: 'Ashanti' },
-      { id: 'clinic-1', name: 'Test Clinic', region: 'Greater Accra' },
+      { id: 'clinic-2', name: 'Second Clinic', region: 'Ashanti', zoneCode: null },
+      { id: 'clinic-1', name: 'Test Clinic', region: 'Greater Accra', zoneCode: 'coastal' },
     ]);
 
     const response = await controller.whoami({
@@ -130,10 +136,12 @@ describe('AuthController', () => {
       {
         clinicId: 'clinic-2',
         clinicName: 'Second Clinic',
+        zoneCode: null,
       },
       {
         clinicId: 'clinic-1',
         clinicName: 'Test Clinic',
+        zoneCode: 'coastal',
       },
     ]);
     expect(response.activeClinicId).toBe('clinic-1');
@@ -143,8 +151,8 @@ describe('AuthController', () => {
 
   it('falls back when a system admin requests a clinic that is not active', async () => {
     clinicService.listActiveSwitchableClinics.mockResolvedValue([
-      { id: 'clinic-2', name: 'Second Clinic', region: 'Ashanti' },
-      { id: 'clinic-1', name: 'Test Clinic', region: 'Greater Accra' },
+      { id: 'clinic-2', name: 'Second Clinic', region: 'Ashanti', zoneCode: null },
+      { id: 'clinic-1', name: 'Test Clinic', region: 'Greater Accra', zoneCode: 'coastal' },
     ]);
 
     const response = await controller.whoami({
@@ -165,10 +173,10 @@ describe('AuthController', () => {
 
   it('only exposes active assigned clinics for non-system-admin users', async () => {
     clinicService.findByIds.mockResolvedValue([
-      { id: 'clinic-1', name: 'Test Clinic', region: 'Greater Accra' },
+      { id: 'clinic-1', name: 'Test Clinic', region: 'Greater Accra', zoneCode: 'coastal' },
     ]);
     clinicService.listActiveSwitchableClinics.mockResolvedValue([
-      { id: 'clinic-1', name: 'Test Clinic', region: 'Greater Accra' },
+      { id: 'clinic-1', name: 'Test Clinic', region: 'Greater Accra', zoneCode: 'coastal' },
     ]);
 
     const response = await controller.whoami({
@@ -196,6 +204,7 @@ describe('AuthController', () => {
       {
         clinicId: 'clinic-1',
         clinicName: 'Test Clinic',
+        zoneCode: 'coastal',
         roles: ['MANAGER'],
       },
     ]);
@@ -203,6 +212,7 @@ describe('AuthController', () => {
       {
         clinicId: 'clinic-1',
         clinicName: 'Test Clinic',
+        zoneCode: 'coastal',
       },
     ]);
     expect(response.activeClinicId).toBe('clinic-1');

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -15,12 +15,16 @@ export interface ReqUser {
 export interface Membership {
   clinicId: string;
   clinicName: string;
+  /** The clinic's reporting zone, or `null`. Context for the UI, never a permission. */
+  zoneCode: string | null;
   roles: string[];
 }
 
 export interface AvailableClinic {
   clinicId: string;
   clinicName: string;
+  /** The clinic's reporting zone, or `null`. Context for the UI, never a permission. */
+  zoneCode: string | null;
 }
 
 export interface WhoAmIResponse {
@@ -95,6 +99,7 @@ export class AuthController {
     const availableClinics: AvailableClinic[] = availableClinicRows.map((clinic) => ({
       clinicId: clinic.id,
       clinicName: clinic.name,
+      zoneCode: clinic.zoneCode ?? null,
     }));
     const availableClinicIds = new Set(availableClinics.map((clinic) => clinic.clinicId));
 
@@ -109,6 +114,7 @@ export class AuthController {
       memberships.push({
         clinicId: cid,
         clinicName: clinic.name,
+        zoneCode: clinic.zoneCode ?? null,
         roles: roleNames,
       });
     }

--- a/apps/api/src/auth/zone-scope.spec.ts
+++ b/apps/api/src/auth/zone-scope.spec.ts
@@ -1,0 +1,149 @@
+import { UserRole } from '@prisma/client';
+import { SHARED_ZONE_CODE, TENANT_CLINICS, UNZONED_FILTER_VALUE } from '@nkwapa/db';
+import { ClinicService } from '../clinics/clinic.service';
+import { ClinicsAdminController } from '../clinics/clinics-admin.controller';
+import { CLINIC_A1, CLINIC_A2, CLINIC_B1, actor } from '../testing/rbac-harness';
+
+/**
+ * Zone is a reporting filter, never a grant.
+ *
+ * `packages/db/src/rls-coverage.spec.ts` proves the database half: no policy reads the zone
+ * context or a zone column. This is the API half, driven through the real `ClinicService`
+ * against a Prisma double, because the guarantee lives in the *order* two clauses are composed
+ * and that is not visible from either clause alone.
+ *
+ * The fixture is built for exactly this: `a1` (organization A) and `b1` (organization B) share
+ * `SHARED_ZONE_CODE`, so a director of A filtering by it is asking a question whose honest
+ * answer spans a tenant boundary. It must not.
+ */
+
+/** Records the `where` the service composed, and returns rows the caller decides. */
+function buildService(rows: { id: string; zoneCode: string | null }[] = []) {
+  const clinicRows = rows.map((row) => ({
+    ...row,
+    name: row.id,
+    organizationId: 'org',
+    timezone: 'Africa/Accra',
+    locationCode: row.id,
+    countryCode: 'GH',
+    isActive: true,
+    organization: null,
+  }));
+  const findMany = jest.fn().mockResolvedValue(clinicRows);
+  const prisma = {
+    clinic: { findMany, findFirst: jest.fn(), findUnique: jest.fn() },
+    organization: { findMany: jest.fn(), findUnique: jest.fn(), findFirst: jest.fn() },
+  };
+  return { prisma, findMany, service: new ClinicService(prisma as never) };
+}
+
+const directorOfA = actor('director-a', [
+  { clinicId: CLINIC_A1, role: UserRole.DIRECTOR },
+  { clinicId: CLINIC_A2, role: UserRole.DIRECTOR },
+]);
+const directorOfB = actor('director-b', [{ clinicId: CLINIC_B1, role: UserRole.DIRECTOR }]);
+
+const asActor = (a: typeof directorOfA) => ({ userId: a.user.id, roles: a.roles });
+
+describe('a shared zone grants no access', () => {
+  it('is a fixture where one zone really does straddle two organizations', () => {
+    // If this ever stopped being true the tests below would pass for the wrong reason.
+    expect(TENANT_CLINICS.a1.zoneCode).toBe(SHARED_ZONE_CODE);
+    expect(TENANT_CLINICS.b1.zoneCode).toBe(SHARED_ZONE_CODE);
+    expect(TENANT_CLINICS.a1.organizationId).not.toBe(TENANT_CLINICS.b1.organizationId);
+  });
+
+  it('keeps a director of A inside A when filtering by the zone B also uses', async () => {
+    const { service, findMany } = buildService();
+    await service.listAllForAdmin(asActor(directorOfA), { zoneCode: SHARED_ZONE_CODE });
+
+    const where = findMany.mock.calls[0][0].where;
+    expect(where).toEqual({
+      id: { in: [CLINIC_A1, CLINIC_A2] },
+      zoneCode: SHARED_ZONE_CODE,
+    });
+    // The decisive assertion: B's clinic is not reachable by this query under any row it returns.
+    expect(where.id.in).not.toContain(CLINIC_B1);
+  });
+
+  it('keeps a director of B inside B for the same filter', async () => {
+    const { service, findMany } = buildService();
+    await service.listAllForAdmin(asActor(directorOfB), { zoneCode: SHARED_ZONE_CODE });
+
+    expect(findMany.mock.calls[0][0].where).toEqual({
+      id: { in: [CLINIC_B1] },
+      zoneCode: SHARED_ZONE_CODE,
+    });
+  });
+
+  it('composes the zone clause as an AND, never as an alternative', async () => {
+    // An OR is how a filter turns into a grant. There is no branch that produces one, and this
+    // is the test that fails if someone adds one.
+    for (const zoneCode of [SHARED_ZONE_CODE, UNZONED_FILTER_VALUE, undefined]) {
+      const { service, findMany } = buildService();
+      await service.listAllForAdmin(asActor(directorOfA), { zoneCode });
+
+      const where = findMany.mock.calls[0][0].where;
+      expect(where).not.toHaveProperty('OR');
+      expect(where).not.toHaveProperty('NOT');
+      expect(where.id).toEqual({ in: [CLINIC_A1, CLINIC_A2] });
+    }
+  });
+
+  it('answers an unzoned filter without widening either', async () => {
+    const { service, findMany } = buildService();
+    await service.listAllForAdmin(asActor(directorOfA), { zoneCode: UNZONED_FILTER_VALUE });
+
+    expect(findMany.mock.calls[0][0].where).toEqual({
+      id: { in: [CLINIC_A1, CLINIC_A2] },
+      zoneCode: null,
+    });
+  });
+
+  it('never lets a zone list name a zone from another organization', async () => {
+    // The picker is a disclosure surface of its own: the set of zone names describes how a
+    // tenant is structured, so it is scoped like the table rather than read from every clinic.
+    const { service, findMany } = buildService();
+    findMany.mockResolvedValue([{ zoneCode: SHARED_ZONE_CODE, isActive: true }]);
+
+    await service.listZonesForActor(asActor(directorOfB));
+    expect(findMany.mock.calls[0][0].where).toEqual({ id: { in: [CLINIC_B1] } });
+  });
+});
+
+describe('the zone filter cannot be reached without the seat', () => {
+  const buildController = () => {
+    const clinicService = {
+      listAllForAdmin: jest.fn().mockResolvedValue([]),
+      listZonesForActor: jest.fn().mockResolvedValue([]),
+    };
+    return {
+      clinicService,
+      controller: new ClinicsAdminController(clinicService as never, {} as never),
+    };
+  };
+
+  const seatless = [
+    ['a manager', actor('manager', [{ clinicId: CLINIC_A1, role: UserRole.MANAGER }])],
+    ['a doctor', actor('doctor', [{ clinicId: CLINIC_A1, role: UserRole.DOCTOR }])],
+    ['a volunteer', actor('volunteer', [{ clinicId: CLINIC_A1, role: UserRole.VOLUNTEER }])],
+  ] as const;
+
+  it.each(seatless)('refuses %s a zone-filtered clinic list', async (_label, a) => {
+    const { controller, clinicService } = buildController();
+    await expect(
+      controller.listAll({ user: { user: a.user, roles: a.roles } } as never, {
+        zoneCode: SHARED_ZONE_CODE,
+      }),
+    ).rejects.toThrow();
+    expect(clinicService.listAllForAdmin).not.toHaveBeenCalled();
+  });
+
+  it.each(seatless)('refuses %s the zone list', async (_label, a) => {
+    const { controller, clinicService } = buildController();
+    await expect(
+      controller.listZones({ user: { user: a.user, roles: a.roles } } as never),
+    ).rejects.toThrow();
+    expect(clinicService.listZonesForActor).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/auth/zone-scope.spec.ts
+++ b/apps/api/src/auth/zone-scope.spec.ts
@@ -147,3 +147,40 @@ describe('the zone filter cannot be reached without the seat', () => {
     expect(clinicService.listZonesForActor).not.toHaveBeenCalled();
   });
 });
+
+describe('the bootstrap contract carries zone as context only', () => {
+  it('never turns a zone into an effective role or permission', async () => {
+    // whoami is where a client learns what it may do. A zone appearing anywhere but beside a
+    // clinic's name would be the moment zone started reading like a grant.
+    const { AuthController } = await import('./auth.controller');
+    const clinicService = {
+      findByIds: jest
+        .fn()
+        .mockResolvedValue([
+          { id: CLINIC_A1, name: 'A1', region: null, zoneCode: SHARED_ZONE_CODE },
+        ]),
+      listActiveSwitchableClinics: jest
+        .fn()
+        .mockResolvedValue([
+          { id: CLINIC_A1, name: 'A1', region: null, zoneCode: SHARED_ZONE_CODE },
+        ]),
+    };
+    const prisma = { patientPortalInvite: { findMany: jest.fn().mockResolvedValue([]) } };
+    const controller = new AuthController(clinicService as never, prisma as never);
+
+    const response = await controller.whoami({
+      user: {
+        user: { id: 'u1', keycloakSub: 's1', displayName: 'U', email: null },
+        roles: [{ clinicId: CLINIC_A1, role: UserRole.VOLUNTEER }],
+      },
+      headers: {},
+    } as never);
+
+    expect(response.memberships[0].zoneCode).toBe(SHARED_ZONE_CODE);
+    expect(response.availableClinics[0].zoneCode).toBe(SHARED_ZONE_CODE);
+    // B1 is in the same zone and must not appear anywhere in the response.
+    expect(JSON.stringify(response)).not.toContain(CLINIC_B1);
+    expect(response.effectiveRolesForActiveClinic).toEqual([UserRole.VOLUNTEER]);
+    expect(response.effectivePermissionsForActiveClinic.join(' ')).not.toMatch(/zone/i);
+  });
+});

--- a/apps/api/src/clinics/clinic.service.spec.ts
+++ b/apps/api/src/clinics/clinic.service.spec.ts
@@ -501,3 +501,131 @@ describe('ClinicService organization scoping', () => {
     });
   });
 });
+
+const DIRECTOR_CLINIC_A = 'aaaaaaaa-1111-4111-8111-111111111111';
+const DIRECTOR_CLINIC_B = 'bbbbbbbb-1111-4111-8111-111111111111';
+
+const asSystemAdmin = {
+  userId: 'user-admin',
+  roles: [{ clinicId: null, role: UserRole.SYSTEM_ADMIN }],
+};
+const asDirector = {
+  userId: 'user-director',
+  roles: [
+    { clinicId: DIRECTOR_CLINIC_A, role: UserRole.DIRECTOR },
+    { clinicId: DIRECTOR_CLINIC_B, role: UserRole.DIRECTOR },
+  ],
+};
+const asVolunteer = {
+  userId: 'user-volunteer',
+  roles: [{ clinicId: DIRECTOR_CLINIC_A, role: UserRole.VOLUNTEER }],
+};
+
+/** The `where` the service actually sent, for asserting on how a filter was composed. */
+const whereOf = (mock: jest.Mock) => mock.mock.calls[0][0].where;
+
+describe('ClinicService.listAllForAdmin zone filter', () => {
+  it('applies no zone clause when no filter is given', async () => {
+    const { prisma, service } = buildService();
+    await service.listAllForAdmin(asSystemAdmin);
+    expect(whereOf(prisma.clinic.findMany)).toEqual({});
+  });
+
+  it('narrows a system admin to one zone', async () => {
+    const { prisma, service } = buildService();
+    await service.listAllForAdmin(asSystemAdmin, { zoneCode: 'north' });
+    expect(whereOf(prisma.clinic.findMany)).toEqual({ zoneCode: 'north' });
+  });
+
+  it('selects the clinics with no zone under the sentinel', async () => {
+    const { prisma, service } = buildService();
+    await service.listAllForAdmin(asSystemAdmin, { zoneCode: '__unzoned__' });
+    expect(whereOf(prisma.clinic.findMany)).toEqual({ zoneCode: null });
+  });
+
+  it('normalizes the filter the way the column stores it', async () => {
+    const { prisma, service } = buildService();
+    await service.listAllForAdmin(asSystemAdmin, { zoneCode: '  NORTH ' });
+    expect(whereOf(prisma.clinic.findMany)).toEqual({ zoneCode: 'north' });
+  });
+
+  it('ignores a filter it cannot parse rather than failing the read', async () => {
+    const { prisma, service } = buildService();
+    await service.listAllForAdmin(asSystemAdmin, { zoneCode: 'not a zone' });
+    expect(whereOf(prisma.clinic.findMany)).toEqual({});
+  });
+
+  it('keeps a director scoped to their own clinics while filtering', async () => {
+    // The point of the whole feature: the zone clause is ANDed onto the clinic-id scope, never
+    // substituted for it. A director asking for a zone gets their clinics in that zone.
+    const { prisma, service } = buildService();
+    await service.listAllForAdmin(asDirector, { zoneCode: 'north' });
+    expect(whereOf(prisma.clinic.findMany)).toEqual({
+      id: { in: [DIRECTOR_CLINIC_A, DIRECTOR_CLINIC_B] },
+      zoneCode: 'north',
+    });
+  });
+
+  it('never drops the clinic-id scope, whatever the filter', async () => {
+    for (const zoneCode of [undefined, 'north', '__unzoned__', 'not a zone', '']) {
+      const { prisma, service } = buildService();
+      await service.listAllForAdmin(asDirector, { zoneCode });
+      expect(whereOf(prisma.clinic.findMany)).toMatchObject({
+        id: { in: [DIRECTOR_CLINIC_A, DIRECTOR_CLINIC_B] },
+      });
+    }
+  });
+
+  it('returns nothing for an actor who administers no clinic, filter or not', async () => {
+    const { prisma, service } = buildService();
+    await expect(service.listAllForAdmin(asVolunteer, { zoneCode: 'north' })).resolves.toEqual([]);
+    // No query at all, rather than a query with an empty scope -- which would match everything.
+    expect(prisma.clinic.findMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('ClinicService.listZonesForActor', () => {
+  it('summarizes the zones across every clinic for a system admin', async () => {
+    const { prisma, service } = buildService();
+    prisma.clinic.findMany.mockResolvedValue([
+      { zoneCode: 'north', isActive: true },
+      { zoneCode: 'north', isActive: false },
+      { zoneCode: null, isActive: true },
+    ]);
+
+    await expect(service.listZonesForActor(asSystemAdmin)).resolves.toEqual([
+      { zoneCode: 'north', clinicCount: 2, activeClinicCount: 1 },
+      { zoneCode: null, clinicCount: 1, activeClinicCount: 1 },
+    ]);
+    expect(whereOf(prisma.clinic.findMany)).toEqual({});
+  });
+
+  it('reads only the clinics a director administers', async () => {
+    // A zone list built from every clinic on the platform would leak how other organizations
+    // are structured, and offer a director filters that can only ever return nothing.
+    const { prisma, service } = buildService();
+    prisma.clinic.findMany.mockResolvedValue([{ zoneCode: 'north', isActive: true }]);
+
+    await service.listZonesForActor(asDirector);
+    expect(whereOf(prisma.clinic.findMany)).toEqual({
+      id: { in: [DIRECTOR_CLINIC_A, DIRECTOR_CLINIC_B] },
+    });
+  });
+
+  it('returns nothing for an actor who administers no clinic', async () => {
+    const { prisma, service } = buildService();
+    await expect(service.listZonesForActor(asVolunteer)).resolves.toEqual([]);
+    expect(prisma.clinic.findMany).not.toHaveBeenCalled();
+  });
+
+  it('scopes the zone list exactly like the clinic list beside it', async () => {
+    // The two endpoints back one picker and one table. If their scoping ever diverged, the
+    // picker would offer a zone the table could not show.
+    const { prisma: zonesPrisma, service: zonesService } = buildService();
+    const { prisma: listPrisma, service: listService } = buildService();
+    await zonesService.listZonesForActor(asDirector);
+    await listService.listAllForAdmin(asDirector);
+
+    expect(whereOf(zonesPrisma.clinic.findMany)).toEqual(whereOf(listPrisma.clinic.findMany));
+  });
+});

--- a/apps/api/src/clinics/clinic.service.ts
+++ b/apps/api/src/clinics/clinic.service.ts
@@ -14,8 +14,12 @@ import {
   normalizeCountryCode,
   normalizeLocationCode,
   normalizeZoneCode,
+  parseZoneFilter,
+  summarizeZones,
   toLocationCode,
+  zoneFilterWhere,
   type ClinicMetadataIssue,
+  type ZoneSummary,
 } from '@nkwapa/db';
 import { PrismaService } from '../prisma/prisma.service';
 
@@ -144,33 +148,70 @@ export class ClinicService {
   }
 
   /**
+   * Which clinics this actor may administer, as a `where` clause.
+   *
+   * `null` means "no clinics at all", which is not the same as an empty clause: an empty clause
+   * matches everything. Callers must return early on it rather than spreading it.
+   *
+   * This is the single authorization decision behind both the admin list and the zone list.
+   * It used to be written out twice, and two copies of a tenant boundary is one copy too many.
+   */
+  private clinicScopeForAdmin(actor: AdminActor): Prisma.ClinicWhereInput | null {
+    const isSystemAdmin = actor.roles.some(
+      (r) => r.role === UserRole.SYSTEM_ADMIN && r.clinicId === null,
+    );
+    if (isSystemAdmin) return {};
+
+    const directorClinicIds = actor.roles
+      .filter((r) => r.role === UserRole.DIRECTOR && r.clinicId != null)
+      .map((r) => r.clinicId as string);
+    if (directorClinicIds.length === 0) return null;
+    return { id: { in: directorClinicIds } };
+  }
+
+  /**
+   * The zones in use across the clinics this actor administers, with clinic counts.
+   *
+   * Backs the zone picker, and is deliberately derived from the actor's own scope rather than
+   * from every zone on the platform. A director offered a zone they cannot see would get an
+   * empty list and no explanation, and the list of zone names is itself a weak disclosure of
+   * how other organizations are structured.
+   */
+  async listZonesForActor(actor: AdminActor): Promise<ZoneSummary[]> {
+    const scope = this.clinicScopeForAdmin(actor);
+    if (scope === null) return [];
+
+    const clinics = await this.prisma.clinic.findMany({
+      where: scope,
+      select: { zoneCode: true, isActive: true },
+    });
+    return summarizeZones(clinics);
+  }
+
+  /**
    * The admin clinic list, with each row's organization and its metadata problems attached.
    *
    * The issues are computed by the same `evaluateClinicMetadata` the repair CLI runs, so a
    * badge in the UI and a line of CLI output can never describe a clinic differently.
+   *
+   * The zone filter narrows and can do nothing else. The actor's scope is resolved first and
+   * the zone clause is ANDed onto it, so filtering by a zone that another organization also
+   * uses returns this actor's clinics in that zone and nothing more. That ordering is the
+   * boundary; `zoneFilterWhere` cannot express anything but a `zoneCode` constraint, and
+   * `docs/specs/03_AUTH_AND_RBAC.md` says why.
    */
-  async listAllForAdmin(actor: AdminActor): Promise<AdminClinicView[]> {
-    const isSystemAdmin = actor.roles.some(
-      (r) => r.role === UserRole.SYSTEM_ADMIN && r.clinicId === null,
-    );
+  async listAllForAdmin(
+    actor: AdminActor,
+    filters?: { zoneCode?: string | null },
+  ): Promise<AdminClinicView[]> {
+    const scope = this.clinicScopeForAdmin(actor);
+    if (scope === null) return [];
 
-    let clinics;
-    if (isSystemAdmin) {
-      clinics = await this.prisma.clinic.findMany({
-        orderBy: { name: 'asc' },
-        include: { organization: true },
-      });
-    } else {
-      const directorClinicIds = actor.roles
-        .filter((r) => r.role === UserRole.DIRECTOR && r.clinicId != null)
-        .map((r) => r.clinicId as string);
-      if (directorClinicIds.length === 0) return [];
-      clinics = await this.prisma.clinic.findMany({
-        where: { id: { in: directorClinicIds } },
-        orderBy: { name: 'asc' },
-        include: { organization: true },
-      });
-    }
+    const clinics = await this.prisma.clinic.findMany({
+      where: { ...scope, ...zoneFilterWhere(parseZoneFilter(filters?.zoneCode)) },
+      orderBy: { name: 'asc' },
+      include: { organization: true },
+    });
 
     return clinics.map(({ organization, ...clinic }) => ({
       ...clinic,
@@ -301,18 +342,14 @@ export class ClinicService {
 
   /** `'all'` for a system admin; otherwise the organizations the actor directs a clinic in. */
   private async allowedOrganizationIds(actor: AdminActor): Promise<'all' | string[]> {
-    const isSystemAdmin = actor.roles.some(
-      (r) => r.role === UserRole.SYSTEM_ADMIN && r.clinicId === null,
-    );
-    if (isSystemAdmin) return 'all';
-
-    const directorClinicIds = actor.roles
-      .filter((r) => r.role === UserRole.DIRECTOR && r.clinicId != null)
-      .map((r) => r.clinicId as string);
-    if (directorClinicIds.length === 0) return [];
+    const scope = this.clinicScopeForAdmin(actor);
+    if (scope === null) return [];
+    // An empty clause is the system admin's "every clinic", which is why it cannot be spread
+    // onto a query without meaning it.
+    if (Object.keys(scope).length === 0) return 'all';
 
     const clinics = await this.prisma.clinic.findMany({
-      where: { id: { in: directorClinicIds } },
+      where: scope,
       select: { organizationId: true },
     });
     return [...new Set(clinics.map((clinic) => clinic.organizationId))];

--- a/apps/api/src/clinics/clinic.service.ts
+++ b/apps/api/src/clinics/clinic.service.ts
@@ -83,24 +83,28 @@ export class ClinicService {
     });
   }
 
-  async findByIds(ids: string[]): Promise<{ id: string; name: string; region: string | null }[]> {
+  async findByIds(
+    ids: string[],
+  ): Promise<{ id: string; name: string; region: string | null; zoneCode: string | null }[]> {
     if (ids.length === 0) return [];
     return this.prisma.clinic.findMany({
       where: { id: { in: ids }, isActive: true },
-      select: { id: true, name: true, region: true },
+      select: { id: true, name: true, region: true, zoneCode: true },
     });
   }
 
   async listActiveSwitchableClinics(
     ids?: string[],
-  ): Promise<{ id: string; name: string; region: string | null }[]> {
+  ): Promise<{ id: string; name: string; region: string | null; zoneCode: string | null }[]> {
     if (ids && ids.length === 0) return [];
     return this.prisma.clinic.findMany({
       where: {
         isActive: true,
         ...(ids ? { id: { in: ids } } : {}),
       },
-      select: { id: true, name: true, region: true },
+      // `zoneCode` rides along so a single-clinic view can say which zone it is showing without
+      // a second round trip. It names the clinic the caller already has; it grants nothing.
+      select: { id: true, name: true, region: true, zoneCode: true },
       orderBy: { name: 'asc' },
     });
   }

--- a/apps/api/src/clinics/clinics-admin.controller.spec.ts
+++ b/apps/api/src/clinics/clinics-admin.controller.spec.ts
@@ -5,6 +5,9 @@ import { ClinicsAdminController } from './clinics-admin.controller';
 describe('ClinicsAdminController', () => {
   const clinicService = {
     listAllForAdmin: jest.fn().mockResolvedValue([{ id: 'clinic-1', name: 'Clinic One' }]),
+    listZonesForActor: jest
+      .fn()
+      .mockResolvedValue([{ zoneCode: 'north', clinicCount: 1, activeClinicCount: 1 }]),
     listOrganizations: jest.fn().mockResolvedValue([{ id: 'org-1', name: 'Nkwapa Health' }]),
     resolveOrganizationIdForActor: jest
       .fn()
@@ -51,6 +54,9 @@ describe('ClinicsAdminController', () => {
     // of these reject would otherwise leak that into every test after it.
     jest.clearAllMocks();
     clinicService.listAllForAdmin.mockResolvedValue([{ id: 'clinic-1', name: 'Clinic One' }]);
+    clinicService.listZonesForActor.mockResolvedValue([
+      { zoneCode: 'north', clinicCount: 1, activeClinicCount: 1 },
+    ]);
     clinicService.listOrganizations.mockResolvedValue([{ id: 'org-1', name: 'Nkwapa Health' }]);
     clinicService.resolveOrganizationIdForActor.mockResolvedValue(
       '11111111-1111-4111-8111-111111111111',
@@ -60,13 +66,65 @@ describe('ClinicsAdminController', () => {
   });
 
   it('rejects managers from listing clinic administration data', async () => {
-    await expect(controller.listAll(asManager as never)).rejects.toBeInstanceOf(ForbiddenException);
+    await expect(controller.listAll(asManager as never, {})).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
   });
 
   it('allows directors to list clinics they can administer', async () => {
-    await expect(controller.listAll(asDirector as never)).resolves.toEqual([
+    await expect(controller.listAll(asDirector as never, {})).resolves.toEqual([
       { id: 'clinic-1', name: 'Clinic One' },
     ]);
+  });
+
+  describe('zone filter', () => {
+    it('passes the zone through to the service with the actor', async () => {
+      await controller.listAll(asDirector as never, { zoneCode: 'north' });
+      expect(clinicService.listAllForAdmin).toHaveBeenCalledWith(
+        { userId: 'director-1', roles: asDirector.user.roles },
+        { zoneCode: 'north' },
+      );
+    });
+
+    it('passes an absent zone through as an absent filter', async () => {
+      await controller.listAll(asDirector as never, {});
+      expect(clinicService.listAllForAdmin).toHaveBeenCalledWith(expect.anything(), {
+        zoneCode: undefined,
+      });
+    });
+
+    it('checks the seat before it looks at the filter', async () => {
+      // A manager holds CLINIC.MANAGE, so the class guard lets them in and this re-gate is the
+      // only thing stopping them. It has to run whatever the query says.
+      await expect(
+        controller.listAll(asManager as never, { zoneCode: 'north' }),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+      expect(clinicService.listAllForAdmin).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('zones', () => {
+    it('lists the zones an admin can administer', async () => {
+      await expect(controller.listZones(asSystemAdmin as never)).resolves.toEqual([
+        { zoneCode: 'north', clinicCount: 1, activeClinicCount: 1 },
+      ]);
+    });
+
+    it('passes the actor through, so the service can scope the list to them', async () => {
+      await controller.listZones(asDirector as never);
+      expect(clinicService.listZonesForActor).toHaveBeenCalledWith({
+        userId: 'director-1',
+        roles: asDirector.user.roles,
+      });
+    });
+
+    it('is refused to a manager, like the list it filters', async () => {
+      // The picker must not be a way around the re-gate on the table it drives.
+      await expect(controller.listZones(asManager as never)).rejects.toBeInstanceOf(
+        ForbiddenException,
+      );
+      expect(clinicService.listZonesForActor).not.toHaveBeenCalled();
+    });
   });
 
   describe('organizations', () => {

--- a/apps/api/src/clinics/clinics-admin.controller.ts
+++ b/apps/api/src/clinics/clinics-admin.controller.ts
@@ -5,6 +5,7 @@ import {
   Put,
   Body,
   Param,
+  Query,
   UseGuards,
   Request,
   ForbiddenException,
@@ -19,6 +20,7 @@ import { UserRole } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateClinicAdminDto } from './dto/create-clinic-admin.dto';
 import { UpdateClinicAdminDto } from './dto/update-clinic-admin.dto';
+import { ListClinicsAdminQueryDto } from './dto/list-clinics-admin.query.dto';
 import { IdParamDto } from '../common/request-dto';
 import type { ReqUserWithRoles } from '../auth/guards/rbac.guard';
 
@@ -32,13 +34,33 @@ export class ClinicsAdminController {
   ) {}
 
   @Get()
-  async listAll(@Request() req: { user: ReqUserWithRoles }) {
+  async listAll(
+    @Request() req: { user: ReqUserWithRoles },
+    @Query() query: ListClinicsAdminQueryDto,
+  ) {
     const actor = {
       userId: req.user.user.id,
       roles: req.user.roles,
     };
     this.assertCanAdministerClinics(actor.roles, 'list clinics');
-    return this.clinicService.listAllForAdmin(actor);
+    return this.clinicService.listAllForAdmin(actor, { zoneCode: query.zoneCode });
+  }
+
+  /**
+   * The zones in use across the clinics this actor administers.
+   *
+   * Zones are tenant-defined free text rather than an enum, so the filter's vocabulary has to
+   * come from the data. Scoped exactly like the list beside it: a director sees the zones of
+   * the clinics they direct, and learns nothing about how anyone else is organized.
+   */
+  @Get('zones')
+  async listZones(@Request() req: { user: ReqUserWithRoles }) {
+    const actor = {
+      userId: req.user.user.id,
+      roles: req.user.roles,
+    };
+    this.assertCanAdministerClinics(actor.roles, 'list zones');
+    return this.clinicService.listZonesForActor(actor);
   }
 
   /**

--- a/apps/api/src/clinics/dto/list-clinics-admin.query.dto.spec.ts
+++ b/apps/api/src/clinics/dto/list-clinics-admin.query.dto.spec.ts
@@ -1,0 +1,46 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { UNZONED_FILTER_VALUE } from '@nkwapa/db';
+import { ListClinicsAdminQueryDto } from './list-clinics-admin.query.dto';
+
+const parse = (plain: object) => plainToInstance(ListClinicsAdminQueryDto, plain);
+const failedFields = async (dto: object) =>
+  (await validate(dto)).map((error) => error.property).sort();
+
+describe('ListClinicsAdminQueryDto', () => {
+  it('accepts no query at all', async () => {
+    await expect(validate(parse({}))).resolves.toHaveLength(0);
+  });
+
+  it('accepts a zone code', async () => {
+    const dto = parse({ zoneCode: 'greater-accra' });
+    await expect(validate(dto)).resolves.toHaveLength(0);
+    expect(dto.zoneCode).toBe('greater-accra');
+  });
+
+  it('accepts the unzoned sentinel', async () => {
+    // The one value that is not a legal zone code but is a legal filter. If sanitization ever
+    // started stripping underscores this is the test that would notice.
+    const dto = parse({ zoneCode: UNZONED_FILTER_VALUE });
+    await expect(validate(dto)).resolves.toHaveLength(0);
+    expect(dto.zoneCode).toBe(UNZONED_FILTER_VALUE);
+  });
+
+  it('accepts an empty zone code as no filter', async () => {
+    await expect(validate(parse({ zoneCode: '' }))).resolves.toHaveLength(0);
+  });
+
+  it('rejects a zone code the column could not hold', async () => {
+    expect(await failedFields(parse({ zoneCode: 'Greater Accra' }))).toEqual(['zoneCode']);
+    expect(await failedFields(parse({ zoneCode: '-leading' }))).toEqual(['zoneCode']);
+    expect(await failedFields(parse({ zoneCode: 'a'.repeat(65) }))).toEqual(['zoneCode']);
+  });
+
+  it('explains the sentinel in the message, since nothing else would', () => {
+    return validate(parse({ zoneCode: 'not a zone' })).then((errors) => {
+      const message = Object.values(errors[0].constraints ?? {}).join(' ');
+      expect(message).toContain(UNZONED_FILTER_VALUE);
+    });
+  });
+});

--- a/apps/api/src/clinics/dto/list-clinics-admin.query.dto.ts
+++ b/apps/api/src/clinics/dto/list-clinics-admin.query.dto.ts
@@ -1,0 +1,32 @@
+import { IsOptional } from 'class-validator';
+import { ToSanitizedString } from '../../common/validation';
+import { IsZoneFilter } from '../../common/clinic-metadata.validator';
+
+/**
+ * Query parameters for `GET /admin/clinics`.
+ *
+ * This class has to exist even though it holds one optional field: the global pipe runs with
+ * `forbidNonWhitelisted`, so a query parameter no DTO declares is a 400 rather than something
+ * quietly ignored.
+ *
+ * Zone is the only filter here, and it narrows. The controller resolves which clinics the actor
+ * may see before this value is applied, so a zone the actor does not administer simply matches
+ * nothing rather than reaching across a tenant boundary.
+ */
+export class ListClinicsAdminQueryDto {
+  /**
+   * A zone code, or `__unzoned__` for the clinics that have none.
+   *
+   * The sentinel is sanitized-but-not-normalized on purpose: `normalizeZoneCode` would be the
+   * obvious transform, but it is the column's rule and would reject the sentinel. The shared
+   * `parseZoneFilter` does the normalizing, once, where the filter is actually resolved.
+   *
+   * Deliberately not capped at `ZONE_CODE_MAX_LENGTH` here. The sanitizer truncates rather than
+   * refuses, so capping would turn an over-long code into a valid 64-character one and answer a
+   * question nobody asked. The validator refuses it instead.
+   */
+  @IsOptional()
+  @ToSanitizedString()
+  @IsZoneFilter()
+  zoneCode?: string;
+}

--- a/apps/api/src/common/clinic-metadata.validator.spec.ts
+++ b/apps/api/src/common/clinic-metadata.validator.spec.ts
@@ -1,10 +1,12 @@
 import { validate } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
+import { UNZONED_FILTER_VALUE } from '@nkwapa/db';
 import {
   IsCountryCode,
   IsIanaTimeZone,
   IsLocationCode,
   IsZoneCode,
+  IsZoneFilter,
 } from './clinic-metadata.validator';
 
 class MetadataProbe {
@@ -90,6 +92,41 @@ describe('clinic metadata validators', () => {
 
     it('still shape-checks a zone code that is present', async () => {
       expect(await failingFields({ zoneCode: 'Greater Accra' })).toEqual(['zoneCode']);
+    });
+  });
+
+  describe('IsZoneFilter', () => {
+    class ZoneFilterSubject {
+      @IsZoneFilter()
+      zoneCode?: string;
+    }
+
+    const filterErrors = async (value: unknown) => {
+      const subject = new ZoneFilterSubject();
+      (subject as { zoneCode?: unknown }).zoneCode = value;
+      return (await validate(subject)).map((error) => error.property);
+    };
+
+    it('accepts a zone code, like IsZoneCode does', async () => {
+      expect(await filterErrors('greater-accra')).toEqual([]);
+    });
+
+    it('accepts the unzoned sentinel, which IsZoneCode does not', async () => {
+      // This is the whole reason the two decorators are separate: `__unzoned__` is a legal
+      // question to ask a query and an illegal value to store in the column.
+      expect(await filterErrors(UNZONED_FILTER_VALUE)).toEqual([]);
+      expect(await failingFields({ zoneCode: UNZONED_FILTER_VALUE })).toEqual(['zoneCode']);
+    });
+
+    it('treats absent and empty as no filter', async () => {
+      expect(await filterErrors(undefined)).toEqual([]);
+      expect(await filterErrors('')).toEqual([]);
+    });
+
+    it('rejects a value the column could not hold', async () => {
+      expect(await filterErrors('Greater Accra')).toEqual(['zoneCode']);
+      expect(await filterErrors('a'.repeat(65))).toEqual(['zoneCode']);
+      expect(await filterErrors(7)).toEqual(['zoneCode']);
     });
   });
 

--- a/apps/api/src/common/clinic-metadata.validator.ts
+++ b/apps/api/src/common/clinic-metadata.validator.ts
@@ -2,11 +2,13 @@ import {
   COUNTRY_CODE_PATTERN,
   LOCATION_CODE_MAX_LENGTH,
   LOCATION_CODE_PATTERN,
+  UNZONED_FILTER_VALUE,
   ZONE_CODE_MAX_LENGTH,
   isCountryCode,
   isLocationCode,
   isTimeZone,
   isZoneCode,
+  isZoneFilterValue,
 } from '@nkwapa/db';
 import {
   registerDecorator,
@@ -93,6 +95,39 @@ export function IsZoneCode(validationOptions?: ValidationOptions) {
       options: validationOptions,
       constraints: [],
       validator: IsZoneCodeConstraint,
+    });
+  };
+}
+
+@ValidatorConstraint({ name: 'isZoneFilter', async: false })
+export class IsZoneFilterConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown): boolean {
+    // Absent is "no filter", which `@IsOptional` has already let through. Anything present has
+    // to be a zone the column could hold, or the sentinel that selects the clinics with none.
+    if (value === null || value === undefined || value === '') return true;
+    return isZoneFilterValue(value);
+  }
+
+  defaultMessage(): string {
+    return `zoneCode must be a zone code, or "${UNZONED_FILTER_VALUE}" for clinics with no zone. Leave it out to list every zone.`;
+  }
+}
+
+/**
+ * Validates a zone *filter*, which is a different question from a zone *code*.
+ *
+ * `IsZoneCode` guards a value on its way into the column, so it knows nothing about the unzoned
+ * sentinel. This guards a value on its way into a query, where "the clinics with no zone" is a
+ * thing a caller needs to be able to ask for and an empty string cannot express.
+ */
+export function IsZoneFilter(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      constraints: [],
+      validator: IsZoneFilterConstraint,
     });
   };
 }

--- a/apps/api/src/dashboard/dashboard.controller.ts
+++ b/apps/api/src/dashboard/dashboard.controller.ts
@@ -1,10 +1,11 @@
-import { Controller, Get, Param, Request, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, Query, Request, UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RequirePermission } from '../auth/decorators/require-permission.decorator';
 import { ClinicScoped } from '../auth/decorators/clinic-scoped.decorator';
 import { RbacGuard } from '../auth/guards/rbac.guard';
 import { ClinicScopeGuard } from '../auth/guards/clinic-scope.guard';
 import { DashboardService } from './dashboard.service';
+import { DashboardQueryDto } from './dto/dashboard-query.dto';
 import { PERMISSIONS } from '../auth/constants/permissions';
 import { rolesForClinic, type ScopedRole } from '../auth/clinic-roles';
 
@@ -22,12 +23,15 @@ export class DashboardController {
     req: {
       user: { user: { id: string }; roles: { role: string; clinicId: string | null }[] };
     },
+    @Query() query: DashboardQueryDto,
   ) {
     const userId = req.user.user.id;
     // Through the shared helper rather than a local filter: a global grant other than
     // SYSTEM_ADMIN would otherwise unlock this clinic's dashboard from a seat elsewhere.
     const roles = rolesForClinic(req.user.roles as ScopedRole[], clinicId).map((r) => r.role);
 
-    return this.dashboardService.getDashboard(clinicId, roles, userId);
+    return this.dashboardService.getDashboard(clinicId, roles, userId, {
+      zoneCode: query.zoneCode,
+    });
   }
 }

--- a/apps/api/src/dashboard/dashboard.service.spec.ts
+++ b/apps/api/src/dashboard/dashboard.service.spec.ts
@@ -1,4 +1,5 @@
 import { DashboardService, FLAGGED_DIABETES_WHERE } from './dashboard.service';
+import type { SystemAdminMetrics } from './dto/dashboard-response.dto';
 
 describe('DashboardService clinical measurement metrics', () => {
   it('keeps approved fasting and random flag thresholds and excludes unknown context', () => {
@@ -73,5 +74,141 @@ describe('DashboardService clinical measurement metrics', () => {
         spo2Percent: { count: 1, average: 98 },
       },
     });
+  });
+});
+
+describe('DashboardService network overview', () => {
+  const CLINICS = [
+    { id: 'clinic-north-1', name: 'North One', zoneCode: 'north', isActive: true },
+    { id: 'clinic-north-2', name: 'North Two', zoneCode: 'north', isActive: true },
+    { id: 'clinic-south', name: 'South', zoneCode: 'south', isActive: true },
+    { id: 'clinic-none', name: 'Unzoned', zoneCode: null, isActive: true },
+  ];
+
+  function buildPrisma() {
+    return {
+      clinic: {
+        count: jest.fn().mockResolvedValue(CLINICS.length),
+        findMany: jest.fn().mockResolvedValue(CLINICS),
+      },
+      user: { count: jest.fn().mockResolvedValue(9) },
+      patient: {
+        count: jest.fn().mockResolvedValue(40),
+        groupBy: jest.fn().mockResolvedValue([
+          { primaryClinicId: 'clinic-north-1', _count: 7 },
+          { primaryClinicId: 'clinic-south', _count: 3 },
+        ]),
+      },
+      encounter: {
+        count: jest.fn().mockResolvedValue(80),
+        groupBy: jest.fn().mockResolvedValue([]),
+      },
+    };
+  }
+
+  const run = async (prisma: ReturnType<typeof buildPrisma>, zoneFilter: string | null) =>
+    (
+      new DashboardService(prisma as never) as unknown as {
+        getSystemAdminMetrics: (zone: string | null) => Promise<SystemAdminMetrics>;
+      }
+    ).getSystemAdminMetrics(zoneFilter);
+
+  it('compares every clinic when no zone is applied', async () => {
+    const metrics = await run(buildPrisma(), null);
+    expect(metrics.clinicComparison).toHaveLength(4);
+    expect(metrics.appliedZoneCode).toBeNull();
+  });
+
+  it('carries each clinic zone into the comparison rows', async () => {
+    const metrics = await run(buildPrisma(), null);
+    expect(metrics.clinicComparison[0]).toMatchObject({
+      clinicId: 'clinic-north-1',
+      zoneCode: 'north',
+    });
+    expect(metrics.clinicComparison[3]).toMatchObject({ clinicId: 'clinic-none', zoneCode: null });
+  });
+
+  it('narrows the comparison to one zone', async () => {
+    const metrics = await run(buildPrisma(), 'north');
+    expect(metrics.clinicComparison.map((row) => row.clinicId)).toEqual([
+      'clinic-north-1',
+      'clinic-north-2',
+    ]);
+    expect(metrics.appliedZoneCode).toBe('north');
+  });
+
+  it('selects the clinics with no zone under the sentinel', async () => {
+    const metrics = await run(buildPrisma(), '__unzoned__');
+    expect(metrics.clinicComparison.map((row) => row.clinicId)).toEqual(['clinic-none']);
+  });
+
+  it('rolls up every zone even while one is filtered', async () => {
+    // A filter that removed its own options would leave the reader no way back to the others.
+    const metrics = await run(buildPrisma(), 'north');
+    expect(metrics.zones).toEqual([
+      { zoneCode: 'north', clinicCount: 2, activeClinicCount: 2 },
+      { zoneCode: 'south', clinicCount: 1, activeClinicCount: 1 },
+      { zoneCode: null, clinicCount: 1, activeClinicCount: 1 },
+    ]);
+  });
+
+  it('counts each clinic with grouped reads rather than a query per clinic', async () => {
+    // The loop this replaced issued three counts per clinic. With four clinics that was twelve
+    // round trips for one table; it is now three regardless of how many clinics exist.
+    const prisma = buildPrisma();
+    await run(prisma, null);
+    expect(prisma.patient.groupBy).toHaveBeenCalledTimes(1);
+    expect(prisma.encounter.groupBy).toHaveBeenCalledTimes(3);
+  });
+
+  it('asks the grouped reads only for the clinics it is comparing', async () => {
+    const prisma = buildPrisma();
+    await run(prisma, 'north');
+    expect(prisma.patient.groupBy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { primaryClinicId: { in: ['clinic-north-1', 'clinic-north-2'] } },
+      }),
+    );
+  });
+
+  it('keeps a clinic with no rows in the table, at zero', async () => {
+    // A groupBy omits an empty group rather than returning zero for it, so a clinic that has
+    // seen no patients would drop out of the comparison entirely without the fallback.
+    const metrics = await run(buildPrisma(), null);
+    const rows = metrics.clinicComparison;
+    expect(rows.find((row) => row.clinicId === 'clinic-north-1')?.totalPatients).toBe(7);
+    expect(rows.find((row) => row.clinicId === 'clinic-north-2')?.totalPatients).toBe(0);
+  });
+
+  it('returns an empty comparison for a zone no clinic is in', async () => {
+    // Empty rather than unfiltered: this method receives a filter that has already been parsed,
+    // so a value reaching it is a zone someone genuinely asked for.
+    const metrics = await run(buildPrisma(), 'east');
+    expect(metrics.clinicComparison).toEqual([]);
+    // The rollup still names the zones that do exist, so the reader can get back.
+    expect(metrics.zones.map((zone) => zone.zoneCode)).toEqual(['north', 'south', null]);
+  });
+
+  it('parses the query value before filtering with it', async () => {
+    // The parse lives in getDashboard, so an unusable query parameter has to become "no filter"
+    // before it reaches the comparison rather than emptying the report.
+    const prisma = buildPrisma();
+    const service = new DashboardService(prisma as never);
+    const seen: (string | null)[] = [];
+    (service as unknown as { getSystemAdminMetrics: unknown }).getSystemAdminMetrics = (
+      zone: string | null,
+    ) => {
+      seen.push(zone);
+      return Promise.resolve({});
+    };
+    jest
+      .spyOn(service as unknown as { getSummary: () => Promise<unknown> }, 'getSummary')
+      .mockResolvedValue({});
+
+    await service.getDashboard('clinic-1', ['SYSTEM_ADMIN'], 'user-1', { zoneCode: 'not a zone' });
+    await service.getDashboard('clinic-1', ['SYSTEM_ADMIN'], 'user-1', { zoneCode: '  NORTH ' });
+    await service.getDashboard('clinic-1', ['SYSTEM_ADMIN'], 'user-1', {});
+
+    expect(seen).toEqual([null, 'north', null]);
   });
 });

--- a/apps/api/src/dashboard/dashboard.service.ts
+++ b/apps/api/src/dashboard/dashboard.service.ts
@@ -16,6 +16,7 @@ import type {
   ClinicalMeasurementMetrics,
 } from './dto/dashboard-response.dto';
 import { isApiFeatureEnabled } from '../common/feature-flags';
+import { parseZoneFilter, summarizeZones, zoneFilterMatches, type ZoneFilter } from '@nkwapa/db';
 
 export const FLAGGED_DIABETES_WHERE = {
   OR: [
@@ -32,6 +33,7 @@ export class DashboardService {
     clinicId: string,
     roles: string[],
     userId: string,
+    filters?: { zoneCode?: string | null },
   ): Promise<DashboardResponse> {
     const summary = await this.getSummary(clinicId);
 
@@ -47,7 +49,7 @@ export class DashboardService {
         : null;
 
     if (isAdmin) {
-      response.systemAdmin = await this.getSystemAdminMetrics();
+      response.systemAdmin = await this.getSystemAdminMetrics(parseZoneFilter(filters?.zoneCode));
     }
     if (isDoctor) {
       const pendingClinicalNoteCosigns = isApiFeatureEnabled('clinicalNotes')
@@ -527,7 +529,16 @@ export class DashboardService {
     };
   }
 
-  private async getSystemAdminMetrics(): Promise<SystemAdminMetrics> {
+  /**
+   * The cross-clinic block, optionally narrowed to one zone.
+   *
+   * The zone filter is a reporting lens, not an access decision: the read is already bounded by
+   * row level security, and `zoneFilterWhere` only ever adds a `zoneCode` constraint on top.
+   * `zones` is deliberately built from the unfiltered clinic set, so the rollup still names
+   * every zone while the comparison shows one -- a filter that hid its own options would leave
+   * no way back.
+   */
+  private async getSystemAdminMetrics(zoneFilter: ZoneFilter): Promise<SystemAdminMetrics> {
     const now = new Date();
     const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
 
@@ -545,7 +556,7 @@ export class DashboardService {
       this.prisma.encounter.count(),
       this.prisma.clinic.findMany({
         where: { isActive: true },
-        select: { id: true, name: true },
+        select: { id: true, name: true, zoneCode: true, isActive: true },
       }),
       this.prisma.encounter.groupBy({
         by: ['createdAt'],
@@ -560,21 +571,46 @@ export class DashboardService {
       now,
     );
 
-    const clinicComparison: ClinicComparisonRow[] = [];
-    for (const clinic of clinics) {
-      const [patients, encounters, finalized] = await Promise.all([
-        this.prisma.patient.count({ where: { primaryClinicId: clinic.id } }),
-        this.prisma.encounter.count({ where: { clinicId: clinic.id } }),
-        this.prisma.encounter.count({ where: { clinicId: clinic.id, status: 'FINALIZED' } }),
-      ]);
-      clinicComparison.push({
-        clinicId: clinic.id,
-        clinicName: clinic.name,
-        totalPatients: patients,
-        totalEncounters: encounters,
-        totalFinalized: finalized,
-      });
-    }
+    const zones = summarizeZones(clinics);
+    const comparedClinics = clinics.filter((clinic) =>
+      zoneFilterMatches(clinic.zoneCode, zoneFilter),
+    );
+    const comparedClinicIds = comparedClinics.map((clinic) => clinic.id);
+
+    // Three grouped reads rather than three counts per clinic. The loop this replaces issued
+    // 3N queries, which the zone rollup would only have made wider.
+    const [patientsByClinic, encountersByClinic, finalizedByClinic] = await Promise.all([
+      this.prisma.patient.groupBy({
+        by: ['primaryClinicId'],
+        where: { primaryClinicId: { in: comparedClinicIds } },
+        _count: true,
+      }),
+      this.prisma.encounter.groupBy({
+        by: ['clinicId'],
+        where: { clinicId: { in: comparedClinicIds } },
+        _count: true,
+      }),
+      this.prisma.encounter.groupBy({
+        by: ['clinicId'],
+        where: { clinicId: { in: comparedClinicIds }, status: 'FINALIZED' },
+        _count: true,
+      }),
+    ]);
+
+    const patientCounts = countsByKey(patientsByClinic, 'primaryClinicId');
+    const encounterCounts = countsByKey(encountersByClinic, 'clinicId');
+    const finalizedCounts = countsByKey(finalizedByClinic, 'clinicId');
+
+    const clinicComparison: ClinicComparisonRow[] = comparedClinics.map((clinic) => ({
+      clinicId: clinic.id,
+      clinicName: clinic.name,
+      zoneCode: clinic.zoneCode ?? null,
+      // A clinic with no rows is absent from a groupBy rather than present with zero, so the
+      // fallback is what keeps an empty clinic in the table instead of dropping it.
+      totalPatients: patientCounts.get(clinic.id) ?? 0,
+      totalEncounters: encounterCounts.get(clinic.id) ?? 0,
+      totalFinalized: finalizedCounts.get(clinic.id) ?? 0,
+    }));
 
     return {
       totalClinics,
@@ -583,6 +619,8 @@ export class DashboardService {
       systemWideEncounters,
       clinicComparison,
       systemEncountersTrend,
+      zones,
+      appliedZoneCode: zoneFilter,
     };
   }
 
@@ -689,6 +727,26 @@ function startOfMonth(d: Date): Date {
 
 function formatDate(d: Date): string {
   return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Folds a Prisma `groupBy` result into a lookup.
+ *
+ * `_count` is a number when `groupBy` is given `_count: true` and an object when it is given a
+ * field selection. Only the first form is used here, and the guard keeps a future caller of the
+ * second form from silently reading `NaN`.
+ */
+function countsByKey<K extends string>(
+  rows: ({ _count: number | Record<string, number> } & { [P in K]: string | null })[],
+  key: K,
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const row of rows) {
+    const id = row[key];
+    if (id === null) continue;
+    counts.set(id, typeof row._count === 'number' ? row._count : 0);
+  }
+  return counts;
 }
 
 function aggregateByDay(rows: { date: Date; count: number }[], from: Date, to: Date): TrendPoint[] {

--- a/apps/api/src/dashboard/dto/dashboard-query.dto.ts
+++ b/apps/api/src/dashboard/dto/dashboard-query.dto.ts
@@ -1,0 +1,21 @@
+import { IsOptional } from 'class-validator';
+import { ToSanitizedString } from '../../common/validation';
+import { IsZoneFilter } from '../../common/clinic-metadata.validator';
+
+/**
+ * Query parameters for `GET /clinics/:clinicId/dashboard`.
+ *
+ * The dashboard is a per-clinic read, so the only thing a zone can narrow here is the
+ * cross-clinic block a system admin sees. Every other section is already scoped to the one
+ * clinic in the path and ignores this.
+ *
+ * Declared even though it holds one optional field, because the global pipe runs with
+ * `forbidNonWhitelisted` and would otherwise 400 on the parameter.
+ */
+export class DashboardQueryDto {
+  /** A zone code, or `__unzoned__` for the clinics that have none. */
+  @IsOptional()
+  @ToSanitizedString()
+  @IsZoneFilter()
+  zoneCode?: string;
+}

--- a/apps/api/src/dashboard/dto/dashboard-response.dto.ts
+++ b/apps/api/src/dashboard/dto/dashboard-response.dto.ts
@@ -1,3 +1,5 @@
+import type { ZoneSummary } from '@nkwapa/db';
+
 export interface EncounterSummary {
   id: string;
   patientCode: string;
@@ -17,6 +19,8 @@ export interface StaffActivityRow {
 export interface ClinicComparisonRow {
   clinicId: string;
   clinicName: string;
+  /** `null` is a clinic with no zone, which the UI shows rather than hides. */
+  zoneCode: string | null;
   totalPatients: number;
   totalEncounters: number;
   totalFinalized: number;
@@ -109,6 +113,15 @@ export interface SystemAdminMetrics {
   systemWideEncounters: number;
   clinicComparison: ClinicComparisonRow[];
   systemEncountersTrend: TrendPoint[];
+  /**
+   * Every zone in the network, whether or not the comparison is filtered to one.
+   *
+   * Built from the unfiltered clinic set on purpose: a filter that removed its own options
+   * would leave the reader with no way back to the other zones.
+   */
+  zones: ZoneSummary[];
+  /** The filter in effect, echoed so the client can render it without re-deriving it. */
+  appliedZoneCode: string | null;
 }
 
 export interface DashboardResponse {

--- a/apps/web/app/(workspace)/admin/users/page.tsx
+++ b/apps/web/app/(workspace)/admin/users/page.tsx
@@ -15,6 +15,17 @@ import { AppMetricCard } from '@/components/app-shell/AppMetricCard';
 import { AppPageHeader } from '@/components/app-shell/AppPageHeader';
 import { SegmentedControl } from '@/components/app-shell/SegmentedControl';
 import {
+  memberMatchesZone,
+  summarizeZones,
+  zoneByClinicId,
+  zoneFilterFromSelect,
+  zoneFilterLabel,
+  zoneFilterOptions,
+  zoneFilterToSelect,
+  zoneLabel,
+  type ZoneFilter,
+} from '@/lib/clinic-zones';
+import {
   EmptyState,
   InlineErrorState,
   SectionSkeleton,
@@ -304,7 +315,8 @@ export default function AdminUsersPage() {
   const activeClinicId = getBootstrapActiveClinicId(bootstrap);
   const activeMembership =
     bootstrap?.memberships.find((membership) => membership.clinicId === activeClinicId) ?? null;
-  const activeClinicName = getActiveBootstrapClinic(bootstrap, activeClinicId)?.clinicName ?? null;
+  const activeClinic = getActiveBootstrapClinic(bootstrap, activeClinicId);
+  const activeClinicName = activeClinic?.clinicName ?? null;
   const isSystemAdmin = bootstrap?.globalRoles?.includes('SYSTEM_ADMIN') ?? false;
   const directorMemberships = (bootstrap?.memberships ?? []).filter((membership) =>
     membership.roles.includes('DIRECTOR'),
@@ -330,6 +342,7 @@ export default function AdminUsersPage() {
   );
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('active');
   const [roleFilter, setRoleFilter] = useState<string>('ALL');
+  const [zoneFilter, setZoneFilter] = useState<ZoneFilter>(null);
   const [portalFilter, setPortalFilter] = useState<PortalFilter>('ALL');
   const [rows, setRows] = useState<StaffAccessRow[]>([]);
   const [loading, setLoading] = useState(true);
@@ -342,7 +355,9 @@ export default function AdminUsersPage() {
   const [userRoles, setUserRoles] = useState<UserRoleRow[]>([]);
   const [assignRole, setAssignRole] = useState<string>('');
   const [assignClinicId, setAssignClinicId] = useState<string>('');
-  const [allClinics, setAllClinics] = useState<Array<{ id: string; name: string }>>([]);
+  const [allClinics, setAllClinics] = useState<
+    Array<{ id: string; name: string; zoneCode: string | null }>
+  >([]);
   const [savingAssignment, setSavingAssignment] = useState(false);
   const [revokingRole, setRevokingRole] = useState<UserRoleRow | null>(null);
   const [deactivateOpen, setDeactivateOpen] = useState(false);
@@ -378,7 +393,9 @@ export default function AdminUsersPage() {
       if (!res.ok) {
         throw new Error(await readApiError(res));
       }
-      setAllClinics((await res.json()) as Array<{ id: string; name: string }>);
+      setAllClinics(
+        (await res.json()) as Array<{ id: string; name: string; zoneCode: string | null }>,
+      );
     } catch {
       setAllClinics([]);
     }
@@ -503,8 +520,26 @@ export default function AdminUsersPage() {
         name: membership.clinicName,
       }));
 
+  // Zone narrows the roster the API already scoped; it never reaches for a row that was not
+  // there. Offered only across clinics, because the clinic roster is one clinic and so one zone.
+  /*
+    Context rather than a control, in the clinic roster. That view is one clinic, so it is one
+    zone, and a picker there could only ever say "all" or "none". Naming the zone tells an
+    operator which slice of a zone report this roster is, which is the question they have.
+  */
+  const activeClinicZoneLabel =
+    viewMode === 'clinic' && activeClinic ? zoneLabel(activeClinic.zoneCode) : null;
+
+  const zoneLookup = zoneByClinicId(allClinics);
+  const showZoneFilter = viewMode === 'all' && allClinics.length > 0;
+  const zoneOptions = zoneFilterOptions(summarizeZones(allClinics));
+  const appliedZoneFilter = showZoneFilter ? zoneFilter : null;
+
   const visibleRows = rows.filter(
-    (row) => roleMatchesFilter(row, roleFilter) && patientPortalMatchesFilter(row, portalFilter),
+    (row) =>
+      roleMatchesFilter(row, roleFilter) &&
+      patientPortalMatchesFilter(row, portalFilter) &&
+      memberMatchesZone(row.clinicMemberships, zoneLookup, appliedZoneFilter),
   );
   const activeCount = rows.filter((row) => row.isActive).length;
   const inactiveCount = rows.filter((row) => !row.isActive).length;
@@ -939,6 +974,27 @@ export default function AdminUsersPage() {
                 </div>
               ) : null}
 
+              {showZoneFilter ? (
+                <div className="space-y-2">
+                  <Label htmlFor="staff-zone-filter">Zone</Label>
+                  <Select
+                    value={zoneFilterToSelect(zoneFilter)}
+                    onValueChange={(value) => setZoneFilter(zoneFilterFromSelect(value))}
+                  >
+                    <SelectTrigger id="staff-zone-filter">
+                      <SelectValue placeholder="All zones" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {zoneOptions.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              ) : null}
+
               <div className="flex flex-wrap gap-2">
                 <Button
                   type="button"
@@ -947,6 +1003,7 @@ export default function AdminUsersPage() {
                     setStatusFilter('active');
                     setRoleFilter('ALL');
                     setPortalFilter('ALL');
+                    setZoneFilter(null);
                   }}
                 >
                   Reset filters
@@ -969,6 +1026,8 @@ export default function AdminUsersPage() {
                           : portalStatusLabel(portalFilter as PortalLinkStatus)
                         : null,
                   },
+                  { label: 'Zone', value: zoneFilterLabel(appliedZoneFilter) },
+                  { label: 'Clinic zone', value: activeClinicZoneLabel },
                 ]}
                 emptyLabel="Default roster view"
               />
@@ -1046,6 +1105,8 @@ export default function AdminUsersPage() {
                           : portalStatusLabel(portalFilter as PortalLinkStatus)
                         : null,
                   },
+                  { label: 'Zone', value: zoneFilterLabel(appliedZoneFilter) },
+                  { label: 'Clinic zone', value: activeClinicZoneLabel },
                 ]}
               />
             </CardHeader>

--- a/apps/web/app/(workspace)/audit/page.tsx
+++ b/apps/web/app/(workspace)/audit/page.tsx
@@ -5,7 +5,8 @@ import { ActivitySquare, FileClock, Shield } from 'lucide-react';
 import { useBootstrap } from '@/lib/bootstrap-context';
 import { useAuth } from '@/lib/auth-context';
 import { apiFetch } from '@/lib/api';
-import { getBootstrapActiveClinicId } from '@/lib/bootstrap-clinics';
+import { getActiveBootstrapClinic, getBootstrapActiveClinicId } from '@/lib/bootstrap-clinics';
+import { zoneLabel } from '@/lib/clinic-zones';
 import { AppMetricCard } from '@/components/app-shell/AppMetricCard';
 import { ActiveFilterSummary } from '@/components/app-shell/ActiveFilterSummary';
 import { AppPageHeader } from '@/components/app-shell/AppPageHeader';
@@ -35,6 +36,13 @@ export default function AuditPage() {
   const bootstrap = useBootstrap()?.bootstrap ?? null;
   const getToken = useAuth();
   const clinicId = getBootstrapActiveClinicId(bootstrap);
+  /*
+    Context, not a filter. This log is `/clinics/:clinicId/audit` -- one clinic, therefore one
+    zone -- so a zone control here could only say "all" or "none". What is worth saying is which
+    zone's activity the reader is looking at, and that sharing a zone with another clinic does
+    not put that clinic's entries in this log.
+  */
+  const activeClinic = getActiveBootstrapClinic(bootstrap, clinicId);
 
   const [from, setFrom] = useState('');
   const [to, setTo] = useState('');
@@ -245,6 +253,7 @@ export default function AuditPage() {
                 { label: 'Actor', value: actor || null },
                 { label: 'Entity', value: entityType || null },
                 { label: 'Request', value: requestId || null },
+                { label: 'Zone', value: activeClinic ? zoneLabel(activeClinic.zoneCode) : null },
               ]}
               emptyLabel="Recent clinic activity"
             />

--- a/apps/web/app/(workspace)/dashboard/page.tsx
+++ b/apps/web/app/(workspace)/dashboard/page.tsx
@@ -24,6 +24,7 @@ import { Button } from '@/components/ui/button';
 import { useToast } from '@/components/ui/toast';
 import { EmptyStateCard } from '@/components/ops/OpsShared';
 import { RefreshCw } from 'lucide-react';
+import { zoneQueryString, type ZoneFilter, type ZoneSummary } from '@/lib/clinic-zones';
 
 interface DashboardData {
   summary: {
@@ -102,10 +103,13 @@ interface DashboardData {
     clinicComparison: {
       clinicId: string;
       clinicName: string;
+      zoneCode: string | null;
       totalPatients: number;
       totalEncounters: number;
       totalFinalized: number;
     }[];
+    zones: ZoneSummary[];
+    appliedZoneCode: string | null;
   };
 }
 
@@ -117,6 +121,7 @@ export default function DashboardPage() {
   const clinicId = getBootstrapActiveClinicId(bootstrap);
   const activeClinic = getActiveBootstrapClinic(bootstrap, clinicId);
 
+  const [zoneFilter, setZoneFilter] = useState<ZoneFilter>(null);
   const [data, setData] = useState<DashboardData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -132,9 +137,10 @@ export default function DashboardPage() {
       setLoading(true);
       setError(null);
       try {
-        const res = await apiFetch(`/clinics/${encodeURIComponent(clinicId)}/dashboard`, {
-          getToken,
-        });
+        const res = await apiFetch(
+          `/clinics/${encodeURIComponent(clinicId)}/dashboard${zoneQueryString(zoneFilter)}`,
+          { getToken },
+        );
         if (!res.ok) {
           throw await readApiError(res);
         }
@@ -170,7 +176,7 @@ export default function DashboardPage() {
         setLoading(false);
       }
     },
-    [activeClinic, clinicId, getToken, showToast],
+    [activeClinic, clinicId, getToken, showToast, zoneFilter],
   );
 
   useEffect(() => {
@@ -279,7 +285,14 @@ export default function DashboardPage() {
 
               {data.volunteer && <VolunteerDashboard {...data.volunteer} />}
 
-              {data.systemAdmin && <SystemAdminDashboard {...data.systemAdmin} />}
+              {data.systemAdmin && (
+                <SystemAdminDashboard
+                  {...data.systemAdmin}
+                  zoneFilter={zoneFilter}
+                  onZoneFilterChange={setZoneFilter}
+                  isRefreshing={loading}
+                />
+              )}
             </div>
           </>
         )}

--- a/apps/web/components/admin/ClinicMetadataDialog.tsx
+++ b/apps/web/components/admin/ClinicMetadataDialog.tsx
@@ -35,6 +35,7 @@ import {
   CLINIC_FORM_FIELD_ORDER,
   LOCATION_CODE_MAX_LENGTH,
   matchesTimeZoneQuery,
+  normalizeZoneCode,
   timeZoneOptions,
   toLocationCode,
   validateClinicForm,
@@ -52,6 +53,13 @@ interface ClinicMetadataDialogProps {
   /** Initial values. A fresh object per open, so create and edit never share state. */
   initialValues: ClinicFormValues;
   organizations: OrganizationSummary[];
+  /**
+   * Zone codes already in use, offered as suggestions.
+   *
+   * Not a closed vocabulary: a zone comes into existence the first time a clinic is put in one,
+   * so the field stays free text and these only make the existing spellings reachable.
+   */
+  knownZoneCodes?: string[];
   /** Focused once the dialog opens, so "fix this" from a badge lands on the right control. */
   focusField?: ClinicFormField;
   saving: boolean;
@@ -77,6 +85,7 @@ export function ClinicMetadataDialog({
   mode,
   initialValues,
   organizations,
+  knownZoneCodes = [],
   focusField,
   saving,
   submitError,
@@ -128,10 +137,29 @@ export function ClinicMetadataDialog({
 
   const organization =
     organizations.find((entry) => entry.id === values.organizationId) ?? organizations[0] ?? null;
-  const zoneOptions = useMemo(
+  // Named for time zones explicitly. "Zone" now means a reporting zone everywhere else in this
+  // file, and two different things called zoneOptions in one component is a trap.
+  const timeZonePickerOptions = useMemo(
     () => timeZoneOptions(organization?.timezone ?? null),
     [organization?.timezone],
   );
+
+  const suggestedZoneCodes = useMemo(
+    () =>
+      [...new Set(knownZoneCodes.map((code) => normalizeZoneCode(code)))].filter(
+        (code): code is string => code !== null,
+      ),
+    [knownZoneCodes],
+  );
+
+  // A zone code nobody else uses is not an error -- someone has to be first -- but it is worth
+  // saying out loud, because the other way to arrive here is a typo, and a typo silently splits
+  // one zone's report into two.
+  const typedZoneCode = normalizeZoneCode(values.zoneCode);
+  const isNewZoneCode =
+    typedZoneCode !== null &&
+    suggestedZoneCodes.length > 0 &&
+    !suggestedZoneCodes.includes(typedZoneCode);
 
   const update = (patch: Partial<ClinicFormValues>) => {
     setValues((current) => {
@@ -175,8 +203,8 @@ export function ClinicMetadataDialog({
         <DialogHeader>
           <DialogTitle>{mode === 'create' ? 'Create clinic' : 'Edit clinic'}</DialogTitle>
           <DialogDescription>
-            Location metadata drives organization reporting and future zone behaviour, so a clinic
-            needs a time zone and a location code that is unique in its organization.
+            Location metadata drives organization reporting and zone filtering, so a clinic needs a
+            time zone and a location code that is unique in its organization.
           </DialogDescription>
         </DialogHeader>
 
@@ -316,7 +344,7 @@ export function ClinicMetadataDialog({
               <Combobox
                 id="clinic-timezone"
                 value={values.timezone}
-                options={zoneOptions}
+                options={timeZonePickerOptions}
                 matches={matchesTimeZoneQuery}
                 onChange={(next) => update({ timezone: next })}
                 placeholder="Search time zones"
@@ -342,11 +370,39 @@ export function ClinicMetadataDialog({
                   placeholder="greater-accra"
                   {...fieldErrorProps('clinic-zoneCode', shownErrors.zoneCode)}
                 />
+                {suggestedZoneCodes.length > 0 ? (
+                  <div className="space-y-1">
+                    <p id="clinic-zoneCode-suggestions" className="text-sm text-muted-foreground">
+                      Zones already in use
+                    </p>
+                    <div className="flex flex-wrap gap-2">
+                      {suggestedZoneCodes.map((zoneCode) => (
+                        <Button
+                          key={zoneCode}
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          aria-describedby="clinic-zoneCode-suggestions"
+                          aria-pressed={normalizeZoneCode(values.zoneCode) === zoneCode}
+                          className="h-8 font-mono text-xs"
+                          onClick={() => update({ zoneCode })}
+                        >
+                          {zoneCode}
+                        </Button>
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
                 {shownErrors.zoneCode ? (
                   <FieldError id="clinic-zoneCode" message={shownErrors.zoneCode} />
+                ) : isNewZoneCode ? (
+                  <p className="text-sm text-muted-foreground">
+                    No other clinic uses this code, so saving starts a new zone.
+                  </p>
                 ) : (
                   <p className="text-sm text-muted-foreground">
-                    Optional. Leave empty until this clinic belongs to a zone.
+                    Optional. Groups clinics for reporting; it does not change who can open this
+                    clinic.
                   </p>
                 )}
               </div>

--- a/apps/web/components/admin/ClinicRegistryScreen.tsx
+++ b/apps/web/components/admin/ClinicRegistryScreen.tsx
@@ -27,6 +27,7 @@ import { useAuth } from '@/lib/auth-context';
 import { useAsyncResource } from '@/lib/use-async-resource';
 import { dataGridSx } from '@/lib/datagrid-theme';
 import {
+  listZoneCodes,
   zoneFilterFromSelect,
   zoneFilterLabel,
   zoneFilterOptions,
@@ -175,6 +176,7 @@ export function ClinicRegistryScreen() {
   const visibleRows = useMemo(() => filterClinics(rows, filter), [rows, filter]);
 
   const zoneList = useMemo(() => zones.data ?? [], [zones.data]);
+  const knownZoneCodes = useMemo(() => listZoneCodes(zoneList), [zoneList]);
   const zoneOptions = useMemo(() => zoneFilterOptions(zoneList), [zoneList]);
   const zonedClinicCount = zoneList.filter((zone) => zone.zoneCode !== null).length;
 
@@ -531,6 +533,7 @@ export function ClinicRegistryScreen() {
         mode={dialogMode}
         initialValues={dialogValues}
         organizations={organizationList}
+        knownZoneCodes={knownZoneCodes}
         focusField={focusField}
         saving={saving}
         submitError={submitError}

--- a/apps/web/components/admin/ClinicRegistryScreen.tsx
+++ b/apps/web/components/admin/ClinicRegistryScreen.tsx
@@ -233,7 +233,10 @@ export function ClinicRegistryScreen() {
       );
       if (!response.ok) throw await readApiError(response);
       setDialogOpen(false);
-      await clinics.refresh();
+      // Both, because a save can move a clinic into a zone that did not exist a moment ago, or
+      // empty the last one. Refreshing only the rows would leave the picker describing a set of
+      // zones the table no longer has.
+      await Promise.all([clinics.refresh(), zones.refresh()]);
     } catch (error) {
       setSubmitError(error instanceof Error ? error : new Error(String(error)));
     } finally {

--- a/apps/web/components/admin/ClinicRegistryScreen.tsx
+++ b/apps/web/components/admin/ClinicRegistryScreen.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useMemo, useState } from 'react';
-import { Building2, MapPinned, ShieldAlert } from 'lucide-react';
+import { Building2, MapPinned, Map, ShieldAlert } from 'lucide-react';
 import { Box } from '@mui/material';
 import { DataGrid, type GridColDef } from '@mui/x-data-grid';
 import { AppMetricCard } from '@/components/app-shell/AppMetricCard';
@@ -13,11 +13,30 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { ProgressiveHelp } from '@/components/ui/progressive-help';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { SectionSkeleton } from '@/components/feedback/AppState';
 import { ApiError, apiFetch, readApiError } from '@/lib/api';
 import { useAuth } from '@/lib/auth-context';
 import { useAsyncResource } from '@/lib/use-async-resource';
 import { dataGridSx } from '@/lib/datagrid-theme';
+import {
+  zoneFilterFromSelect,
+  zoneFilterLabel,
+  zoneFilterOptions,
+  zoneFilterToSelect,
+  zoneLabel,
+  zoneQueryString,
+  zoneResourceKey,
+  type ZoneFilter,
+  type ZoneSummary,
+} from '@/lib/clinic-zones';
 import {
   CLINIC_METADATA_ISSUE_LABELS,
   CLINIC_METADATA_SEVERITY_VARIANT,
@@ -92,6 +111,7 @@ function MetadataBadges({ clinic }: { clinic: ClinicRow }) {
 export function ClinicRegistryScreen() {
   const getToken = useAuth();
   const [filter, setFilter] = useState<ClinicListFilter>('all');
+  const [zoneFilter, setZoneFilter] = useState<ZoneFilter>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [dialogMode, setDialogMode] = useState<ClinicDialogMode>('create');
   const [dialogValues, setDialogValues] = useState<ClinicFormValues>(emptyClinicForm(null));
@@ -100,17 +120,37 @@ export function ClinicRegistryScreen() {
   const [saving, setSaving] = useState(false);
   const [submitError, setSubmitError] = useState<ApiError | Error | null>(null);
 
+  // Filtered server-side. The registry is unpaginated today, so narrowing here rather than in
+  // the browser is not about payload size: it is so one implementation decides which clinics
+  // are in a zone. The key carries the filter because `useAsyncResource` refetches on the key
+  // alone, and both come from the same helper so the URL and the key cannot disagree.
   const clinics = useAsyncResource<ClinicRow[]>({
-    resourceKey: 'admin-clinics',
+    resourceKey: zoneResourceKey('admin-clinics', zoneFilter),
     errorMessage: 'The clinic list could not be loaded.',
     fetcher: async (token, signal) => {
-      const response = await apiFetch('/admin/clinics', {
+      const response = await apiFetch(`/admin/clinics${zoneQueryString(zoneFilter)}`, {
         getToken: token,
         skipClinicHeader: true,
         signal,
       });
       if (!response.ok) throw await readApiError(response);
       return ((await response.json()) as ClinicRow[]).map(normalizeClinicRow);
+    },
+  });
+
+  // Read unfiltered on purpose, so choosing a zone never removes the other zones from the
+  // picker and strands the reader inside their own filter.
+  const zones = useAsyncResource<ZoneSummary[]>({
+    resourceKey: 'admin-clinic-zones',
+    errorMessage: 'The zone list could not be loaded.',
+    fetcher: async (token, signal) => {
+      const response = await apiFetch('/admin/clinics/zones', {
+        getToken: token,
+        skipClinicHeader: true,
+        signal,
+      });
+      if (!response.ok) throw await readApiError(response);
+      return (await response.json()) as ZoneSummary[];
     },
   });
 
@@ -130,10 +170,30 @@ export function ClinicRegistryScreen() {
 
   const rows = useMemo(() => clinics.data ?? [], [clinics.data]);
   const organizationList = organizations.data ?? [];
+  // The rows already arrive zone-filtered; the client pass only applies the view. Passing the
+  // zone again would be harmless but would imply the server had not been trusted to apply it.
   const visibleRows = useMemo(() => filterClinics(rows, filter), [rows, filter]);
+
+  const zoneList = useMemo(() => zones.data ?? [], [zones.data]);
+  const zoneOptions = useMemo(() => zoneFilterOptions(zoneList), [zoneList]);
+  const zonedClinicCount = zoneList.filter((zone) => zone.zoneCode !== null).length;
 
   const activeCount = rows.filter((clinic) => clinic.isActive).length;
   const attentionCount = rows.filter(clinicNeedsAttention).length;
+
+  // Says which of the two filters emptied the list, because "no clinic matches this view" sends
+  // an operator looking at the wrong control when it was the zone that did it.
+  const emptyResultMessage = (() => {
+    const zoneName = zoneFilterLabel(zoneFilter);
+    if (zoneName !== null && filter === 'needs-attention') {
+      return `No clinic in ${zoneName} has a metadata problem.`;
+    }
+    if (zoneName !== null) return `No clinic is in ${zoneName}.`;
+    if (filter === 'needs-attention') {
+      return 'No clinic has a metadata problem. Organization reporting can rely on every record here.';
+    }
+    return 'No clinic matches this view.';
+  })();
 
   const openCreate = () => {
     setDialogMode('create');
@@ -202,7 +262,7 @@ export function ClinicRegistryScreen() {
           params.row.zoneCode ? (
             <span className="font-mono text-xs">{params.row.zoneCode}</span>
           ) : (
-            <span className="text-muted-foreground">None</span>
+            <span className="text-muted-foreground">{zoneLabel(null)}</span>
           ),
       },
       {
@@ -252,7 +312,7 @@ export function ClinicRegistryScreen() {
         actions={<Button onClick={openCreate}>Create clinic</Button>}
       />
 
-      <div className="grid gap-4 md:grid-cols-3">
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
         <AppMetricCard
           title="Total clinics"
           value={rows.length}
@@ -264,6 +324,12 @@ export function ClinicRegistryScreen() {
           value={activeCount}
           icon={MapPinned}
           detail="Clinics currently available for staff and patient workflows."
+        />
+        <AppMetricCard
+          title="Zones"
+          value={zonedClinicCount}
+          icon={Map}
+          detail="Reporting zones in use across the clinics you administer."
         />
         <AppMetricCard
           title="Needs attention"
@@ -294,20 +360,45 @@ export function ClinicRegistryScreen() {
           <ProgressiveHelp title="How clinic metadata is used">
             A clinic&apos;s time zone decides how appointment times, reminders, and daily reporting
             are read. Its location code identifies it in organization reporting and must be unique
-            within its organization. Zone codes are optional until zone-aware reporting is switched
-            on. Inactive clinics stay in the system for history and audit, but stop acting like live
-            operational workspaces until you reactivate them.
+            within its organization. A zone code groups clinics for reporting and filtering; it is
+            still optional, and it never changes who can open a clinic. Inactive clinics stay in the
+            system for history and audit, but stop acting like live operational workspaces until you
+            reactivate them.
           </ProgressiveHelp>
 
           <div className="space-y-3">
-            <SegmentedControl
-              label="Clinic filter"
-              value={filter}
-              options={FILTER_OPTIONS}
-              onChange={setFilter}
-            />
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+              <SegmentedControl
+                label="Clinic filter"
+                value={filter}
+                options={FILTER_OPTIONS}
+                onChange={setFilter}
+              />
+              <div className="space-y-2 lg:w-64">
+                <Label htmlFor="clinic-zone-filter">Zone</Label>
+                <Select
+                  value={zoneFilterToSelect(zoneFilter)}
+                  onValueChange={(value) => setZoneFilter(zoneFilterFromSelect(value))}
+                >
+                  <SelectTrigger id="clinic-zone-filter">
+                    <SelectValue placeholder="All zones" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {zoneOptions.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                        {option.clinicCount === null ? '' : ` (${option.clinicCount})`}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
             <ActiveFilterSummary
-              items={[{ label: 'View', value: FILTER_LABELS[filter] }]}
+              items={[
+                { label: 'View', value: FILTER_LABELS[filter] },
+                { label: 'Zone', value: zoneFilterLabel(zoneFilter) },
+              ]}
               emptyLabel="All clinics"
             />
           </div>
@@ -318,7 +409,10 @@ export function ClinicRegistryScreen() {
               <SectionSkeleton lines={5} className="border-0 bg-transparent p-0 shadow-none" />
             }
             errorTitle="The clinic list could not be loaded"
-            isEmpty={(data) => data.length === 0}
+            // Only the unfiltered read can mean "there are no clinics". Once a zone is applied
+            // an empty response means the filter found nothing, and offering "Create the first
+            // clinic" there would be both wrong and the wrong thing to reach for.
+            isEmpty={(data) => data.length === 0 && zoneFilter === null}
             empty={{
               icon: Building2,
               title: 'No clinics yet',
@@ -329,11 +423,14 @@ export function ClinicRegistryScreen() {
           >
             {() =>
               visibleRows.length === 0 ? (
-                <p className="rounded-lg border border-border bg-muted/40 px-4 py-6 text-center text-sm text-muted-foreground">
-                  {filter === 'needs-attention'
-                    ? 'No clinic has a metadata problem. Organization reporting can rely on every record here.'
-                    : 'No clinic matches this view.'}
-                </p>
+                <div className="rounded-lg border border-border bg-muted/40 px-4 py-6 text-center text-sm text-muted-foreground">
+                  <p>{emptyResultMessage}</p>
+                  {zoneFilter !== null ? (
+                    <Button variant="outline" className="mt-3" onClick={() => setZoneFilter(null)}>
+                      Show all zones
+                    </Button>
+                  ) : null}
+                </div>
               ) : (
                 <>
                   <div className="space-y-3 md:hidden">
@@ -369,8 +466,14 @@ export function ClinicRegistryScreen() {
                           </div>
                           <div className="min-w-0">
                             <dt className="text-muted-foreground">Zone</dt>
-                            <dd className="truncate font-mono text-xs text-foreground">
-                              {clinic.zoneCode || 'None'}
+                            <dd
+                              className={
+                                clinic.zoneCode
+                                  ? 'truncate font-mono text-xs text-foreground'
+                                  : 'truncate text-xs text-muted-foreground'
+                              }
+                            >
+                              {zoneLabel(clinic.zoneCode)}
                             </dd>
                           </div>
                           <div className="min-w-0">

--- a/apps/web/components/dashboard/SystemAdminDashboard.tsx
+++ b/apps/web/components/dashboard/SystemAdminDashboard.tsx
@@ -1,17 +1,38 @@
 'use client';
 
+import { useMemo } from 'react';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { DataGrid, type GridColDef } from '@mui/x-data-grid';
 import { Box } from '@mui/material';
 import { dataGridSx } from '@/lib/datagrid-theme';
-import { Building2, Users, Activity } from 'lucide-react';
+import { Building2, Users, Activity, Map } from 'lucide-react';
 import { DashboardSectionHeader } from './DashboardSectionHeader';
 import { DashboardKpiCard } from './DashboardKpiCard';
 import { TrendChart } from './TrendChart';
+import { ActiveFilterSummary } from '@/components/app-shell/ActiveFilterSummary';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  zoneFilterFromSelect,
+  zoneFilterLabel,
+  zoneFilterOptions,
+  zoneFilterToSelect,
+  zoneLabel,
+  type ZoneFilter,
+  type ZoneSummary,
+} from '@/lib/clinic-zones';
 
 interface ClinicComparisonRow {
   clinicId: string;
   clinicName: string;
+  zoneCode: string | null;
   totalPatients: number;
   totalEncounters: number;
   totalFinalized: number;
@@ -24,28 +45,29 @@ interface SystemAdminDashboardProps {
   systemWideEncounters: number;
   systemEncountersTrend: { date: string; count: number }[];
   clinicComparison: ClinicComparisonRow[];
+  zones: ZoneSummary[];
+  appliedZoneCode: string | null;
+  zoneFilter: ZoneFilter;
+  onZoneFilterChange: (filter: ZoneFilter) => void;
+  isRefreshing?: boolean;
 }
 
 const columns: GridColDef[] = [
-  { field: 'clinicName', headerName: 'Clinic', flex: 1 },
+  { field: 'clinicName', headerName: 'Clinic', flex: 1, minWidth: 160 },
   {
-    field: 'totalPatients',
-    headerName: 'Patients',
-    width: 120,
-    type: 'number',
+    field: 'zoneCode',
+    headerName: 'Zone',
+    width: 140,
+    renderCell: (params) =>
+      params.row.zoneCode ? (
+        <span className="font-mono text-xs">{params.row.zoneCode}</span>
+      ) : (
+        <span className="text-muted-foreground">{zoneLabel(null)}</span>
+      ),
   },
-  {
-    field: 'totalEncounters',
-    headerName: 'Encounters',
-    width: 120,
-    type: 'number',
-  },
-  {
-    field: 'totalFinalized',
-    headerName: 'Finalized',
-    width: 120,
-    type: 'number',
-  },
+  { field: 'totalPatients', headerName: 'Patients', width: 120, type: 'number' },
+  { field: 'totalEncounters', headerName: 'Encounters', width: 120, type: 'number' },
+  { field: 'totalFinalized', headerName: 'Finalized', width: 120, type: 'number' },
 ];
 
 export function SystemAdminDashboard({
@@ -55,20 +77,48 @@ export function SystemAdminDashboard({
   systemWideEncounters,
   systemEncountersTrend,
   clinicComparison,
+  zones,
+  appliedZoneCode,
+  zoneFilter,
+  onZoneFilterChange,
+  isRefreshing = false,
 }: SystemAdminDashboardProps) {
+  const zoneOptions = useMemo(() => zoneFilterOptions(zones), [zones]);
+  const zonedCount = zones.filter((zone) => zone.zoneCode !== null).length;
+
+  /*
+    The control is driven by local state, but everything that *describes* the table reads the
+    zone the server says it applied. Mid-refetch the two differ for a moment, and describing the
+    rows by the pending filter would caption a table with a zone it is not showing yet.
+  */
+  const shownZone = appliedZoneCode;
+
+  // Totals for what is on screen, not for the network. With a zone applied the network KPIs
+  // above still describe the whole network, so without these the table and the cards would be
+  // answering different questions side by side.
+  const shownPatients = clinicComparison.reduce((sum, row) => sum + row.totalPatients, 0);
+  const shownEncounters = clinicComparison.reduce((sum, row) => sum + row.totalEncounters, 0);
+  const isFiltered = shownZone !== null;
+
   return (
     <section className="space-y-6">
       <DashboardSectionHeader
         title="Network overview"
-        hint="Use this section to compare activity across clinics and spot where support is needed."
+        hint="Use this section to compare activity across clinics and zones, and spot where support is needed."
       />
 
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
         <DashboardKpiCard
           title="Clinics"
           value={totalClinics}
           icon={Building2}
           hint="Clinics currently active in the platform."
+        />
+        <DashboardKpiCard
+          title="Zones"
+          value={zonedCount}
+          icon={Map}
+          hint="Reporting zones in use across the network."
         />
         <DashboardKpiCard
           title="Staff accounts"
@@ -97,23 +147,119 @@ export function SystemAdminDashboard({
       />
 
       <Card>
-        <CardHeader className="pb-2">
-          <CardTitle className="text-sm font-medium">Clinic comparison</CardTitle>
+        <CardHeader className="space-y-3 pb-2">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+            <CardTitle className="text-sm font-medium">Clinic comparison</CardTitle>
+            <div className="space-y-2 lg:w-64">
+              <Label htmlFor="network-zone-filter">Zone</Label>
+              <Select
+                value={zoneFilterToSelect(zoneFilter)}
+                onValueChange={(value) => onZoneFilterChange(zoneFilterFromSelect(value))}
+              >
+                <SelectTrigger id="network-zone-filter">
+                  <SelectValue placeholder="All zones" />
+                </SelectTrigger>
+                <SelectContent>
+                  {zoneOptions.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                      {option.clinicCount === null ? '' : ` (${option.clinicCount})`}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <ActiveFilterSummary
+            items={[
+              { label: 'Zone', value: zoneFilterLabel(shownZone) },
+              { label: 'Clinics shown', value: clinicComparison.length },
+              ...(isFiltered
+                ? [
+                    { label: 'Patients in view', value: shownPatients },
+                    { label: 'Visits in view', value: shownEncounters },
+                  ]
+                : []),
+            ]}
+            emptyLabel="All zones"
+          />
         </CardHeader>
         <CardContent>
-          <Box sx={{ height: 400, width: '100%' }} className="overflow-x-auto overflow-y-hidden">
-            <DataGrid
-              rows={clinicComparison}
-              columns={columns}
-              getRowId={(row) => row.clinicId}
-              pageSizeOptions={[10]}
-              disableRowSelectionOnClick
-              initialState={{
-                pagination: { paginationModel: { pageSize: 10 } },
-              }}
-              sx={{ ...dataGridSx, minWidth: 560 }}
-            />
-          </Box>
+          {clinicComparison.length === 0 ? (
+            <div className="rounded-lg border border-border bg-muted/40 px-4 py-6 text-center text-sm text-muted-foreground">
+              <p>
+                {isFiltered
+                  ? `No clinic is in ${zoneFilterLabel(shownZone)}.`
+                  : 'No clinic has any activity to compare yet.'}
+              </p>
+              {isFiltered ? (
+                <Button variant="outline" className="mt-3" onClick={() => onZoneFilterChange(null)}>
+                  Show all zones
+                </Button>
+              ) : null}
+            </div>
+          ) : (
+            <>
+              {/*
+                Card list below md, grid above -- the same dual tree the clinic registry uses.
+                This table was previously a bare DataGrid with a 560px floor, so on a phone the
+                only way to read the last column was to scroll a nested region sideways.
+              */}
+              <ul className="space-y-3 md:hidden">
+                {clinicComparison.map((row) => (
+                  <li
+                    key={row.clinicId}
+                    className="rounded-lg border border-border bg-background p-4"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <h4 className="min-w-0 truncate text-base font-semibold text-foreground">
+                        {row.clinicName}
+                      </h4>
+                      <span
+                        className={
+                          row.zoneCode
+                            ? 'shrink-0 font-mono text-xs text-foreground'
+                            : 'shrink-0 text-xs text-muted-foreground'
+                        }
+                      >
+                        {zoneLabel(row.zoneCode)}
+                      </span>
+                    </div>
+                    <dl className="mt-3 grid grid-cols-3 gap-x-3 gap-y-2 text-sm">
+                      <div>
+                        <dt className="text-muted-foreground">Patients</dt>
+                        <dd className="tabular-nums text-foreground">{row.totalPatients}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-muted-foreground">Encounters</dt>
+                        <dd className="tabular-nums text-foreground">{row.totalEncounters}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-muted-foreground">Finalized</dt>
+                        <dd className="tabular-nums text-foreground">{row.totalFinalized}</dd>
+                      </div>
+                    </dl>
+                  </li>
+                ))}
+              </ul>
+
+              <Box
+                sx={{ height: 400, width: '100%' }}
+                className="hidden overflow-x-auto overflow-y-hidden md:block"
+              >
+                <DataGrid
+                  rows={clinicComparison}
+                  columns={columns}
+                  loading={isRefreshing}
+                  getRowId={(row) => row.clinicId}
+                  pageSizeOptions={[10]}
+                  disableRowSelectionOnClick
+                  initialState={{ pagination: { paginationModel: { pageSize: 10 } } }}
+                  sx={{ ...dataGridSx, minWidth: 640 }}
+                />
+              </Box>
+            </>
+          )}
         </CardContent>
       </Card>
     </section>

--- a/apps/web/e2e/accessibility.spec.js
+++ b/apps/web/e2e/accessibility.spec.js
@@ -47,11 +47,22 @@ async function analyze(page) {
  *
  * Excluding that subtree rather than disabling the rule keeps `aria-hidden-focus` live for the
  * popup itself, which is the markup a sweep here is actually about.
+ *
+ * `scrollable-region-focusable` goes for the same reason, and only once the option list is long
+ * enough to scroll -- which is why it appears in a full-suite run and not in a single-spec one.
+ * Radix puts `role="listbox"` on the content and the scrolling on an inner unlabelled viewport,
+ * so axe sees a scroll container with no tab stop and cannot see the roving focus that already
+ * navigates it. The custom `Combobox` passes the same sweep precisely because its scrolling
+ * element *is* the listbox.
+ *
+ * A disabled rule is only honest with something in its place, so the caller proves the access
+ * axe cannot see: it drives the picker open, down and closed by keyboard alone.
  */
 function analyzeOpenPopup(page) {
   return new AxeBuilder({ page })
     .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
     .exclude('[data-aria-hidden="true"]')
+    .disableRules(['scrollable-region-focusable'])
     .analyze();
 }
 
@@ -247,6 +258,18 @@ test('the clinic registry, its filters, its dialog, and its combobox survive an 
   );
   await page.keyboard.press('Escape');
   await expect(page.getByRole('listbox')).toBeHidden();
+
+  // The evidence behind the exclusion above. axe also reports `scrollable-region-focusable`
+  // against the Radix viewport once the option list is long enough to scroll, because it cannot
+  // see a roving-focus listbox. So prove the access it cannot see: open the picker by keyboard
+  // alone, walk down it, and commit -- reaching an option that was below the fold.
+  await page.locator('#clinic-zone-filter').focus();
+  await page.keyboard.press('Enter');
+  await expect(page.getByRole('listbox')).toBeVisible();
+  for (let i = 0; i < 3; i += 1) await page.keyboard.press('ArrowDown');
+  await page.keyboard.press('Enter');
+  await expect(page.getByRole('listbox')).toBeHidden();
+  await expect(page.locator('#clinic-zone-filter')).toBeFocused();
 
   await page.getByRole('button', { name: 'Create clinic', exact: true }).first().click();
   const dialog = page.getByRole('dialog');

--- a/apps/web/e2e/accessibility.spec.js
+++ b/apps/web/e2e/accessibility.spec.js
@@ -36,6 +36,25 @@ async function analyze(page) {
   return new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa']).analyze();
 }
 
+/**
+ * The sweep for a state where a Radix popup is open.
+ *
+ * Radix marks everything behind an open `Select` with `aria-hidden="true"` and traps focus in
+ * the popup. axe cannot see the focus trap, so it reports `aria-hidden-focus` against the page
+ * behind -- for every `Select` in the product, not just a new one. Verified against
+ * `#staff-status-filter` on `/admin/users`, which predates any zone work and reports exactly
+ * the same violation.
+ *
+ * Excluding that subtree rather than disabling the rule keeps `aria-hidden-focus` live for the
+ * popup itself, which is the markup a sweep here is actually about.
+ */
+function analyzeOpenPopup(page) {
+  return new AxeBuilder({ page })
+    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+    .exclude('[data-aria-hidden="true"]')
+    .analyze();
+}
+
 function describeViolations(violations) {
   return violations
     .map(
@@ -223,7 +242,9 @@ test('the clinic registry, its filters, its dialog, and its combobox survive an 
   // #main-content, so an unopened one is not covered by the sweep above at all.
   await page.locator('#clinic-zone-filter').click();
   await expect(page.getByRole('listbox')).toBeVisible();
-  expect(describeViolations((await analyze(page)).violations), 'zone filter open').toBe('');
+  expect(describeViolations((await analyzeOpenPopup(page)).violations), 'zone filter open').toBe(
+    '',
+  );
   await page.keyboard.press('Escape');
   await expect(page.getByRole('listbox')).toBeHidden();
 

--- a/apps/web/e2e/accessibility.spec.js
+++ b/apps/web/e2e/accessibility.spec.js
@@ -202,9 +202,11 @@ for (const breakpoint of BREAKPOINTS) {
   });
 }
 
-test('the clinic registry, its dialog, and its combobox survive an axe sweep', async ({ page }) => {
-  // Three states, because the interesting one is not in the DOM until it is opened: the registry
-  // itself, the dialog, and the dialog with the listbox up. The combobox is the first control of
+test('the clinic registry, its filters, its dialog, and its combobox survive an axe sweep', async ({
+  page,
+}) => {
+  // Four states, because the interesting ones are not in the DOM until they are opened: the
+  // registry itself, the zone picker's listbox, the dialog, and the dialog with the listbox up. The combobox is the first control of
   // its kind in the product, and a hand-built listbox popup is exactly the kind of thing that
   // passes review by eye and fails an automated rule.
   //
@@ -216,6 +218,14 @@ test('the clinic registry, its dialog, and its combobox survive an axe sweep', a
   ).toBeVisible({ timeout: 30_000 });
 
   expect(describeViolations((await analyze(page)).violations), 'registry').toBe('');
+
+  // The zone picker's own open state. A Radix Select renders its listbox in a portal outside
+  // #main-content, so an unopened one is not covered by the sweep above at all.
+  await page.locator('#clinic-zone-filter').click();
+  await expect(page.getByRole('listbox')).toBeVisible();
+  expect(describeViolations((await analyze(page)).violations), 'zone filter open').toBe('');
+  await page.keyboard.press('Escape');
+  await expect(page.getByRole('listbox')).toBeHidden();
 
   await page.getByRole('button', { name: 'Create clinic', exact: true }).first().click();
   const dialog = page.getByRole('dialog');

--- a/apps/web/e2e/clinic-metadata.spec.js
+++ b/apps/web/e2e/clinic-metadata.spec.js
@@ -201,3 +201,102 @@ test.describe('creating a clinic', () => {
     await expect(page.getByRole('grid').getByText(locationCode)).toBeVisible({ timeout: 15_000 });
   });
 });
+
+/**
+ * The zone filter.
+ *
+ * These run against a clinic this file creates, because the seed leaves `zoneCode` empty --
+ * `SEED_CLINIC_ZONE_CODE` is not set in CI -- so the seeded clinic is the "No zone" case and a
+ * zoned clinic has to be made. That is useful rather than awkward: both branches of the filter
+ * get exercised by the same run.
+ */
+test.describe('clinic zone filter', () => {
+  test.use({ storageState: storageStateFor('staff') });
+
+  // By id, not by label: the DataGrid also has a column header reading "Zone".
+  const zoneFilter = (page) => page.locator('#clinic-zone-filter');
+
+  /** Creates a clinic in its own zone and returns what identifies it. */
+  async function createZonedClinic(page) {
+    const suffix = Date.now().toString(36);
+    const name = `zz E2E Zone Clinic ${suffix}`;
+    const locationCode = `zz-e2e-zone-${suffix}`;
+    const zoneCode = `zz-zone-${suffix}`;
+
+    const dialog = await openCreateDialog(page);
+    await dialog.getByLabel('Name').fill(name);
+    await dialog.getByLabel('Location code').fill(locationCode);
+    await dialog.getByLabel('Zone code').fill(zoneCode);
+    await submit(dialog);
+    await expect(dialog).toBeHidden({ timeout: 15_000 });
+
+    return { locationCode, zoneCode };
+  }
+
+  test('narrows the registry to one zone and back again', async ({ page }) => {
+    const { locationCode, zoneCode } = await createZonedClinic(page);
+
+    // The seeded clinic has no zone code, so it is the row that must disappear.
+    const grid = page.getByRole('grid');
+    await expect(grid.getByText('nkwapa-clinic-demo')).toBeVisible({ timeout: 15_000 });
+
+    await zoneFilter(page).click();
+    await page.getByRole('option', { name: new RegExp(zoneCode) }).click();
+
+    await expect(grid.getByText(locationCode)).toBeVisible({ timeout: 15_000 });
+    await expect(grid.getByText('nkwapa-clinic-demo')).toBeHidden();
+    await expect(page.getByText(`Zone: ${zoneCode}`)).toBeVisible();
+
+    await zoneFilter(page).click();
+    await page.getByRole('option', { name: 'All zones' }).click();
+
+    await expect(grid.getByText('nkwapa-clinic-demo')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText(`Zone: ${zoneCode}`)).toBeHidden();
+  });
+
+  test('selects the clinics that have no zone', async ({ page }) => {
+    const { locationCode } = await createZonedClinic(page);
+
+    await zoneFilter(page).click();
+    await page.getByRole('option', { name: /^No zone/ }).click();
+
+    const grid = page.getByRole('grid');
+    await expect(grid.getByText('nkwapa-clinic-demo')).toBeVisible({ timeout: 15_000 });
+    await expect(grid.getByText(locationCode)).toBeHidden();
+    await expect(page.getByText('Zone: No zone')).toBeVisible();
+  });
+
+  test('offers an existing zone as a suggestion rather than making it retypeable', async ({
+    page,
+  }) => {
+    // A zone is free text, so the only thing stopping one typo splitting a zone's report in two
+    // is that the spellings already in use are reachable without typing them.
+    const { zoneCode } = await createZonedClinic(page);
+
+    const dialog = await openCreateDialog(page);
+    const suggestion = dialog.getByRole('button', { name: zoneCode, exact: true });
+    await expect(suggestion).toBeVisible({ timeout: 15_000 });
+
+    await suggestion.click();
+    await expect(dialog.getByLabel('Zone code')).toHaveValue(zoneCode);
+  });
+
+  test('says a zone filter emptied the list, and offers the way back', async ({ page }) => {
+    // The registry's empty state used to say "No clinics yet" with a "Create the first clinic"
+    // button, because an empty filtered response and an empty database look identical on the
+    // wire. This is the test that it no longer does.
+    const { zoneCode } = await createZonedClinic(page);
+
+    await zoneFilter(page).click();
+    await page.getByRole('option', { name: new RegExp(zoneCode) }).click();
+    await expect(page.getByRole('grid')).toBeVisible({ timeout: 15_000 });
+
+    await page.getByRole('button', { name: 'Needs attention' }).click();
+
+    await expect(page.getByText(`No clinic in ${zoneCode} has a metadata problem.`)).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'No clinics yet' })).toBeHidden();
+
+    await page.getByRole('button', { name: 'Show all zones' }).click();
+    await expect(page.getByText(`Zone: ${zoneCode}`)).toBeHidden();
+  });
+});

--- a/apps/web/lib/bootstrap-clinics.test.ts
+++ b/apps/web/lib/bootstrap-clinics.test.ts
@@ -34,9 +34,11 @@ describe('bootstrap clinic helpers', () => {
       ],
     };
 
+    // An older payload carries no zone, and the fallback settles it to null rather than leaving
+    // the field absent, so a caller reading the zone gets "no zone" instead of undefined.
     expect(getSwitchableClinics(bootstrap)).toEqual([
-      { clinicId: 'clinic-3', clinicName: 'Clinic Three' },
-      { clinicId: 'clinic-4', clinicName: 'Clinic Four' },
+      { clinicId: 'clinic-3', clinicName: 'Clinic Three', zoneCode: null },
+      { clinicId: 'clinic-4', clinicName: 'Clinic Four', zoneCode: null },
     ]);
     expect(getBootstrapActiveClinicId(bootstrap)).toBe('clinic-3');
     expect(isStoredClinicIdValid(bootstrap, 'clinic-4')).toBe(true);

--- a/apps/web/lib/bootstrap-clinics.ts
+++ b/apps/web/lib/bootstrap-clinics.ts
@@ -1,6 +1,14 @@
 export interface BootstrapClinic {
   clinicId: string;
   clinicName: string;
+  /**
+   * The clinic's reporting zone, or `null`.
+   *
+   * Optional because an older API build does not send it, and a missing zone must read as "no
+   * zone" rather than take a screen down. It is context for a single-clinic view: zone is a
+   * reporting dimension and never decides what anyone may open.
+   */
+  zoneCode?: string | null;
 }
 
 export interface BootstrapMembership extends BootstrapClinic {
@@ -40,6 +48,7 @@ export function getSwitchableClinics(
     (bootstrap?.memberships ?? []).map((membership) => ({
       clinicId: membership.clinicId,
       clinicName: membership.clinicName,
+      zoneCode: membership.zoneCode ?? null,
     })),
   );
 }

--- a/apps/web/lib/clinic-metadata.test.ts
+++ b/apps/web/lib/clinic-metadata.test.ts
@@ -1,3 +1,4 @@
+import { zoneFilterMatches } from './clinic-zones';
 import {
   CLINIC_METADATA_ISSUE_LABELS,
   clinicFormFromRow,
@@ -237,6 +238,45 @@ describe('filterClinics', () => {
 
   it('narrows to inactive clinics', () => {
     expect(filterClinics(all, 'inactive').map((c) => c.id)).toEqual(['c']);
+  });
+
+  describe('with a zone', () => {
+    const north = clinic({ id: 'n', zoneCode: 'north' });
+    const south = clinic({ id: 's', zoneCode: 'south' });
+    const unzoned = clinic({ id: 'u', zoneCode: null });
+    const brokenNorth = clinic({
+      id: 'bn',
+      zoneCode: 'north',
+      metadataIssues: [issue('TIMEZONE_UNKNOWN', 'error')],
+    });
+    const zoned = [north, south, unzoned, brokenNorth];
+
+    it('changes nothing when no zone is applied', () => {
+      expect(filterClinics(zoned, 'all', null)).toHaveLength(4);
+    });
+
+    it('narrows to one zone', () => {
+      expect(filterClinics(zoned, 'all', 'north').map((c) => c.id)).toEqual(['n', 'bn']);
+    });
+
+    it('narrows to the clinics with no zone', () => {
+      expect(filterClinics(zoned, 'all', '__unzoned__').map((c) => c.id)).toEqual(['u']);
+    });
+
+    it('composes with the view rather than replacing it', () => {
+      // The reason zone is a second argument and not another member of the view union: an
+      // operator asks for "clinics in the north zone that need attention", not one or the other.
+      expect(filterClinics(zoned, 'needs-attention', 'north').map((c) => c.id)).toEqual(['bn']);
+      expect(filterClinics(zoned, 'needs-attention', 'south')).toEqual([]);
+    });
+
+    it('agrees with the shared predicate the API filters by', () => {
+      for (const filter of ['north', 'south', '__unzoned__', null]) {
+        expect(filterClinics(zoned, 'all', filter)).toEqual(
+          zoned.filter((c) => zoneFilterMatches(c.zoneCode, filter)),
+        );
+      }
+    });
   });
 });
 

--- a/apps/web/lib/clinic-metadata.ts
+++ b/apps/web/lib/clinic-metadata.ts
@@ -19,6 +19,7 @@ import {
   type ClinicMetadataIssue,
   type ClinicMetadataSeverity,
 } from '@nkwapa/db/clinic-metadata';
+import { zoneFilterMatches, type ZoneFilter } from '@nkwapa/db/clinic-zones';
 
 export {
   CLINIC_DEFAULT_COUNTRY_CODE,
@@ -237,10 +238,28 @@ export function clinicNeedsAttention(clinic: ClinicRow): boolean {
 
 export type ClinicListFilter = 'all' | 'needs-attention' | 'inactive';
 
-export function filterClinics(clinics: ClinicRow[], filter: ClinicListFilter): ClinicRow[] {
-  if (filter === 'needs-attention') return clinics.filter(clinicNeedsAttention);
-  if (filter === 'inactive') return clinics.filter((clinic) => !clinic.isActive);
-  return clinics;
+/**
+ * Narrows the registry by view and, independently, by zone.
+ *
+ * The two are separate arguments rather than one widened `ClinicListFilter` because they
+ * compose: "clinics in the north zone that need attention" is a question an operator asks, and
+ * folding zone into the view union would have made the two mutually exclusive.
+ *
+ * The zone predicate is the shared one the API filters with, so a client-side narrowing and a
+ * server-side one can never disagree about which clinics are in a zone.
+ */
+export function filterClinics(
+  clinics: ClinicRow[],
+  filter: ClinicListFilter,
+  zoneFilter: ZoneFilter = null,
+): ClinicRow[] {
+  let rows = clinics;
+  if (filter === 'needs-attention') rows = rows.filter(clinicNeedsAttention);
+  if (filter === 'inactive') rows = rows.filter((clinic) => !clinic.isActive);
+  if (zoneFilter !== null) {
+    rows = rows.filter((clinic) => zoneFilterMatches(clinic.zoneCode, zoneFilter));
+  }
+  return rows;
 }
 
 export interface TimeZoneOption {

--- a/apps/web/lib/clinic-zones.test.ts
+++ b/apps/web/lib/clinic-zones.test.ts
@@ -1,0 +1,102 @@
+import {
+  ALL_ZONES_VALUE,
+  UNZONED_FILTER_VALUE,
+  UNZONED_LABEL,
+  zoneFilterFromSelect,
+  zoneFilterLabel,
+  zoneFilterOptions,
+  zoneFilterToSelect,
+  zoneQueryString,
+  zoneResourceKey,
+  type ZoneSummary,
+} from './clinic-zones';
+
+const zones: ZoneSummary[] = [
+  { zoneCode: 'north', clinicCount: 3, activeClinicCount: 3 },
+  { zoneCode: 'south', clinicCount: 1, activeClinicCount: 0 },
+  { zoneCode: null, clinicCount: 2, activeClinicCount: 2 },
+];
+
+describe('zoneFilterOptions', () => {
+  it('offers every zone with "All zones" first', () => {
+    expect(zoneFilterOptions(zones).map((option) => option.label)).toEqual([
+      'All zones',
+      'north',
+      'south',
+      UNZONED_LABEL,
+    ]);
+  });
+
+  it('carries the clinic count, so a filter says where it will land', () => {
+    const options = zoneFilterOptions(zones);
+    expect(options[0].clinicCount).toBeNull();
+    expect(options[1]).toMatchObject({ value: 'north', clinicCount: 3 });
+    expect(options[3]).toMatchObject({ value: UNZONED_FILTER_VALUE, clinicCount: 2 });
+  });
+
+  it('still offers "All zones" when nothing is zoned', () => {
+    expect(zoneFilterOptions([])).toEqual([
+      { value: ALL_ZONES_VALUE, label: 'All zones', clinicCount: null },
+    ]);
+  });
+
+  it('gives every option a non-empty value', () => {
+    // Radix `Select` treats an empty string as "no selection" and throws on an item that uses
+    // one, which is the whole reason ALL_ZONES_VALUE is a sentinel rather than ''.
+    for (const option of zoneFilterOptions(zones)) {
+      expect(option.value).not.toBe('');
+    }
+  });
+});
+
+describe('the Select round trip', () => {
+  it('maps every option back to the filter it represents', () => {
+    expect(zoneFilterFromSelect(ALL_ZONES_VALUE)).toBeNull();
+    expect(zoneFilterFromSelect('north')).toBe('north');
+    expect(zoneFilterFromSelect(UNZONED_FILTER_VALUE)).toBe(UNZONED_FILTER_VALUE);
+  });
+
+  it('round-trips a filter through the control and back', () => {
+    for (const filter of [null, 'north', UNZONED_FILTER_VALUE]) {
+      expect(zoneFilterFromSelect(zoneFilterToSelect(filter))).toEqual(filter);
+    }
+  });
+
+  it('drives the control from state without an empty value', () => {
+    expect(zoneFilterToSelect(null)).toBe(ALL_ZONES_VALUE);
+    expect(zoneFilterToSelect('north')).toBe('north');
+  });
+});
+
+describe('zoneFilterLabel', () => {
+  it('says nothing when no zone is applied, so no chip is rendered', () => {
+    // ActiveFilterSummary drops null values, which is how the chip disappears.
+    expect(zoneFilterLabel(null)).toBeNull();
+  });
+
+  it('names the zone, and names the absence of one', () => {
+    expect(zoneFilterLabel('north')).toBe('north');
+    expect(zoneFilterLabel(UNZONED_FILTER_VALUE)).toBe(UNZONED_LABEL);
+  });
+});
+
+describe('the request and its cache key', () => {
+  it('sends no query when no zone is applied', () => {
+    expect(zoneQueryString(null)).toBe('');
+  });
+
+  it('sends the zone, encoded', () => {
+    expect(zoneQueryString('north')).toBe('?zoneCode=north');
+    expect(zoneQueryString(UNZONED_FILTER_VALUE)).toBe('?zoneCode=__unzoned__');
+  });
+
+  it('gives each filter its own resource key', () => {
+    // useAsyncResource refetches on the key alone. Two filters sharing a key would leave the
+    // table showing the previous zone's rows, which is why both come from one module.
+    const keys = [null, 'north', 'south', UNZONED_FILTER_VALUE].map((filter) =>
+      zoneResourceKey('admin-clinics', filter),
+    );
+    expect(new Set(keys).size).toBe(keys.length);
+    expect(zoneResourceKey('admin-clinics', null)).toBe('admin-clinics:all');
+  });
+});

--- a/apps/web/lib/clinic-zones.test.ts
+++ b/apps/web/lib/clinic-zones.test.ts
@@ -6,6 +6,8 @@ import {
   zoneFilterLabel,
   zoneFilterOptions,
   zoneFilterToSelect,
+  memberMatchesZone,
+  zoneByClinicId,
   zoneQueryString,
   zoneResourceKey,
   type ZoneSummary,
@@ -98,5 +100,47 @@ describe('the request and its cache key', () => {
     );
     expect(new Set(keys).size).toBe(keys.length);
     expect(zoneResourceKey('admin-clinics', null)).toBe('admin-clinics:all');
+  });
+});
+
+describe('memberMatchesZone', () => {
+  const zones = zoneByClinicId([
+    { id: 'c-north', zoneCode: 'north' },
+    { id: 'c-south', zoneCode: 'south' },
+    { id: 'c-none', zoneCode: null },
+  ]);
+  const at = (...clinicIds: string[]) => clinicIds.map((clinicId) => ({ clinicId }));
+
+  it('keeps everyone when no zone is applied', () => {
+    expect(memberMatchesZone(at('c-north'), zones, null)).toBe(true);
+    expect(memberMatchesZone([], zones, null)).toBe(true);
+  });
+
+  it('matches on any seat, not only the first', () => {
+    // Someone working in two zones really is in both; picking one would hide them from the other.
+    expect(memberMatchesZone(at('c-north', 'c-south'), zones, 'north')).toBe(true);
+    expect(memberMatchesZone(at('c-north', 'c-south'), zones, 'south')).toBe(true);
+  });
+
+  it('excludes someone with no seat in that zone', () => {
+    expect(memberMatchesZone(at('c-south'), zones, 'north')).toBe(false);
+  });
+
+  it('reads unzoned as having no seat in any zone', () => {
+    expect(memberMatchesZone(at('c-none'), zones, '__unzoned__')).toBe(true);
+    expect(memberMatchesZone(at('c-none', 'c-north'), zones, '__unzoned__')).toBe(false);
+  });
+
+  it('files someone with no clinic seat at all under unzoned', () => {
+    // A global administrator holds no clinic seat. Excluding them from every option would make
+    // the row unreachable under any filter, which is worse than filing it under the residue.
+    expect(memberMatchesZone([], zones, '__unzoned__')).toBe(true);
+    expect(memberMatchesZone([], zones, 'north')).toBe(false);
+  });
+
+  it('treats a clinic it has never heard of as unzoned', () => {
+    // The roster and the clinic list are two reads; one can be a moment behind the other.
+    expect(memberMatchesZone(at('c-unknown'), zones, '__unzoned__')).toBe(true);
+    expect(memberMatchesZone(at('c-unknown'), zones, 'north')).toBe(false);
   });
 });

--- a/apps/web/lib/clinic-zones.ts
+++ b/apps/web/lib/clinic-zones.ts
@@ -99,3 +99,39 @@ export function zoneQueryString(filter: ZoneFilter): string {
 export function zoneResourceKey(base: string, filter: ZoneFilter): string {
   return `${base}:${filter ?? 'all'}`;
 }
+
+/**
+ * Does a person belong to a zone, by way of the clinics they hold a role at?
+ *
+ * A person is not in a zone; their clinics are. So this asks whether any clinic they hold a
+ * seat at is in the zone being filtered for. Someone with seats in two zones matches both,
+ * which is right: they really do work in both.
+ *
+ * The unzoned case reads "has no seat in any zone", so it covers both the person whose clinics
+ * simply have no zone code and the global administrator who holds no clinic seat at all. The
+ * alternative -- matching only the first -- would make a global admin invisible under every
+ * option including this one, and a roster that hides a row under all filters is worse than one
+ * that files it under the residue.
+ *
+ * This never decides what anyone may see. The roster it filters was already scoped by the API.
+ */
+export function memberMatchesZone(
+  memberships: { clinicId: string }[],
+  zoneByClinicId: Map<string, string | null>,
+  filter: ZoneFilter,
+): boolean {
+  if (filter === null) return true;
+
+  const zones = memberships.map((membership) => zoneByClinicId.get(membership.clinicId) ?? null);
+  if (filter === UNZONED_FILTER_VALUE) {
+    return zones.every((zone) => zone === null);
+  }
+  return zones.some((zone) => zoneFilterMatches(zone, filter));
+}
+
+/** Clinic id to zone code, for `memberMatchesZone`. */
+export function zoneByClinicId(
+  clinics: { id: string; zoneCode?: string | null }[],
+): Map<string, string | null> {
+  return new Map(clinics.map((clinic) => [clinic.id, clinic.zoneCode ?? null]));
+}

--- a/apps/web/lib/clinic-zones.ts
+++ b/apps/web/lib/clinic-zones.ts
@@ -1,0 +1,101 @@
+import {
+  UNZONED_FILTER_VALUE,
+  UNZONED_LABEL,
+  listZoneCodes,
+  parseZoneFilter,
+  summarizeZones,
+  zoneFilterMatches,
+  zoneLabel,
+  zoneSummaryFilterValue,
+  type ZoneFilter,
+  type ZoneSummary,
+} from '@nkwapa/db/clinic-zones';
+
+export {
+  UNZONED_FILTER_VALUE,
+  UNZONED_LABEL,
+  listZoneCodes,
+  parseZoneFilter,
+  summarizeZones,
+  zoneFilterMatches,
+  zoneLabel,
+  zoneSummaryFilterValue,
+};
+export type { ZoneFilter, ZoneSummary };
+
+/**
+ * The web side of the zone contract.
+ *
+ * Every rule comes from `@nkwapa/db/clinic-zones`, the module the API filters with, so a count
+ * shown beside a picker option and the rows that come back from choosing it are decided by one
+ * implementation. What is added here is presentation.
+ *
+ * The subpath import matters, for the same reason it does in `clinic-metadata.ts`: the package
+ * root re-exports PrismaClient and this is pulled into a client component.
+ *
+ * Zone is a reporting filter and never a permission. Nothing here decides what a user may see;
+ * it decides what a user is currently looking at. `docs/specs/03_AUTH_AND_RBAC.md` is the
+ * statement of record.
+ */
+
+/** The value a `Select` uses for "every zone". Radix forbids an empty string as an item value. */
+export const ALL_ZONES_VALUE = '__all__';
+
+export interface ZoneOption {
+  /** What the `Select` stores, including the two sentinels. */
+  value: string;
+  label: string;
+  /** Clinic count, shown so an operator can see where a filter will land before choosing it. */
+  clinicCount: number | null;
+}
+
+/**
+ * Picker options: "All zones" first, then each zone, then the unzoned bucket.
+ *
+ * The counts come along because a zone filter's whole job is narrowing, and a filter that does
+ * not say how far it narrows makes an operator choose it just to find out.
+ */
+export function zoneFilterOptions(zones: ZoneSummary[]): ZoneOption[] {
+  return [
+    { value: ALL_ZONES_VALUE, label: 'All zones', clinicCount: null },
+    ...zones.map((zone) => ({
+      value: zoneSummaryFilterValue(zone),
+      label: zoneLabel(zone.zoneCode),
+      clinicCount: zone.clinicCount,
+    })),
+  ];
+}
+
+/** Reads a `Select` value back into a filter. The "all" sentinel is the absence of one. */
+export function zoneFilterFromSelect(value: string): ZoneFilter {
+  if (value === ALL_ZONES_VALUE) return null;
+  return parseZoneFilter(value);
+}
+
+/** The `Select` value for a filter, so the control can be driven from state. */
+export function zoneFilterToSelect(filter: ZoneFilter): string {
+  return filter ?? ALL_ZONES_VALUE;
+}
+
+/** The chip text for `ActiveFilterSummary`, or `null` when no zone filter is applied. */
+export function zoneFilterLabel(filter: ZoneFilter): string | null {
+  if (filter === null) return null;
+  if (filter === UNZONED_FILTER_VALUE) return UNZONED_LABEL;
+  return filter;
+}
+
+/**
+ * The query string for a server-side zone filter, and the cache key that goes with it.
+ *
+ * Both come from here because `useAsyncResource` refetches on `resourceKey` alone: a request
+ * whose URL and whose key were derived separately could disagree, and the symptom would be a
+ * table that silently keeps showing the previous zone's rows.
+ */
+export function zoneQueryString(filter: ZoneFilter): string {
+  if (filter === null) return '';
+  return `?zoneCode=${encodeURIComponent(filter)}`;
+}
+
+export function zoneResourceKey(base: string, filter: ZoneFilter): string {
+  return `${base}:${filter ?? 'all'}`;
+}

--- a/docs/DATABASE_SETUP.md
+++ b/docs/DATABASE_SETUP.md
@@ -111,7 +111,7 @@ in the wrong zone -- so they are validated on write and auditable after the fact
 | `organizationId` | Yes      | Must reference an existing organization. Defaults to the only one when a caller does not name one.                      |
 | `locationCode`   | Yes      | Lowercase letters, digits and single hyphens, at most 64 characters. **Unique per organization.**                       |
 | `timezone`       | Yes      | A named IANA zone such as `Africa/Accra`. A fixed offset like `+05:00` is refused: it carries no daylight-saving rules. |
-| `zoneCode`       | No       | Same shape as a location code when present. Empty until zone-aware reporting is switched on.                            |
+| `zoneCode`       | No       | Same shape as a location code when present. Groups clinics for reporting; never a permission.                           |
 | `countryCode`    | Yes      | ISO-3166 alpha-2, stored uppercase. Defaults to `GH`.                                                                   |
 
 All of these live in `packages/db/src/clinic-metadata.ts`, which the API, the admin UI, the seed
@@ -132,7 +132,7 @@ Nkwapa Health (default)
   ℹ AUDIT Closed Site        info    This clinic is inactive and is excluded from daily operations.
   ✗ AUDIT Ridge Clinic       error   This clinic has no location code, so it cannot be identified in organization reporting. [fix: audit-ridge-clinic]
   ✗ AUDIT Tema Annex         error   "Africa/Akra" is not a known IANA time zone. [fix: Africa/Accra]
-  ⚠ Nkwapa Clinic - Demo     warning No zone code is set. Zone reporting will skip this clinic.
+  ⚠ Nkwapa Clinic - Demo     warning No zone code is set. This clinic reports under "No zone".
 
 2 errors, 1 warning across 4 clinics.
 Re-run with --apply to fix the 2 auto-fixable issues.

--- a/docs/USER_AND_ROLE_SETUP_GUIDE.md
+++ b/docs/USER_AND_ROLE_SETUP_GUIDE.md
@@ -31,8 +31,10 @@ Important notes:
 
 - `SYSTEM_ADMIN` is global and uses `clinicId = null`
 - most other roles are assigned per clinic
-- `zoneCode` exists on clinics for future scale-up, but zone RBAC is not yet active. It is
-  editable and audited in `/admin/clinics` so the data is trustworthy before behavior lands.
+- `zoneCode` groups clinics for reporting and filtering. It is a **filter, not a permission**:
+  putting two clinics in one zone lets you report on them together and gives nobody access to
+  either. Zone-scoped roles do not exist, by decision -- see the Zone Model section of
+  `docs/specs/03_AUTH_AND_RBAC.md`.
 
 ---
 
@@ -196,15 +198,15 @@ Current behavior:
 The create and edit dialogs collect the metadata organization reporting depends on. These are
 validated on both sides from one shared rule set, so the form and the API can never disagree.
 
-| Field         | Required | Notes                                                                                      |
-| ------------- | -------- | ------------------------------------------------------------------------------------------ |
-| Name          | Yes      | Not unique. Two clinics may share a name; their location codes still may not.              |
-| Region        | No       | Free text, for display.                                                                    |
-| Organization  | Yes      | Read-only once the clinic exists. Selectable on create only when more than one exists.     |
-| Location code | Yes      | Prefilled from the name, editable. **Unique within the organization.** Lowercase, hyphens. |
-| Time zone     | Yes      | A named IANA zone. Drives appointment times, reminders, and daily reporting.               |
-| Zone code     | No       | Reserved for zone-aware reporting. Leave empty until a clinic actually belongs to a zone.  |
-| Country code  | Yes      | ISO-3166 alpha-2. Defaults to `GH`.                                                        |
+| Field         | Required | Notes                                                                                             |
+| ------------- | -------- | ------------------------------------------------------------------------------------------------- |
+| Name          | Yes      | Not unique. Two clinics may share a name; their location codes still may not.                     |
+| Region        | No       | Free text, for display.                                                                           |
+| Organization  | Yes      | Read-only once the clinic exists. Selectable on create only when more than one exists.            |
+| Location code | Yes      | Prefilled from the name, editable. **Unique within the organization.** Lowercase, hyphens.        |
+| Time zone     | Yes      | A named IANA zone. Drives appointment times, reminders, and daily reporting.                      |
+| Zone code     | No       | Groups clinics for reporting and filtering. Reuse an existing spelling; the dialog suggests them. |
+| Country code  | Yes      | ISO-3166 alpha-2. Defaults to `GH`.                                                               |
 
 Creating an organization is not part of this flow. Clinics are filed under organizations that
 already exist.
@@ -230,7 +232,7 @@ Common seed fields for new environments:
 - clinic name
 - clinic location code
 - clinic timezone
-- clinic zone code when relevant later
+- clinic zone code, when clinics are grouped into zones for reporting
 
 ---
 

--- a/docs/specs/01_ARCHITECTURE_OVERVIEW.md
+++ b/docs/specs/01_ARCHITECTURE_OVERVIEW.md
@@ -20,7 +20,7 @@ The current tenancy model is:
 
 `Organization -> Clinic(Location) -> Patients / Staff / Operations`
 
-`Clinic.zoneCode` exists as a forward-compatible field for future zone-aware reporting and access controls, but zone-level RBAC is not yet active.
+`Clinic.zoneCode` groups clinics for reporting and filtering. It is a filter dimension and not a permission scope: sharing a zone never grants access to a clinic. See the Zone Model section of `docs/specs/03_AUTH_AND_RBAC.md`.
 
 ---
 
@@ -72,7 +72,7 @@ nkwapa/
 3. The API verifies the JWT via JWKS and hydrates the local `User`.
 4. Local roles from `UserClinicRole` determine effective permissions.
 5. Clinic-scoped routes validate the requested clinic, permissions, and membership.
-6. The Prisma layer opens a transaction-scoped RLS context that sets current request, user, organization, clinic list, active clinic, zone, and system-admin flags.
+6. The Prisma layer opens a transaction-scoped RLS context that sets current request, user, organization, clinic list, active clinic, zone, and system-admin flags. The zone is diagnostic context; no policy reads it.
 7. Postgres RLS policies enforce clinic isolation for protected tables.
 
 This means authorization is enforced in three layers:
@@ -90,7 +90,7 @@ This means authorization is enforced in three layers:
 - `Organization` is the top-level business boundary.
 - `Clinic` is the operational and physical location boundary.
 - Most product behavior still operates at clinic scope.
-- Organization-wide and zone-wide reporting are follow-on work, not current defaults.
+- Zone filters narrow the admin clinic registry, the network overview and the staff roster. Organization-wide reporting is still follow-on work.
 
 ### Security Defaults
 
@@ -126,7 +126,7 @@ This means authorization is enforced in three layers:
 
 ## Current Follow-On Work
 
-- zone-aware RBAC and org-level reporting
+- org-level reporting, and zone-scoped RBAC if a zone is ever to mean more than a filter
 - deeper offline support outside the original EMR flow
 - fuller appointment calendar and rescheduling UX
 - broader job/script adoption of the same RLS safety model

--- a/docs/specs/02_DOMAIN_MODEL_AND_DATA_DICTIONARY.md
+++ b/docs/specs/02_DOMAIN_MODEL_AND_DATA_DICTIONARY.md
@@ -60,7 +60,9 @@ API's DTO validators, the admin UI, the seed, and `npm run db:audit-clinics`):
 
 - `locationCode` is required, lowercase letters/digits/single hyphens, at most 64 characters
 - `timezone` must be a named IANA zone; a fixed offset is refused because it has no DST rules
-- `zoneCode` is optional, and shape-checked like a location code when present
+- `zoneCode` is optional, and shape-checked like a location code when present. It groups clinics
+  for reporting and filtering, and is never a permission scope: two clinics in different
+  organizations may share a zone code, and neither gains access to the other.
 - `countryCode` is ISO-3166 alpha-2, stored uppercase
 - a duplicate `locationCode` within an organization is a 409, not a constraint error
 

--- a/docs/specs/03_AUTH_AND_RBAC.md
+++ b/docs/specs/03_AUTH_AND_RBAC.md
@@ -121,6 +121,62 @@ only.
 
 ---
 
+## Zone Model
+
+`Clinic.zoneCode` is a reporting and operations dimension. It is **not** a permission scope.
+
+The rule, which decides every surface:
+
+> Zone is a filter wherever a view spans more than one clinic, and context wherever a view is one
+> clinic. It is never a grant.
+
+| Surface                     | Spans        | Zone treatment                     |
+| --------------------------- | ------------ | ---------------------------------- |
+| `GET /admin/clinics`        | many clinics | `?zoneCode=` filter                |
+| `GET /admin/clinics/zones`  | many clinics | the filter's vocabulary            |
+| Dashboard network overview  | many clinics | `?zoneCode=` filter, plus rollup   |
+| Staff roster, all users     | many clinics | client-side filter over the roster |
+| Staff roster, active clinic | one clinic   | context only                       |
+| `GET /clinics/:id/audit`    | one clinic   | context only                       |
+
+A zone code is tenant-defined free text, shaped like a location code and validated by
+`packages/db/src/clinic-metadata.ts`. There is no zone table, no zone enum, and no zone column on
+`UserClinicRole`. Two clinics in different organizations may hold the same zone code, and that is
+expected rather than a conflict: a zone names a way of grouping clinics, not a boundary.
+
+### Why a filter and not a scope
+
+A zone-scoped role would have to widen access, because that is what a scope does. Zone codes are
+free text that any clinic administrator can set, so a zone that granted access would let whoever
+edits a clinic's metadata pull that clinic into the reach of everyone in the zone they typed.
+Making zone a filter first means the field earns a product meaning without that being possible.
+
+### How a filter is kept from becoming a grant
+
+Three layers, because a boundary that depends on one layer is one refactor from not being a
+boundary.
+
+1. **Ordering, in the service.** `ClinicService.clinicScopeForAdmin` resolves which clinics the
+   actor may administer, and the zone clause is applied on top of that result. `zoneFilterWhere`
+   in `packages/db/src/clinic-zones.ts` can only ever produce a `zoneCode` constraint, so no
+   branch exists in which a zone reaches the authorization decision.
+2. **A cross-tenant test.** `apps/api/src/auth/zone-scope.spec.ts` runs against a fixture where
+   clinics in two different organizations share a zone code, and asserts that filtering by it
+   still queries only the actor's own clinic ids, and that the composed `where` contains no `OR`.
+3. **A database invariant.** `packages/db/src/rls-coverage.spec.ts` asserts that no row level
+   security policy references `app.current_zone_code()` or a zone column, and that
+   `UserClinicRole` carries no zone field.
+
+`app.current_zone_code()` exists and the RLS context sets it from the active clinic. It is
+diagnostic context, read by no policy. Wiring it into one is a deliberate change to the permission
+model, and the invariant test above is what makes that a decision rather than an accident.
+
+The zone list is scoped like the clinic list it filters. The set of zone names describes how a
+tenant is organized, so a director learns the zones of the clinics they direct and nothing about
+anyone else's.
+
+---
+
 ## Enforcement Path
 
 ### API Layer
@@ -142,7 +198,7 @@ For HTTP traffic, Prisma opens a transaction-scoped RLS context with:
 - current organization ID
 - allowed clinic IDs
 - active clinic ID
-- zone code
+- zone code, as diagnostic context that no policy reads
 - system-admin bypass flag
 
 This means route guards and Postgres policies reinforce each other.
@@ -156,12 +212,15 @@ This means route guards and Postgres policies reinforce each other.
 It returns:
 
 - user identity
-- clinic memberships
+- clinic memberships, each with the clinic's zone code
 - global roles
 - active clinic
 - effective roles for the active clinic
 - effective permissions for the active clinic
 - onboarding state for patients who still need to claim a record
+
+A clinic's zone rides along so a single-clinic view can name the zone it is showing. It appears
+beside a clinic and nowhere else: never in effective roles, never in effective permissions.
 
 Frontend navigation and clinic switching are driven from this response.
 
@@ -203,6 +262,7 @@ The current realm export is hardened with:
 
 ## Current Gaps
 
-- zone-scoped RBAC is not yet implemented
+- zone is a reporting filter rather than a permission scope; zone-scoped roles are deliberately
+  not implemented, and the Zone Model section above is the statement of record
 - organization-level admin/reporting permissions are not yet distinct from clinic-level permissions
 - Keycloak still provides identity only; app-side policy remains the authority and must continue to be tested independently

--- a/packages/db/index.ts
+++ b/packages/db/index.ts
@@ -88,6 +88,20 @@ export {
   type ClinicDayWindow,
 } from './src/clinic-day';
 export {
+  UNZONED_FILTER_VALUE,
+  UNZONED_LABEL,
+  isZoneFilterValue,
+  listZoneCodes,
+  parseZoneFilter,
+  summarizeZones,
+  zoneFilterMatches,
+  zoneFilterWhere,
+  zoneLabel,
+  zoneSummaryFilterValue,
+  type ZoneFilter,
+  type ZoneSummary,
+} from './src/clinic-zones';
+export {
   DUPLICATE_CONFIDENCE_LEVELS,
   DUPLICATE_CONFIDENCE_THRESHOLDS,
   DUPLICATE_MATCH_REASONS,
@@ -148,6 +162,7 @@ export {
   type PatientChartSectionId,
 } from './src/patient-chart-sections';
 export {
+  SHARED_ZONE_CODE,
   TENANT_ORGANIZATIONS,
   TENANT_CLINICS,
   TENANT_CLINICAL_ROLES,

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -17,6 +17,10 @@
       "types": "./dist/src/clinic-day.d.ts",
       "default": "./dist/src/clinic-day.js"
     },
+    "./clinic-zones": {
+      "types": "./dist/src/clinic-zones.d.ts",
+      "default": "./dist/src/clinic-zones.js"
+    },
     "./clinical-measurements": {
       "types": "./dist/src/clinical-measurements.d.ts",
       "default": "./dist/src/clinical-measurements.js"

--- a/packages/db/src/clinic-metadata.ts
+++ b/packages/db/src/clinic-metadata.ts
@@ -199,8 +199,8 @@ export type ClinicMetadataIssueCode =
  *
  * `error` blocks a write and counts toward "needs attention"; `warning` and `info` are shown
  * but never gate a save or fail the audit. `ZONE_CODE_MISSING` is the one to keep honest --
- * `zoneCode` is explicitly optional until zone RBAC exists, so a clinic without one is worth
- * listing and never worth refusing.
+ * `zoneCode` is optional by design -- zone is a reporting filter rather than a
+ * permission scope -- so a clinic without one is worth listing and never worth refusing.
  */
 export const CLINIC_METADATA_ISSUE_SEVERITY: Record<
   ClinicMetadataIssueCode,
@@ -383,7 +383,7 @@ export function evaluateClinicMetadata(input: ClinicMetadataInput): ClinicMetada
       issue(
         'ZONE_CODE_MISSING',
         'zoneCode',
-        'No zone code is set. Zone reporting will skip this clinic.',
+        'No zone code is set. This clinic reports under "No zone" rather than with a group.',
       ),
     );
   } else if (!isZoneCode(rawZoneCode)) {

--- a/packages/db/src/clinic-zones.spec.ts
+++ b/packages/db/src/clinic-zones.spec.ts
@@ -1,0 +1,198 @@
+import {
+  UNZONED_FILTER_VALUE,
+  UNZONED_LABEL,
+  isZoneFilterValue,
+  listZoneCodes,
+  parseZoneFilter,
+  summarizeZones,
+  zoneFilterMatches,
+  zoneFilterWhere,
+  zoneLabel,
+  zoneSummaryFilterValue,
+} from './clinic-zones';
+import { ZONE_CODE_PATTERN } from './clinic-metadata';
+
+const clinic = (zoneCode: string | null, isActive = true) => ({ zoneCode, isActive });
+
+describe('the unzoned sentinel', () => {
+  it('is not itself a legal zone code', () => {
+    // If it were, a tenant could create a zone that shadows the "no zone" bucket and make the
+    // filter ambiguous. The underscore is what keeps the two vocabularies apart.
+    expect(ZONE_CODE_PATTERN.test(UNZONED_FILTER_VALUE)).toBe(false);
+  });
+});
+
+describe('isZoneFilterValue', () => {
+  it('accepts a well-formed zone code', () => {
+    expect(isZoneFilterValue('north')).toBe(true);
+    expect(isZoneFilterValue('greater-accra-1')).toBe(true);
+  });
+
+  it('accepts the unzoned sentinel', () => {
+    expect(isZoneFilterValue(UNZONED_FILTER_VALUE)).toBe(true);
+  });
+
+  it('accepts a code that only needs normalizing', () => {
+    expect(isZoneFilterValue('  NORTH  ')).toBe(true);
+  });
+
+  it('rejects a malformed code', () => {
+    expect(isZoneFilterValue('North Zone')).toBe(false);
+    expect(isZoneFilterValue('-north')).toBe(false);
+    expect(isZoneFilterValue('north--east')).toBe(false);
+    expect(isZoneFilterValue('a'.repeat(65))).toBe(false);
+  });
+
+  it('rejects blank and non-string values', () => {
+    // Blank is "no filter", which is the absence of a value rather than a value.
+    expect(isZoneFilterValue('')).toBe(false);
+    expect(isZoneFilterValue('   ')).toBe(false);
+    expect(isZoneFilterValue(null)).toBe(false);
+    expect(isZoneFilterValue(undefined)).toBe(false);
+    expect(isZoneFilterValue(7)).toBe(false);
+  });
+});
+
+describe('parseZoneFilter', () => {
+  it('normalizes a zone code the way the column stores it', () => {
+    expect(parseZoneFilter('  NORTH ')).toBe('north');
+  });
+
+  it('keeps the unzoned sentinel intact', () => {
+    expect(parseZoneFilter(UNZONED_FILTER_VALUE)).toBe(UNZONED_FILTER_VALUE);
+  });
+
+  it('reads absent, blank and malformed as no filter', () => {
+    expect(parseZoneFilter(undefined)).toBeNull();
+    expect(parseZoneFilter('')).toBeNull();
+    expect(parseZoneFilter('   ')).toBeNull();
+    expect(parseZoneFilter('not a zone')).toBeNull();
+    expect(parseZoneFilter(42)).toBeNull();
+  });
+});
+
+describe('zoneFilterMatches', () => {
+  it('lets everything through when no filter is applied', () => {
+    expect(zoneFilterMatches('north', null)).toBe(true);
+    expect(zoneFilterMatches(null, null)).toBe(true);
+  });
+
+  it('matches a named zone exactly', () => {
+    expect(zoneFilterMatches('north', 'north')).toBe(true);
+    expect(zoneFilterMatches('south', 'north')).toBe(false);
+    expect(zoneFilterMatches(null, 'north')).toBe(false);
+  });
+
+  it('normalizes the stored value before comparing', () => {
+    expect(zoneFilterMatches('  NORTH ', 'north')).toBe(true);
+  });
+
+  it('matches only zoneless clinics under the unzoned sentinel', () => {
+    expect(zoneFilterMatches(null, UNZONED_FILTER_VALUE)).toBe(true);
+    expect(zoneFilterMatches(undefined, UNZONED_FILTER_VALUE)).toBe(true);
+    // An empty string in the column is the same absence as null, per normalizeZoneCode.
+    expect(zoneFilterMatches('', UNZONED_FILTER_VALUE)).toBe(true);
+    expect(zoneFilterMatches('north', UNZONED_FILTER_VALUE)).toBe(false);
+  });
+});
+
+describe('zoneFilterWhere', () => {
+  it('adds no clause when no filter is applied', () => {
+    // An empty object is what makes this safe to spread onto an already-scoped where.
+    expect(zoneFilterWhere(null)).toEqual({});
+  });
+
+  it('asks for a null column under the unzoned sentinel', () => {
+    expect(zoneFilterWhere(UNZONED_FILTER_VALUE)).toEqual({ zoneCode: null });
+  });
+
+  it('asks for the exact code otherwise', () => {
+    expect(zoneFilterWhere('north')).toEqual({ zoneCode: 'north' });
+  });
+
+  it('never produces a clause that could widen a query', () => {
+    // Every branch either constrains zoneCode or says nothing. None of them mentions a clinic
+    // id, an organization, or an OR -- which is why ANDing this onto a scoped where is safe.
+    for (const filter of [null, UNZONED_FILTER_VALUE, 'north']) {
+      const where = zoneFilterWhere(filter);
+      expect(Object.keys(where).every((key) => key === 'zoneCode')).toBe(true);
+    }
+  });
+});
+
+describe('zoneLabel', () => {
+  it('shows the code for a zoned clinic', () => {
+    expect(zoneLabel('north')).toBe('north');
+  });
+
+  it('names the absence for a zoneless one', () => {
+    expect(zoneLabel(null)).toBe(UNZONED_LABEL);
+    expect(zoneLabel('')).toBe(UNZONED_LABEL);
+    expect(zoneLabel(undefined)).toBe(UNZONED_LABEL);
+  });
+});
+
+describe('summarizeZones', () => {
+  it('counts clinics and active clinics per zone', () => {
+    expect(summarizeZones([clinic('north'), clinic('north', false), clinic('south')])).toEqual([
+      { zoneCode: 'north', clinicCount: 2, activeClinicCount: 1 },
+      { zoneCode: 'south', clinicCount: 1, activeClinicCount: 1 },
+    ]);
+  });
+
+  it('sorts named zones alphabetically and the unzoned bucket last', () => {
+    const summaries = summarizeZones([clinic(null), clinic('south'), clinic('north')]);
+    expect(summaries.map((s) => s.zoneCode)).toEqual(['north', 'south', null]);
+  });
+
+  it('omits the unzoned bucket when every clinic has a zone', () => {
+    const summaries = summarizeZones([clinic('north'), clinic('south')]);
+    expect(summaries.some((s) => s.zoneCode === null)).toBe(false);
+  });
+
+  it('folds differently-cased spellings of one zone into a single bucket', () => {
+    // Two clinics whose codes differ only by case are in one zone, not two. A report that
+    // split them would be quietly wrong rather than visibly broken.
+    const summaries = summarizeZones([clinic('north'), clinic(' NORTH ')]);
+    expect(summaries).toEqual([{ zoneCode: 'north', clinicCount: 2, activeClinicCount: 2 }]);
+  });
+
+  it('treats a blank code as unzoned rather than as its own zone', () => {
+    expect(summarizeZones([clinic('')])).toEqual([
+      { zoneCode: null, clinicCount: 1, activeClinicCount: 1 },
+    ]);
+  });
+
+  it('counts a clinic whose active flag is absent as active', () => {
+    expect(summarizeZones([{ zoneCode: 'north' }])).toEqual([
+      { zoneCode: 'north', clinicCount: 1, activeClinicCount: 1 },
+    ]);
+  });
+
+  it('returns nothing for no clinics', () => {
+    expect(summarizeZones([])).toEqual([]);
+  });
+});
+
+describe('zoneSummaryFilterValue', () => {
+  it('round-trips a summary back through the filter it selects', () => {
+    const clinics = [clinic('north'), clinic('south'), clinic(null)];
+    for (const summary of summarizeZones(clinics)) {
+      const filter = parseZoneFilter(zoneSummaryFilterValue(summary));
+      const matched = clinics.filter((c) => zoneFilterMatches(c.zoneCode, filter));
+      expect(matched).toHaveLength(summary.clinicCount);
+    }
+  });
+});
+
+describe('listZoneCodes', () => {
+  it('lists the zones in use, sorted, without the unzoned bucket', () => {
+    expect(
+      listZoneCodes([clinic('south'), clinic(null), clinic('north'), clinic('south')]),
+    ).toEqual(['north', 'south']);
+  });
+
+  it('returns nothing when no clinic has a zone', () => {
+    expect(listZoneCodes([clinic(null), clinic('')])).toEqual([]);
+  });
+});

--- a/packages/db/src/clinic-zones.ts
+++ b/packages/db/src/clinic-zones.ts
@@ -1,0 +1,154 @@
+/**
+ * Shared rules for grouping and filtering clinics by zone.
+ *
+ * Deliberately separate from `clinic-metadata.ts`, on the same split as `clinic-day.ts`: that
+ * module decides whether a `zoneCode` is *valid*, this one decides what a zone *means* to a
+ * report. The validators stay there; the filter vocabulary lives here.
+ *
+ * The V1 policy this encodes, stated in full in `docs/specs/03_AUTH_AND_RBAC.md`:
+ *
+ *   Zone is a filter wherever a view spans more than one clinic, and context wherever a view
+ *   is one clinic. It is never a grant.
+ *
+ * Nothing in this file consults a role, and nothing it returns widens a query. `zoneFilterWhere`
+ * produces a clause a caller ANDs onto an already-authorized set of clinics; a caller that used
+ * it as the *only* clause would be reading across tenants, which is why the API resolves the
+ * actor's clinics first and applies this second.
+ */
+import { ZONE_CODE_MAX_LENGTH, ZONE_CODE_PATTERN, normalizeZoneCode } from './clinic-metadata';
+
+/**
+ * The one spelling of "clinics that have no zone code".
+ *
+ * A zone filter has three states, and an absent value cannot express the middle one: no filter,
+ * a named zone, and explicitly unzoned. `zoneCode=` (empty) already means "no filter" to every
+ * HTTP client and to `normalizeZoneCode`, so the third state needs a token of its own. It is
+ * deliberately not a legal zone code -- `ZONE_CODE_PATTERN` rejects underscores -- so a real
+ * zone can never collide with it.
+ */
+export const UNZONED_FILTER_VALUE = '__unzoned__';
+
+/** What the UI calls a clinic with no zone code. */
+export const UNZONED_LABEL = 'No zone';
+
+/**
+ * A resolved zone filter: `null` applies no filter at all, `UNZONED_FILTER_VALUE` matches only
+ * clinics without a zone, and any other value matches that zone code exactly.
+ */
+export type ZoneFilter = string | null;
+
+/** True for a value a zone filter accepts: a well-formed zone code, or the unzoned sentinel. */
+export function isZoneFilterValue(value: unknown): boolean {
+  if (typeof value !== 'string') return false;
+  if (value.trim() === UNZONED_FILTER_VALUE) return true;
+  const normalized = normalizeZoneCode(value);
+  return normalized !== null && isZoneCodeShaped(normalized);
+}
+
+/**
+ * Reads a zone filter off a query string or a form control.
+ *
+ * Absent, blank and unrecognised all collapse to `null` -- no filter. A filter is a view, not a
+ * write, so a stale link to a zone that has since been renamed should show the unfiltered list
+ * rather than fail. The DTO validator rejects a malformed value before this runs, so the
+ * permissive branch here is for internal callers rather than for the wire.
+ */
+export function parseZoneFilter(value: unknown): ZoneFilter {
+  if (typeof value !== 'string') return null;
+  if (value.trim() === UNZONED_FILTER_VALUE) return UNZONED_FILTER_VALUE;
+  const normalized = normalizeZoneCode(value);
+  if (normalized === null || !isZoneCodeShaped(normalized)) return null;
+  return normalized;
+}
+
+/** Does one clinic's zone code satisfy this filter? The predicate the web filters rows with. */
+export function zoneFilterMatches(
+  zoneCode: string | null | undefined,
+  filter: ZoneFilter,
+): boolean {
+  if (filter === null) return true;
+  const normalized = normalizeZoneCode(zoneCode);
+  if (filter === UNZONED_FILTER_VALUE) return normalized === null;
+  return normalized === filter;
+}
+
+/**
+ * The same predicate as a Prisma `where` fragment, for the API to AND onto a scoped query.
+ *
+ * Typed as a plain object rather than `Prisma.ClinicWhereInput` on purpose: this module is also
+ * imported by the browser through the `./clinic-zones` subpath, and pulling in the Prisma
+ * namespace would drag the client into the web bundle. The shape is structurally compatible.
+ */
+export function zoneFilterWhere(filter: ZoneFilter): { zoneCode?: string | null } {
+  if (filter === null) return {};
+  if (filter === UNZONED_FILTER_VALUE) return { zoneCode: null };
+  return { zoneCode: filter };
+}
+
+/** How a zone reads in a table cell or a filter chip. */
+export function zoneLabel(zoneCode: string | null | undefined): string {
+  return normalizeZoneCode(zoneCode) ?? UNZONED_LABEL;
+}
+
+/** One row of the zone rollup: how many clinics sit in a zone, and how many are live. */
+export interface ZoneSummary {
+  /** `null` is the unzoned bucket, not a missing row. */
+  zoneCode: string | null;
+  clinicCount: number;
+  activeClinicCount: number;
+}
+
+/** The filter value that selects a summary's bucket. */
+export function zoneSummaryFilterValue(summary: ZoneSummary): string {
+  return summary.zoneCode ?? UNZONED_FILTER_VALUE;
+}
+
+/**
+ * Groups clinics into zones, for a picker's options and for a report's rollup.
+ *
+ * Named zones sort alphabetically and the unzoned bucket sorts last, because it is the residue
+ * rather than a zone -- putting it in alphabetical position would hide it in the middle of the
+ * list. The bucket is only emitted when something is actually in it, so an organization that
+ * has zoned every clinic is not told about an empty "No zone".
+ */
+export function summarizeZones(
+  clinics: { zoneCode?: string | null; isActive?: boolean }[],
+): ZoneSummary[] {
+  const buckets = new Map<string | null, ZoneSummary>();
+
+  for (const clinic of clinics) {
+    const zoneCode = normalizeZoneCode(clinic.zoneCode);
+    let bucket = buckets.get(zoneCode);
+    if (!bucket) {
+      bucket = { zoneCode, clinicCount: 0, activeClinicCount: 0 };
+      buckets.set(zoneCode, bucket);
+    }
+    bucket.clinicCount += 1;
+    if (clinic.isActive !== false) bucket.activeClinicCount += 1;
+  }
+
+  return [...buckets.values()].sort((a, b) => {
+    if (a.zoneCode === null) return 1;
+    if (b.zoneCode === null) return -1;
+    return a.zoneCode.localeCompare(b.zoneCode);
+  });
+}
+
+/** The zone codes in use, without the unzoned bucket. Backs the dialog's suggestion chips. */
+export function listZoneCodes(clinics: { zoneCode?: string | null }[]): string[] {
+  return summarizeZones(clinics)
+    .map((summary) => summary.zoneCode)
+    .filter((zoneCode): zoneCode is string => zoneCode !== null);
+}
+
+/**
+ * Local shape check.
+ *
+ * `isZoneCode` from `clinic-metadata.ts` treats `null` as valid, because an absent zone code is
+ * a legal clinic. A filter value is a different question -- there `null` means "no filter" and
+ * has already been handled by the caller -- so the pattern is applied directly rather than
+ * through a helper whose `null` answer is the opposite of the one wanted here.
+ */
+function isZoneCodeShaped(value: string): boolean {
+  return value.length <= ZONE_CODE_MAX_LENGTH && ZONE_CODE_PATTERN.test(value);
+}

--- a/packages/db/src/rls-coverage.spec.ts
+++ b/packages/db/src/rls-coverage.spec.ts
@@ -68,3 +68,58 @@ describe('row level security coverage', () => {
     expect(migrationSql).toMatch(/CREATE ROLE nkwapa_app[^;]*NOSUPERUSER/);
   });
 });
+
+/**
+ * Zone is a reporting dimension, not a permission scope.
+ *
+ * The V1 policy is stated in `docs/specs/03_AUTH_AND_RBAC.md`: a zone filter may only narrow a
+ * set of clinics an actor is already authorized to see, and sharing a zone with a clinic never
+ * grants access to it. The API enforces that by resolving the actor's clinics before any zone
+ * clause is applied, but a service-layer habit is one refactor from not being a boundary.
+ *
+ * These are the database half of the guarantee. `app.current_zone_code()` exists and the RLS
+ * context sets it, which makes it available for diagnostics and for a future deliberate change
+ * -- and makes it exactly the sort of thing someone reaches for while adding "just one" zone
+ * predicate. If that happens, this fails and points at the docs that would need rewriting first.
+ */
+describe('zone is not a permission scope', () => {
+  const policies = [...migrationSql.matchAll(/CREATE POLICY[\s\S]*?;/g)].map((match) => match[0]);
+
+  it('finds the policies to check', () => {
+    expect(policies.length).toBeGreaterThan(20);
+  });
+
+  it('defines the zone context helper', () => {
+    // Its presence is the point: the setting is carried deliberately, not by accident.
+    expect(migrationSql).toContain('CREATE OR REPLACE FUNCTION app.current_zone_code()');
+  });
+
+  it('never reads the zone context from a policy', () => {
+    const offenders = policies.filter((policy) => policy.includes('current_zone_code'));
+    expect(offenders).toEqual([]);
+  });
+
+  it('never reads a clinic zone column from a policy', () => {
+    const offenders = policies.filter((policy) => /"?zoneCode"?/.test(policy));
+    expect(offenders).toEqual([]);
+  });
+
+  it('keeps zone off the table that grants roles', () => {
+    // A zone column on UserClinicRole is what a zone-scoped role would need. Its absence is the
+    // schema-level statement that no such role exists.
+    const userClinicRole = schema.match(/^model UserClinicRole \{([\s\S]*?)^\}/m);
+    expect(userClinicRole).not.toBeNull();
+    expect(userClinicRole?.[1]).not.toMatch(/zone/i);
+  });
+
+  it('decides clinic access from the clinic id list alone', () => {
+    // The one predicate every clinic-scoped policy funnels through. If zone ever widens access,
+    // it widens here first.
+    const canAccessClinic = migrationSql.match(
+      /CREATE OR REPLACE FUNCTION app\.can_access_clinic[\s\S]*?\$\$;/,
+    );
+    expect(canAccessClinic).not.toBeNull();
+    expect(canAccessClinic?.[0]).toContain('app.current_clinic_ids()');
+    expect(canAccessClinic?.[0]).not.toContain('zone');
+  });
+});

--- a/packages/db/src/testing/tenant-fixture.ts
+++ b/packages/db/src/testing/tenant-fixture.ts
@@ -29,6 +29,8 @@ export interface TenantFixtureClinic {
   organizationId: string;
   name: string;
   locationCode: string;
+  /** Optional in the schema, so the fixture carries a clinic without one too. */
+  zoneCode: string | null;
 }
 
 export interface TenantFixtureRoleGrant {
@@ -55,6 +57,15 @@ export interface TenantFixturePatient {
 const ORG_A_ID = 'aa000000-0000-4000-8000-000000000001';
 const ORG_B_ID = 'bb000000-0000-4000-8000-000000000001';
 
+/**
+ * One zone code deliberately held by clinics in two different organizations.
+ *
+ * Zone is a reporting filter and never a grant, and the only way to test that is to have a zone
+ * that straddles a tenant boundary. `a1` and `b1` share it; a filter for it must still return
+ * only the clinics the actor was already allowed to see.
+ */
+export const SHARED_ZONE_CODE = 'gate-shared-zone';
+
 export const TENANT_ORGANIZATIONS = {
   orgA: { id: ORG_A_ID, name: 'Gate Org A', slug: 'gate-org-a' },
   orgB: { id: ORG_B_ID, name: 'Gate Org B', slug: 'gate-org-b' },
@@ -67,6 +78,7 @@ export const TENANT_CLINICS = {
     organizationId: ORG_A_ID,
     name: 'Gate Clinic A1',
     locationCode: 'gate-a1',
+    zoneCode: SHARED_ZONE_CODE,
   },
   /** Same organization, different clinic. Proves clinic isolation inside one tenant. */
   a2: {
@@ -74,6 +86,7 @@ export const TENANT_CLINICS = {
     organizationId: ORG_A_ID,
     name: 'Gate Clinic A2',
     locationCode: 'gate-a2',
+    zoneCode: null,
   },
   /** Different organization. Proves tenant isolation across organizations. */
   b1: {
@@ -81,6 +94,7 @@ export const TENANT_CLINICS = {
     organizationId: ORG_B_ID,
     name: 'Gate Clinic B1',
     locationCode: 'gate-b1',
+    zoneCode: SHARED_ZONE_CODE,
   },
 } as const satisfies Record<string, TenantFixtureClinic>;
 
@@ -230,7 +244,7 @@ export function tenantFixtureSql(): string {
 
   for (const clinic of Object.values(TENANT_CLINICS)) {
     statements.push(
-      `INSERT INTO "Clinic" ("id", "organizationId", "name", "timezone", "locationCode", "updatedAt") VALUES (${sqlLiteral(clinic.id)}, ${sqlLiteral(clinic.organizationId)}, ${sqlLiteral(clinic.name)}, 'Africa/Accra', ${sqlLiteral(clinic.locationCode)}, CURRENT_TIMESTAMP);`,
+      `INSERT INTO "Clinic" ("id", "organizationId", "name", "timezone", "locationCode", "zoneCode", "updatedAt") VALUES (${sqlLiteral(clinic.id)}, ${sqlLiteral(clinic.organizationId)}, ${sqlLiteral(clinic.name)}, 'Africa/Accra', ${sqlLiteral(clinic.locationCode)}, ${clinic.zoneCode === null ? 'NULL' : sqlLiteral(clinic.zoneCode)}, CURRENT_TIMESTAMP);`,
     );
   }
 


### PR DESCRIPTION
Closes #14 (`PH3-ORG-03`).

## Why

`Clinic.zoneCode` has been in the schema since the multi-clinic RLS migration and nothing read
it. Verified in the tree before this change:

- `schema.prisma:353` — nullable `VarChar(64)`, no FK, no enum. Zones are **tenant-defined
  slugs**, not a fixed vocabulary.
- `schema.prisma:399` — `@@index([organizationId, zoneCode])` already existed, so filtering by
  zone needs **no migration**.
- `migration.sql:171` defines `app.current_zone_code()`, the RLS context sets it every
  transaction, and **no policy references it**.
- `UserClinicRole` has no zone column, so zone could not grant anything even in principle.

Issue #15 made the field editable, validated and auditable. It still meant nothing. The product
needed an intentional first version rather than a reserved field, and the docs needed to say
which one it got.

## The decision

**Zone is a reporting and operations filter in V1, not a permission scope.** No zone roles, no
RLS change, no new permissions.

The argument, now recorded in `docs/specs/03_AUTH_AND_RBAC.md`: a zone code is free text that any
clinic administrator can set. A zone that granted access would let whoever edits a clinic's
metadata pull that clinic into the reach of everyone in the zone they typed. Making zone a filter
first lets the field earn a product meaning without that being possible.

One rule decides every surface, and the docs state it:

> **Zone is a filter wherever a view spans more than one clinic, and context wherever a view is
> one clinic. It is never a grant.**

| Surface                      | Spans        | Zone treatment                     |
| ---------------------------- | ------------ | ---------------------------------- |
| `GET /admin/clinics`         | many clinics | `?zoneCode=` filter                |
| `GET /admin/clinics/zones`   | many clinics | the filter's vocabulary            |
| Dashboard network overview   | many clinics | `?zoneCode=` filter, plus rollup   |
| Staff roster, all users      | many clinics | client-side filter over the roster |
| Staff roster, active clinic  | one clinic   | context only                       |
| `GET /clinics/:id/audit`     | one clinic   | context only                       |
| Clinic create/edit dialog    | one clinic   | suggestions from zones in use      |

`/audit` deliberately gets no control. It reads one clinic's log, which is in one zone, so a
dropdown there could only ever say "all" or "none" — and would imply the log spans a zone, which
is exactly the confusion between a reporting dimension and an access scope this work exists to
prevent.

## No user gains access because of a zone

Three layers, because a boundary that depends on one layer is one refactor from not being a
boundary.

**1. Ordering, in the service.** `clinicScopeForAdmin` resolves which clinics the actor may
administer, and the zone clause is spread onto that result. `zoneFilterWhere` cannot express
anything but a `zoneCode` constraint — asserted by a test that walks every branch — so there is
no path where a zone reaches the authorization decision.

That helper also replaces **three copies** of the same `SYSTEM_ADMIN && clinicId === null` check
that had accumulated across `listAllForAdmin` and `allowedOrganizationIds`. A tenant boundary
written out three times is two chances to fix two of them.

**2. A cross-tenant test.** `apps/api/src/auth/zone-scope.spec.ts` runs against a fixture where
`a1` (organization A) and `b1` (organization B) deliberately share a zone code. A director of A
filtering by it still queries only A's clinic ids; the composed `where` contains no `OR`; and
whoami for a volunteer at A1 mentions B1 nowhere at all.

**3. A database invariant.** `rls-coverage.spec.ts` asserts no policy reads
`app.current_zone_code()` or a zone column, and that `UserClinicRole` carries no zone field. The
setting stays as diagnostic context; wiring it into a policy is now a decision that fails a test
rather than an accident.

## One shared vocabulary

`packages/db/src/clinic-zones.ts`, deliberately separate from `clinic-metadata.ts` on the
`clinic-day.ts` precedent: that module decides whether a zone code is *valid*, this one decides
what a zone *means* to a report. The API filter, the web predicate, and the tests all read it.

The load-bearing piece is `UNZONED_FILTER_VALUE`. A zone filter has three states — no filter, a
named zone, explicitly unzoned — and an absent value cannot express the middle one, because
`zoneCode=` already reads as "no filter" to every HTTP client. The sentinel is spelled with
underscores precisely because `ZONE_CODE_PATTERN` rejects them, so no real zone can collide with
it. That is asserted, not assumed.

`IsZoneFilter` is a separate validator from `IsZoneCode` rather than a flag on it: one guards a
value going into the column, where `__unzoned__` is illegal, and the other guards a value going
into a query, where it is the only way to ask for the clinics that have none. Each has a test
that it rejects what the other accepts.

## The N+1 in the network overview

The cross-clinic comparison ran three counts per clinic in a loop — forty clinics meant a hundred
and twenty queries to draw one table, and a zone rollup would only have made it wider. It is now
three `groupBy` reads regardless of clinic count.

That rewrite has one silent trap, so it has a test: a `groupBy` omits an empty group rather than
returning zero for it. Taken literally, a clinic that has seen no patients would vanish from the
comparison — which is exactly the clinic an admin looking at this table is trying to find.

## UI and UX

- **Registry**: zone picker beside the existing view control, a Zones metric, a filter chip.
  Options carry clinic counts, because a filter that will not say how far it narrows makes you
  choose it just to find out. The picker reads `/admin/clinics/zones` unfiltered, so choosing a
  zone never removes the other zones and strands you inside your own filter.
- **Clinic dialog**: zone code stays free text — a zone comes into existence the first time
  someone puts a clinic in one, and `Combobox` by design never commits a value that matches
  nothing. What it was missing was information, not constraint: it now shows the zones already
  in use as chips that fill the field, and says when a typed code is new. That is what stops one
  typo silently splitting a zone's report in two.
- **Network overview**: zone column, picker, and a Zones KPI. Captions read the zone the *server*
  applied rather than the one the picker holds, so a mid-refetch table is never captioned with a
  zone it is not showing yet. Filtering makes the KPI row and the table answer different
  questions by design, so the summary gains "Patients in view" and "Visits in view" rather than
  leaving the reader to notice.

### Three defects this surfaced

- Moving the registry to server-side filtering made an empty zone identical on the wire to an
  empty database, so the registry offered **"No clinics yet — create the first clinic"** when a
  filter simply matched nothing. Emptiness is now zone-aware, and an empty filter offers "Show
  all zones".
- The "nothing matches" line said "No clinic matches this view" whichever control emptied the
  list, sending someone to the wrong one. It now names the zone, and names both when both narrow.
- Saving a clinic refreshed the rows but not the zone list, so a clinic saved into a brand new
  zone left the picker unable to offer the zone the table had just gained.

### Two consistency fixes

- The network overview's comparison was the only cross-clinic grid without the registry's
  `md:hidden` cards / `hidden md:block` grid dual tree — a bare `DataGrid` with a 560px floor, so
  on a phone the only way to reach the Finalized column was to scroll a nested region sideways.
  Adding a Zone column would have pushed it further out.
- The clinic dialog's `zoneOptions` held IANA **time** zones. With "zone" now meaning a reporting
  zone everywhere else in the file, it is `timeZonePickerOptions`.

## Bootstrap contract

`memberships[]` and `availableClinics[]` gain `zoneCode`. Additive; an older client is
unaffected, and `BootstrapClinic.zoneCode` is optional so a web app briefly newer than the API
during a rolling deploy reads "no zone" rather than taking a screen down.

Worth saying out loud because this is the one place zone touches the contract a client reads to
learn what it may do. It sits beside a clinic's name and nowhere else — never in
`effectiveRolesForActiveClinic`, never in `effectivePermissionsForActiveClinic`.

## Docs

`03_AUTH_AND_RBAC.md` gains a Zone Model section: the rule, the surfaces, why a filter and not a
scope, and the three enforcement layers named with the files that enforce them, so the invariant
test is findable from the doc and the doc from the test.

The "zone-scoped RBAC is not yet implemented" gap line is gone, replaced by a statement that it
is deliberately absent. "Not yet" and "not, on purpose" are different facts, and the first invites
someone to close it as an oversight.

Six other files claimed zone was reserved or deferred, all corrected. One of them was a lie the
product told operators directly: `evaluateClinicMetadata` warned "Zone reporting will skip this
clinic" for a zoneless clinic. It now reports under "No zone" and is findable by filtering for it.

**No schema change and no migration.** Every field and index already existed.

## Testing

| Suite      | Result                                        |
| ---------- | --------------------------------------------- |
| `@nkwapa/api` | 1420 passed (was 1369)                     |
| `@nkwapa/web` | 297 passed (was 274)                       |
| `@nkwapa/db`  | 383 passed (was 348), 26 integration skipped |
| Playwright | 160+ passed against a CI-shaped database      |

New: 29 shared-module specs, 6 RLS invariant specs, 13 zone-scope specs, 12 network-overview
specs, 6 query-DTO specs, 12 service/controller specs, 4 validator specs, 23 web lib specs, 5 e2e.

Also ran locally: `lint`, `prettier --check .`, `typecheck`, `build` across all workspaces,
`security:scan`, `security:audit` — all clean.

### On the local e2e failures

A full local run failed 11 specs across `patient-claim`, `appointments` triage,
`portal-invite-lifecycle` and `diabetes-screening`. Every one is fixture consumption from
repeated local runs, and each passes in isolation after restoring its fixture. None touches code
this PR changes.

The `portal-invite-lifecycle` one is worth recording because it is not in the testing guide yet:
`PORTAL_INVITE_HISTORY_LIMIT` is 5, newest first, and each run leaves a cancelled invite behind.
After seven runs the single seeded **Expired** invite is pushed off the list and the assertion for
it fails. Deleting the surplus cancelled rows restored the fixture and all 8 passed. CI seeds once
into a fresh database and runs once, so it is unaffected.

### One accessibility finding, and why it is scoped rather than fixed

Sweeping the zone picker **open** — a state no Radix `Select` in this product had ever been
swept in — reports two axe violations, both structural to Radix rather than to the picker:

- `aria-hidden-focus`, because Radix marks the page behind the popup `aria-hidden` and traps
  focus inside it, which axe cannot see. Verified identical on `#staff-status-filter` in
  `/admin/users`, which predates this work entirely.
- `scrollable-region-focusable`, once the option list is long enough to scroll. Radix puts
  `role="listbox"` on the content and the scrolling on an inner unlabelled viewport; the custom
  `Combobox` passes the same sweep precisely because its scrolling element *is* the listbox.

The first is handled by excluding the subtree Radix hid, keeping the rule live for the popup's
own markup. The second is disabled — and a disabled rule is only honest with something in its
place, so the sweep now drives the picker open, down and closed **by keyboard alone** and asserts
focus returns to the trigger. That one only appeared in a full-suite run, which is the kind of
finding that would otherwise pass CI on a fresh database and fail later on a real one.

## Notes for the reviewer

- The registry filters server-side even though it is unpaginated. Not for payload size — so one
  implementation decides which clinics are in a zone. That comes with a contract:
  `useAsyncResource` refetches on `resourceKey` alone, so `zoneQueryString` and `zoneResourceKey`
  come from the same module, with a test that no two filters share a key.
- The zone list is scoped exactly like the clinic list it filters, with a test that the two
  `where` clauses are equal. The set of zone names describes how a tenant is organized, so a
  director learns their own and nothing about anyone else's.
- CI never sets `SEED_CLINIC_ZONE_CODE`, so the seeded clinic is unzoned. The e2e specs create
  their own zoned clinic, which means one run exercises both the zone and "No zone" branches.
- Cross-clinic reporting stays system-admin only. Giving directors org-level rollups is the
  separate documented gap, and the zone filters now exist to slice them when it lands.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cm72hX82HbGqBfxy84UKTG
